### PR TITLE
chore/hikyaku skill cleanup

### DIFF
--- a/.claude/rules/design-doc-numbering.md
+++ b/.claude/rules/design-doc-numbering.md
@@ -29,9 +29,11 @@ The first implementation step in every design document must be:
 - Update `ARCHITECTURE.md` with the new feature's architecture
 - Update `docs/` directory with usage and configuration details
 - Update `README.md` so it stays consistent with `ARCHITECTURE.md` and `docs/` (use the `/update-readme` skill when the change surface is large)
-- Update relevant skill documentation (including `.claude/skills/*/SKILL.md`)
+- Update every affected skill under `.claude/skills/*/SKILL.md` and `plugins/*/skills/*/SKILL.md`
 - Update project rules if needed
 
 `README.md` is a first-class documentation target on par with `ARCHITECTURE.md` and `docs/`. Any change that affects architecture, CLI surface, API surface, configuration, or project structure MUST be reflected in `README.md` in the same design-doc cycle. Treat README drift as a blocker for "documentation complete".
+
+`SKILL.md` files are **equally** first-class documentation targets. Any change that alters CLI commands, flags, environment variables, required arguments, output formats, or the expected invocation workflow MUST be reflected in every affected `SKILL.md` in the same design-doc cycle. Skill drift — where a `SKILL.md` example no longer matches the actual CLI — is a blocker for "documentation complete", because Claude Code loads these skills as ground truth and will produce broken tool calls when they go stale.
 
 Only after documentation is complete should code implementation begin.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -10,7 +10,11 @@
       "Bash(mise //admin*)",
       "Bash(mise //client*)",
       "Bash(mise //registry*)",
-      "Skill(update-readme)"
+      "Skill(update-readme)",
+      "Bash(hikyaku *)",
+      "Bash(tmux split-window *)",
+      "Bash(tmux send-keys -t * '/exit' Enter)",
+      "Bash(printenv HIKYAKU_URL HIKYAKU_API_KEY)"
     ],
     "deny": [
       "Bash(uv run pytest *)",

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -14,6 +14,8 @@
       "Bash(hikyaku *)",
       "Bash(tmux split-window *)",
       "Bash(tmux send-keys -t * '/exit' Enter)",
+      "Bash(tmux select-layout *)",
+      "Bash(tmux set-window-option *)",
       "Bash(printenv HIKYAKU_URL HIKYAKU_API_KEY)"
     ],
     "deny": [

--- a/.claude/skills/hikyaku/SKILL.md
+++ b/.claude/skills/hikyaku/SKILL.md
@@ -18,30 +18,82 @@ Use the `hikyaku` CLI to register as an agent, send and receive messages, and di
 
 ## Environment Variables
 
-Set these before running any `hikyaku` command (including `register`). The CLI exits with an error if `HIKYAKU_API_KEY` is not set.
+The CLI reads both variables from the environment — they are the **only** way to configure the CLI. There are no `--url` / `--api-key` flags.
 
-- `HIKYAKU_URL` — Broker URL (default: `http://localhost:8000`)
-- `HIKYAKU_API_KEY` — API key created via the Hikyaku WebUI key-management page (format: `hky_` + 32 hex chars). Keys are shown only once at creation.
+- `HIKYAKU_URL` — Broker URL, must include the `http://` / `https://` scheme (e.g. `http://localhost:8000`). The CLI errors with "Request URL is missing an 'http://' or 'https://' protocol" if the scheme is missing.
+- `HIKYAKU_API_KEY` — API key created via the Hikyaku WebUI key-management page (format: `hky_` + 32 hex chars). Keys are shown only once at creation. The CLI exits with an error if this is not set.
+
+## Agent ID
+
+Every command **except `register`** requires `--agent-id <id>`. `register` returns the new `agent_id` — save it and pass it to every subsequent command.
+
+## Global Options
+
+Only `--json` exists, and it must be placed **before** the subcommand:
+
+```bash
+hikyaku --json register --name "My Agent" --description "..."
+hikyaku --json agents --agent-id <agent-id>
+```
+
+`hikyaku agents --json` will fail with `No such option: --json`.
 
 ## Command Reference
 
 ### Register
 
-Register a new agent with the broker. Requires `HIKYAKU_API_KEY` to be set (create the key via the Hikyaku WebUI first).
+Register a new agent with the broker. `HIKYAKU_API_KEY` must be set.
 
 ```bash
 hikyaku register --name "My Agent" --description "What this agent does"
 hikyaku register --name "My Agent" --description "Frontend dev" --skills '[{"id":"react","name":"React Dev","description":"React/TS"}]'
 ```
 
-Returns the newly created `agent_id`. Note it and pass it via `--agent-id` on every subsequent command.
+Returns the newly created `agent_id`. Record it; every other command needs it via `--agent-id`.
+
+#### Self-registration recipe
+
+Use `--json` so the output is machine-parseable, and capture `agent_id` for every subsequent call:
+
+```bash
+hikyaku --json register \
+  --name "<short-label>" \
+  --description "<one-sentence purpose>"
+```
+
+JSON response (field order is not guaranteed):
+
+```json
+{
+  "agent_id": "<uuid>",
+  "name": "<short-label>",
+  "registered_at": "<iso8601>"
+}
+```
+
+Rules:
+
+- **Name**: short, human-identifiable label (`Claude-A`, `reviewer-bot`, …). Not `test`, `foo`, etc.
+- **Description**: one sentence stating who the agent is and what it is for.
+- **Capture `agent_id` immediately.** It is required for every subsequent call; losing it forces re-registration.
+- Non-`--json` output prints `Agent registered successfully!` followed by `  agent_id:  <uuid>` and `  name:      <name>`. Parse the `agent_id:` line if `--json` is not an option.
+- Call `hikyaku deregister --agent-id <id>` at end of session so stale registrations do not accumulate.
+
+### List Agents
+
+List all registered agents, or get detail for a specific agent.
+
+```bash
+hikyaku agents --agent-id <self-agent-id>
+hikyaku agents --agent-id <self-agent-id> --id <target-agent-id>
+```
 
 ### Send (Unicast)
 
 Send a message to a specific agent by ID.
 
 ```bash
-hikyaku send --to <agent-id> --text "Did the API schema change?"
+hikyaku send --agent-id <self-agent-id> --to <target-agent-id> --text "Did the API schema change?"
 ```
 
 ### Broadcast
@@ -49,7 +101,7 @@ hikyaku send --to <agent-id> --text "Did the API schema change?"
 Send a message to all registered agents (except self).
 
 ```bash
-hikyaku broadcast --text "Build failed on main branch"
+hikyaku broadcast --agent-id <self-agent-id> --text "Build failed on main branch"
 ```
 
 ### Poll (Check Inbox)
@@ -57,9 +109,9 @@ hikyaku broadcast --text "Build failed on main branch"
 Poll for incoming messages. Returns tasks addressed to this agent.
 
 ```bash
-hikyaku poll
-hikyaku poll --since "2026-03-28T12:00:00Z"
-hikyaku poll --page-size 10
+hikyaku poll --agent-id <self-agent-id>
+hikyaku poll --agent-id <self-agent-id> --since "2026-03-28T12:00:00Z"
+hikyaku poll --agent-id <self-agent-id> --page-size 10
 ```
 
 ### Acknowledge (ACK)
@@ -67,7 +119,7 @@ hikyaku poll --page-size 10
 Acknowledge receipt of a message. Moves the task from INPUT_REQUIRED to COMPLETED.
 
 ```bash
-hikyaku ack --task-id <task-id>
+hikyaku ack --agent-id <self-agent-id> --task-id <task-id>
 ```
 
 ### Cancel (Retract)
@@ -75,7 +127,7 @@ hikyaku ack --task-id <task-id>
 Cancel a sent message that hasn't been acknowledged yet. Only the sender can cancel.
 
 ```bash
-hikyaku cancel --task-id <task-id>
+hikyaku cancel --agent-id <self-agent-id> --task-id <task-id>
 ```
 
 ### Get Task
@@ -83,16 +135,7 @@ hikyaku cancel --task-id <task-id>
 Get details of a specific task by ID.
 
 ```bash
-hikyaku get-task --task-id <task-id>
-```
-
-### List Agents
-
-List all registered agents, or get detail for a specific agent.
-
-```bash
-hikyaku agents
-hikyaku agents --id <agent-id>
+hikyaku get-task --agent-id <self-agent-id> --task-id <task-id>
 ```
 
 ### Deregister
@@ -100,46 +143,107 @@ hikyaku agents --id <agent-id>
 Remove this agent's registration from the broker.
 
 ```bash
-hikyaku deregister
+hikyaku deregister --agent-id <self-agent-id>
 ```
-
-## Global Options
-
-All commands accept these options (or fall back to env vars):
-
-- `--url <broker-url>` — Override HIKYAKU_URL
-- `--api-key <key>` — Override HIKYAKU_API_KEY
-- `--json` — Output in JSON format instead of human-readable text
 
 ## Typical Workflow
 
 1. **Register** with the broker (`HIKYAKU_API_KEY` must already be set; create the key in the Hikyaku WebUI first):
    ```bash
    hikyaku register --name "Code Review Agent" --description "Reviews pull requests"
-   # Note the returned agent_id; pass it via --agent-id on subsequent commands
+   # → record the returned agent_id as $MY_ID
    ```
 
 2. **Discover** other agents:
    ```bash
-   hikyaku agents
+   hikyaku agents --agent-id $MY_ID
    ```
 
 3. **Send** a message to another agent:
    ```bash
-   hikyaku send --to <target-agent-id> --text "Please review PR #42"
+   hikyaku send --agent-id $MY_ID --to <target-agent-id> --text "Please review PR #42"
    ```
 
 4. **Poll** for incoming messages:
    ```bash
-   hikyaku poll
+   hikyaku poll --agent-id $MY_ID
    ```
 
 5. **Acknowledge** received messages:
    ```bash
-   hikyaku ack --task-id <task-id>
+   hikyaku ack --agent-id $MY_ID --task-id <task-id>
    ```
 
-6. **Repeat** steps 3-5 as needed. Use `--json` flag when parsing output programmatically.
+6. **Repeat** steps 3-5 as needed. Use `hikyaku --json <cmd>` when parsing output programmatically.
+
+## Multi-Session Coordination
+
+### Roles
+
+- **Director** — the Claude Code session that first runs `hikyaku register` in this project. It owns the team lifecycle: spawning members, driving the exchange, and cleaning up.
+- **Member** — any peer Claude Code session the Director spawns in a tmux split-pane. Each member registers itself with `hikyaku`, runs its assigned exchange, and deregisters before exit.
+
+### Monitoring mandate (Director only)
+
+Before spawning **any** member, the Director MUST load `Skill(agent-team-supervision)` and start a `/loop` monitor as that skill instructs. Members do not act autonomously — if the Director stops supervising, the team stalls silently. Keep the `/loop` active until the final shutdown step.
+
+### Layout discipline
+
+Only the Director calls `tmux split-window`. The window is kept in `main-vertical` layout at all times:
+
+- Director occupies the full-height left "main" pane.
+- Every member is stacked in the right column at equal height.
+- Every spawn and every shutdown is followed by `tmux select-layout main-vertical`, so the right column is always evenly divided regardless of how many members are currently active.
+
+### Spawn a member
+
+Spawning a member is a **two-step** sequence. Shell variable expansion in the `tmux split-window` call (e.g. `-e "HIKYAKU_URL=$HIKYAKU_URL"`) is unreliable under the Bash tool's permission validator, so the Director must first read the literal values with `printenv` and then paste them into the `-e` flags verbatim.
+
+Step 1 — read the literal env values:
+
+```bash
+printenv HIKYAKU_URL HIKYAKU_API_KEY
+```
+
+This returns two lines: the URL on the first, the API key on the second. Capture both as plain strings.
+
+Step 2 — spawn `claude` in a new pane with those literal values forwarded via `-e`, then rebalance the window to `main-vertical`:
+
+```bash
+tmux split-window \
+  -e "HIKYAKU_URL=http://localhost:8000" \
+  -e "HIKYAKU_API_KEY=hky_0123456789abcdef0123456789abcdef" \
+  claude "Load Skill(hikyaku), register as Claude-B, send a round-trip ping to <director-agent-id>, poll for a reply, ack, and deregister."
+tmux select-layout main-vertical
+```
+
+Substitute the literal strings from Step 1 for the two placeholders above. Do **not** write `$HIKYAKU_URL` / `$HIKYAKU_API_KEY` in the `tmux split-window` command — always paste the concrete values.
+
+Rules:
+
+- Always run `printenv HIKYAKU_URL HIKYAKU_API_KEY` first and paste the literal output into the `-e` flags. Shell variable expansion inside the `tmux split-window` Bash call is blocked by the validator in some configurations, and even when allowed it fails silently if the variable is unset in the Director's shell.
+- Pass `claude "<prompt>"` as the trailing command of `tmux split-window`. Do **not** use `tmux send-keys` to type `claude` into the new pane — it races with shell startup and loses keystrokes.
+- Call `tmux select-layout main-vertical` immediately after every `split-window`. Without it, the right column is not guaranteed to be evenly divided and may even push the Director off the left-main slot.
+- `HIKYAKU_*` env vars in the current pane are NOT inherited by new panes (the tmux server uses its own frozen environment). Forwarding with `-e` is the only reliable way to give the member access to the broker.
+- Project-level `.claude/settings.local.json` must already allow `Bash(hikyaku:*)`. Do **not** pass `--allowedTools` or `--permission-mode bypassPermissions` — rely on project settings, which the peer inherits by being launched in the same project directory.
+- The prompt must be inline and self-contained. List the exact role, the target `agent_id`, and the expected cleanup. Do not stage the prompt through a temp file and do not write chat-style instructions.
+
+### Shut down a member
+
+After the member has deregistered from the broker, the Director shuts down its Claude Code session gracefully by sending `/exit` to the member's pane, then rebalances the layout:
+
+```bash
+tmux send-keys -t <member-pane-id> '/exit' Enter
+tmux select-layout main-vertical
+```
+
+`/exit` quits `claude` cleanly, which in turn closes the tmux pane because `claude` was the pane's root process. The immediately-following `select-layout main-vertical` re-equalizes the remaining members in the right column. Do **not** use `tmux kill-pane` — that terminates the session abruptly and bypasses any in-flight cleanup inside the peer.
+
+After every member is shut down, the Director deregisters itself and stops the `/loop` monitor:
+
+```bash
+hikyaku deregister --agent-id <director-agent-id>
+```
 
 ## Message Lifecycle
 
@@ -150,6 +254,7 @@ Messages are modeled as A2A Tasks with this lifecycle:
 
 ## Error Handling
 
-- Missing `--api-key` or `--agent-id` on authenticated commands exits with non-zero code
+- Missing `HIKYAKU_API_KEY` env var or missing `--agent-id` on authenticated commands exits with non-zero code
+- `HIKYAKU_URL` without an `http://` / `https://` scheme causes `Request URL is missing an 'http://' or 'https://' protocol`
 - Network errors and API errors are printed to stderr and exit with non-zero code
-- Use `--json` for machine-parseable error output
+- Use `hikyaku --json <cmd>` for machine-parseable output (including errors)

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ admin/node_modules/
 !.claude/skills
 !.claude/settings.json
 .claude/scheduled_tasks.lock
+
+__pycache__

--- a/mise.toml
+++ b/mise.toml
@@ -20,4 +20,4 @@ run = "uv run ty check"
 description = "Run ty type checker"
 
 [env]
-HIKYAKU_URL = "localhost:8000"
+HIKYAKU_URL = "http://localhost:8000"


### PR DESCRIPTION
- **docs(skill): rework hikyaku SKILL for multi-session coordination and printenv-based env forwarding**
- **docs(rules): mark SKILL.md as first-class documentation target**
- **chore(settings): allow hikyaku, tmux spawn, and printenv commands**
- **chore(gitignore): ignore __pycache__ directories**
- **fix(mise): add http scheme to HIKYAKU_URL default**
- **chore: allow tmux layout related commands**
