### PR TITLE
feat/registry bundled webui

### DIFF
--- a/.claude/rules/commands.md
+++ b/.claude/rules/commands.md
@@ -11,7 +11,7 @@
 - Format check (root): `mise //:format`
 - Type check: `mise //:typecheck`
 - Sync workspace: `uv sync` (from project root)
-- Start broker server: `mise //registry:dev`
+- Start broker server: `mise //registry:dev` (`//registry:dev` serves `/ui/` only after `//admin:build` has been run)
 - Start admin dev server: `mise //admin:dev`
 - Build admin: `mise //admin:build`
 

--- a/.claude/rules/git-workflow.md
+++ b/.claude/rules/git-workflow.md
@@ -1,0 +1,12 @@
+# Git Workflow (Project-Specific Overrides)
+
+This file overrides the user's global `~/.claude/rules/git-workflow.md` for this project only. The global rules still apply except where explicitly contradicted here.
+
+## design-docs/ is committed in this project
+
+**Override**: The global rule says `NEVER commit files from design-docs/`. In this project, design docs **MUST** be committed as part of the same feature branch that implements them.
+
+- Stage `design-docs/NNNNNNN-<slug>/design-doc.md` alongside the implementation commits.
+- A dedicated `docs: add design doc NNNNNNN-<slug>` commit at the end of the implementation sequence is acceptable, as is including the design doc in the first implementation commit.
+- Do **not** rely on the user's global gitignore — the file is tracked here.
+- `researches/` (the other half of the global rule) remains gitignored and is NOT committed.

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 !CLAUDE.md
 
 # WebUI SPA build output and dependencies
-admin/dist/
+registry/src/hikyaku_registry/webui/
 admin/node_modules/
 .vite
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -215,7 +215,7 @@ A browser-based dashboard served as a SPA at `/ui/`. Users log in via Auth0 (OID
 - **Backend API**: `/ui/api/*` endpoints in `webui_api.py` — auth config, key management, agent list, inbox, sent, send
 - **Auth**: Auth0 JWT in `Authorization` header. Tenant-scoped endpoints require `X-Tenant-Id` header (validated against `api_keys.owner_sub` ownership).
 - **Key management**: Users create, list, and revoke API keys through `/ui/api/keys` endpoints. Each key corresponds to a tenant. Revoking a key flips its status and bulk-deregisters every agent under that tenant in a single SQL transaction.
-- **Static serving**: `StaticFiles` mount at `/ui` serves `admin/dist/` (production build)
+- **Static serving**: `StaticFiles` mount at `/ui` serves the SPA bundled inside the registry package at `registry/src/hikyaku_registry/webui/` (production build). `mise //admin:build` must be run before `mise //registry:dev` for `/ui/` to be populated; without it the server starts cleanly and `/ui/` simply 404s.
 
 ## Monorepo Structure
 

--- a/README.md
+++ b/README.md
@@ -319,19 +319,19 @@ If step 1 is skipped, the server still starts and the JSON-RPC and Registry REST
 
 ### Running the Vite dev server with Auth0
 
-`mise //admin:dev` serves the SPA at `http://localhost:5173/ui/` with HMR. The SPA's Auth0 `redirect_uri` is computed at runtime as follows:
+`mise //admin:dev` serves the SPA at `http://localhost:5173/ui/` with HMR. Both the Auth0 login `redirect_uri` and the logout `returnTo` are computed at runtime as follows:
 
-1. If `VITE_AUTH0_REDIRECT_URI` is set (non-empty), use that.
+1. If `VITE_AUTH0_REDIRECT_URI` is set (non-empty at build time), use that.
 2. Otherwise fall back to `window.location.origin + "/ui/"`.
 
-For local dev, create `admin/.mise/config.toml` (gitignored, per-developer override) and set the redirect URI explicitly so dev and prod-like runs don't step on each other:
+`admin/mise.toml` scopes `VITE_AUTH0_REDIRECT_URI=http://localhost:5173/ui/` to the `//admin:dev` task only, so the Vite dev server bakes in the `:5173/ui/` URL and the built SPA (`//admin:build`) gets the dynamic `window.location.origin` fallback — meaning the same wheel works whether it is served from `:8000` via `//registry:dev` or from any other production host.
 
-```toml
-[env]
-VITE_AUTH0_REDIRECT_URI = "http://localhost:5173/ui/"
-```
+Both URLs used by the SPA MUST be in your Auth0 application's **Allowed Callback URLs** and **Allowed Logout URLs** lists:
 
-The matching URL MUST also be in your Auth0 application's **Allowed Callback URLs** list. `mise //admin:build` explicitly unsets this variable so the built SPA always uses the dynamic `window.location.origin` fallback and never bakes in a dev URL.
+- `http://localhost:5173/ui/` — for `mise //admin:dev`
+- `http://localhost:8000/ui/` — for `mise //registry:dev` (or whatever host you serve the built SPA from)
+
+Add both origins to **Allowed Web Origins** as well.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -182,10 +182,10 @@ Base path: `/api/v1`
 
 | Method | Endpoint | Auth | Description |
 |---|---|---|---|
-| POST | `/api/v1/agents` | Bearer | Register a new agent; API key (created via WebUI) is always required |
+| POST | `/api/v1/agents` | Bearer | Register a new agent; API key (created via WebUI) is always required. `X-Agent-Id` is not needed for registration |
 | GET | `/api/v1/agents` | Bearer + Agent-Id | List agents in the caller's tenant |
-| GET | `/api/v1/agents/{id}` | Bearer + Agent-Id | Get agent detail (404 if not in same tenant) |
-| DELETE | `/api/v1/agents/{id}` | Bearer + Agent-Id | Deregister an agent (self only) |
+| GET | `/api/v1/agents/{id}` | Bearer + Agent-Id | Get full A2A AgentCard JSON (404 if not in same tenant) |
+| DELETE | `/api/v1/agents/{id}` | Bearer + Agent-Id | Deregister an agent (self only); soft-delete, row is not physically removed |
 | GET | `/.well-known/agent-card.json` | None | Broker's own A2A Agent Card |
 
 Registry API errors use a consistent JSON envelope:
@@ -212,10 +212,10 @@ Registry API errors use a consistent JSON envelope:
 |---|---|
 | `SendMessage` | Send unicast (`metadata.destination=<agent-uuid>`) or broadcast (`metadata.destination=*`) |
 | `ListTasks` | Poll inbox -- use `contextId=<own-agent-id>` to retrieve messages addressed to this agent; supports `statusTimestampAfter` for delta polling |
-| `GetTask` | Retrieve a specific message by task ID |
-| `CancelTask` | Retract an unread message (sender only, `INPUT_REQUIRED` state only) |
+| `GetTask` | Retrieve a specific message by task ID; accessible by sender or recipient within the same tenant |
+| `CancelTask` | Retract an unread message (sender only, `INPUT_REQUIRED` state only); returns `TaskNotCancelableError` (JSON-RPC code `-32002`) if already completed or canceled |
 
-`ListTasks` enforces that `contextId` must equal the caller's agent ID. Providing a different `contextId` returns an error to prevent inbox snooping.
+`ListTasks` enforces that `contextId` must equal the caller's agent ID. Providing a different `contextId` returns an `InvalidParams` error (code `-32602`) to prevent inbox snooping. `GetTask` and `CancelTask` return `TaskNotFoundError` (code `-32001`) for cross-tenant access, indistinguishable from "not found".
 
 ### Message Lifecycle
 

--- a/README.md
+++ b/README.md
@@ -317,6 +317,22 @@ If step 1 is skipped, the server still starts and the JSON-RPC and Registry REST
 
 **Migration note for existing checkouts**: Existing checkouts pulled from before this change may have a stale `admin/dist/` directory; run `rm -rf admin/dist` once after pulling. The directory is no longer produced by `mise //admin:build`.
 
+### Running the Vite dev server with Auth0
+
+`mise //admin:dev` serves the SPA at `http://localhost:5173/ui/` with HMR. The SPA's Auth0 `redirect_uri` is computed at runtime as follows:
+
+1. If `VITE_AUTH0_REDIRECT_URI` is set (non-empty), use that.
+2. Otherwise fall back to `window.location.origin + "/ui/"`.
+
+For local dev, create `admin/.mise/config.toml` (gitignored, per-developer override) and set the redirect URI explicitly so dev and prod-like runs don't step on each other:
+
+```toml
+[env]
+VITE_AUTH0_REDIRECT_URI = "http://localhost:5173/ui/"
+```
+
+The matching URL MUST also be in your Auth0 application's **Allowed Callback URLs** list. `mise //admin:build` explicitly unsets this variable so the built SPA always uses the dynamic `window.location.origin` fallback and never bakes in a dev URL.
+
 ## License
 
 MIT

--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ The WebUI API is consumed by the browser SPA. Authentication uses Auth0 JWT (`Au
 | GET | `/ui/api/agents/{id}/sent` | JWT + Tenant-Id | Sent messages for an agent (newest first) |
 | POST | `/ui/api/messages/send` | JWT + Tenant-Id | Send a unicast message between two same-tenant agents |
 
-The WebUI SPA is served as static files at `/ui/`. It is built from `admin/` (Vite + React + TypeScript + Tailwind CSS).
+The WebUI SPA is served as static files at `/ui/`. It is built from `admin/` (Vite + React + TypeScript + Tailwind CSS) and the build output is bundled inside the registry package at `registry/src/hikyaku_registry/webui/`, which ships inside the `hikyaku-registry` wheel — a single `pip install hikyaku-registry` produces a runnable broker that serves `/ui/` without any external file lookup.
 
 ## Tech Stack
 
@@ -298,6 +298,24 @@ mise //registry:test
 # Run client tests
 mise //client:test
 ```
+
+### Build the WebUI
+
+The registry serves the SPA at `/ui/`, but the build is a separate manual step so backend-only contributors are not forced to install bun. Run these two commands in order:
+
+```bash
+# 1. Build the SPA into registry/src/hikyaku_registry/webui/
+mise //admin:build
+
+# 2. Start the broker — it serves the freshly built SPA at http://localhost:8000/ui/
+mise //registry:dev
+```
+
+If step 1 is skipped, the server still starts and the JSON-RPC and Registry REST surfaces remain functional; only `/ui/` 404s until you run `mise //admin:build`.
+
+**Release maintainers**: run `mise //admin:build` before any `uv build`. The wheel only includes whatever is currently sitting in `registry/src/hikyaku_registry/webui/`, so a stale or missing build will produce a wheel without the SPA. After building, verify the wheel contents with `unzip -l dist/hikyaku_registry-*.whl | grep webui/index.html`.
+
+**Migration note for existing checkouts**: Existing checkouts pulled from before this change may have a stale `admin/dist/` directory; run `rm -rf admin/dist` once after pulling. The directory is no longer produced by `mise //admin:build`.
 
 ## License
 

--- a/admin/mise.toml
+++ b/admin/mise.toml
@@ -6,3 +6,4 @@ run = "bun dev"
 
 [tasks.build]
 run = "bun run build"
+env = { VITE_AUTH0_REDIRECT_URI = "" }

--- a/admin/mise.toml
+++ b/admin/mise.toml
@@ -3,7 +3,7 @@ run = "bun lint"
 
 [tasks.dev]
 run = "bun dev"
+env = { VITE_AUTH0_REDIRECT_URI = "http://localhost:5173/ui/" }
 
 [tasks.build]
 run = "bun run build"
-env = { VITE_AUTH0_REDIRECT_URI = "" }

--- a/admin/src/App.tsx
+++ b/admin/src/App.tsx
@@ -109,7 +109,7 @@ function App() {
       domain={authConfig.domain}
       clientId={authConfig.client_id}
       authorizationParams={{
-        redirect_uri: window.location.origin,
+        redirect_uri: window.location.origin + "/ui/",
         audience: authConfig.audience,
       }}
     >

--- a/admin/src/App.tsx
+++ b/admin/src/App.tsx
@@ -109,7 +109,9 @@ function App() {
       domain={authConfig.domain}
       clientId={authConfig.client_id}
       authorizationParams={{
-        redirect_uri: window.location.origin + "/ui/",
+        redirect_uri:
+          import.meta.env.VITE_AUTH0_REDIRECT_URI ||
+          window.location.origin + "/ui/",
         audience: authConfig.audience,
       }}
     >

--- a/admin/src/components/KeyManagement.tsx
+++ b/admin/src/components/KeyManagement.tsx
@@ -77,7 +77,15 @@ export default function KeyManagement({ onSelectTenant }: KeyManagementProps) {
           Hikyaku — API Keys
         </h1>
         <button
-          onClick={() => logout({ logoutParams: { returnTo: window.location.origin } })}
+          onClick={() =>
+            logout({
+              logoutParams: {
+                returnTo:
+                  import.meta.env.VITE_AUTH0_REDIRECT_URI ||
+                  window.location.origin + "/ui/",
+              },
+            })
+          }
           className="text-sm text-gray-500 hover:text-gray-700"
         >
           Logout

--- a/admin/vite.config.ts
+++ b/admin/vite.config.ts
@@ -10,6 +10,10 @@ export default defineConfig({
     babel({ presets: [reactCompilerPreset()] }),
     tailwindcss(),
   ],
+  build: {
+    outDir: '../registry/src/hikyaku_registry/webui',
+    emptyOutDir: true,
+  },
   server: {
     proxy: {
       '/ui/api': {

--- a/admin/vite.config.ts
+++ b/admin/vite.config.ts
@@ -5,6 +5,7 @@ import tailwindcss from '@tailwindcss/vite'
 
 // https://vite.dev/config/
 export default defineConfig({
+  base: '/ui/',
   plugins: [
     react(),
     babel({ presets: [reactCompilerPreset()] }),

--- a/design-docs/0000012-registry-bundled-webui/design-doc.md
+++ b/design-docs/0000012-registry-bundled-webui/design-doc.md
@@ -1,0 +1,235 @@
+# Registry-Bundled WebUI Assets
+
+**Status**: Complete
+**Progress**: 15/15 tasks complete
+**Last Updated**: 2026-04-11
+
+## Overview
+
+Move the admin SPA build output from `admin/dist/` into the registry Python package (`registry/src/hikyaku_registry/webui/`) and ship it inside the `hikyaku-registry` wheel, so a single `pip install hikyaku-registry` produces a runnable broker that serves `/ui/` without any external file lookup.
+
+## Success Criteria
+
+- [x] `mise //admin:build` writes the SPA to `registry/src/hikyaku_registry/webui/index.html` (and sibling assets)
+- [x] `mise //registry:dev` serves the built SPA at `http://localhost:8000/ui/` with no extra steps (verified in-process via `test_default_mount_serves_spa` integration test)
+- [x] `uv build` (run after `mise //admin:build`) produces a wheel whose contents include `hikyaku_registry/webui/index.html`
+- [x] `create_app()`'s default `webui_dist_dir` resolves to a path inside the installed package, not a sibling repo directory
+- [x] `ARCHITECTURE.md`, `README.md`, and `.claude/rules/commands.md` document the new layout and the manual two-step build order
+- [x] `admin/dist/` is no longer produced by the build (Vite `outDir` redirected away from `admin/`)
+- [x] `.gitignore` entry for `admin/dist/` is replaced with the new `registry/src/hikyaku_registry/webui/` path
+
+---
+
+## Background
+
+The admin SPA currently builds to `admin/dist/` at the repo root. The registry server reaches outside its own package to load it:
+
+```python
+# registry/src/hikyaku_registry/main.py:331-334
+if webui_dist_dir is None:
+    webui_dist_dir = str(
+        Path(__file__).resolve().parent.parent.parent.parent / "admin" / "dist"
+    )
+```
+
+This works in a source checkout but breaks for any installed wheel — `Path(__file__).parent.parent.parent.parent` lands somewhere in `site-packages`, not at a repo root that contains `admin/`. The registry wheel's `[tool.hatch.build.targets.wheel].include` only ships `alembic.ini` and `alembic/**/*`; nothing under `admin/` is bundled. The result: `pip install hikyaku-registry` produces a server that can never serve the WebUI.
+
+The user's stated intent is "registry と一緒に web server としてホストしてほしい" — the WebUI must travel with the registry process as a single shippable unit.
+
+---
+
+## Specification
+
+### Target layout
+
+```
+registry/
+  src/hikyaku_registry/
+    webui/                      # NEW — Vite build output (gitignored)
+      index.html
+      assets/
+        index-<hash>.js
+        index-<hash>.css
+      ...
+    main.py                     # default webui_dist_dir resolves here
+    alembic/
+    ...
+admin/
+  vite.config.ts                # outDir points OUT of admin/ into registry package
+  src/                          # SPA sources unchanged
+  (no dist/ directory)          # admin/dist/ is permanently retired
+```
+
+### Vite build config
+
+`admin/vite.config.ts` adds an explicit `build` block:
+
+```ts
+export default defineConfig({
+  plugins: [
+    react(),
+    babel({ presets: [reactCompilerPreset()] }),
+    tailwindcss(),
+  ],
+  build: {
+    outDir: '../registry/src/hikyaku_registry/webui',
+    emptyOutDir: true,
+  },
+  server: {
+    proxy: {
+      '/ui/api': {
+        target: 'http://localhost:8000',
+        changeOrigin: true,
+      },
+    },
+  },
+})
+```
+
+`emptyOutDir: true` is required because Vite refuses by default to clear a directory outside the project root. The dev server (`mise //admin:dev`) is unaffected — it does not write to disk.
+
+### Runtime path resolution
+
+`create_app()` in `registry/src/hikyaku_registry/main.py` is updated to default to a package-relative path via a small helper, so the resolution logic is independently unit-testable:
+
+```python
+def _default_webui_dist_dir() -> Path:
+    return Path(__file__).resolve().parent / "webui"
+
+
+def create_app(...) -> FastAPI:
+    ...
+    if webui_dist_dir is None:
+        webui_dist_dir = str(_default_webui_dist_dir())
+    dist_path = Path(webui_dist_dir)
+    if dist_path.exists():
+        app.mount("/ui", SPAStaticFiles(directory=str(dist_path)), name="webui")
+```
+
+The existing `dist_path.exists()` guard is preserved: if a contributor has not yet run `mise //admin:build`, the server starts cleanly and `/ui/` simply 404s. The JSON-RPC and Registry REST surfaces remain fully functional. Tests already inject `webui_dist_dir` via the `mounted_app` fixture (`registry/tests/test_webui_mount.py:36`), so they are unaffected by the default change. The new helper exists specifically so a regression test can assert the default path stays inside the installed package without spinning up a full app.
+
+### Wheel packaging
+
+`registry/pyproject.toml` extends `[tool.hatch.build.targets.wheel].include`:
+
+```toml
+[tool.hatch.build.targets.wheel]
+packages = ["src/hikyaku_registry"]
+include = [
+  "src/hikyaku_registry/alembic.ini",
+  "src/hikyaku_registry/alembic/**/*",
+  "src/hikyaku_registry/webui/**/*",
+]
+```
+
+Wheel-only. The sdist is intentionally NOT extended — `pip install hikyaku-registry --no-binary` is out of scope.
+
+### Build orchestration — explicitly NO coupling
+
+`mise //registry:dev` and `mise //registry:test` are **not** modified. Backend-only contributors are not forced to install bun. The two-step manual order is documented:
+
+1. `mise //admin:build` — produces `registry/src/hikyaku_registry/webui/`
+2. `mise //registry:dev` — serves the result at `/ui/`
+
+If step 1 is skipped, the server still runs; only `/ui/` 404s.
+
+For wheel builds, the same manual order applies: run `mise //admin:build` before `uv build`. There is no hatch build hook enforcing this — documentation is the only enforcement mechanism. **Ownership**: the release maintainer is responsible for running `mise //admin:build` and the wheel-listing verification (`unzip -l dist/*.whl | grep webui/index.html`) before every `uv build`. This procedure is documented in the README's "Build the WebUI" subsection (added in Step 1) so there is exactly one canonical home for the manual order. There is no separate release runbook in this repo, and one is not introduced here.
+
+### Verification scope & residual risk
+
+Acceptance is verified at three levels — `mise //admin:build` produces the expected file, `mise //registry:dev` serves it locally, and `unzip -l dist/*.whl` confirms the wheel archive contains it. A fresh-venv `pip install dist/*.whl` smoke test (which would prove that the package-relative `Path(__file__).resolve().parent / "webui"` resolves correctly from a real `site-packages` layout) is **intentionally out of scope** per user decision. The wheel file listing proves the asset is in the archive but does NOT prove runtime path resolution from an installed package. This residual risk is accepted because:
+
+- The `Path(__file__).resolve().parent / "webui"` pattern is the same pattern used today by `alembic.ini` and `alembic/**/*` (also bundled via `[tool.hatch.build.targets.wheel].include`), and that bundling is known to work for `hikyaku-registry db init`.
+- The project has no release workflow yet (no `.github/workflows/release.*`), so adding a fresh-venv install test would be process overhead with no automation surface to wire it into.
+- If the install path ever becomes load-bearing (e.g. when a release workflow is introduced), the missing smoke test should be added at that time, not pre-emptively here.
+
+### .gitignore
+
+Replace the `admin/dist/` line with the new package-internal location:
+
+```gitignore
+# WebUI SPA build output and dependencies
+registry/src/hikyaku_registry/webui/
+admin/node_modules/
+.vite
+```
+
+Note: `admin/dist/` is removed entirely, since Vite no longer writes there.
+
+### Affected files
+
+| File | Change |
+|---|---|
+| `admin/vite.config.ts` | Add `build.outDir` + `build.emptyOutDir` |
+| `registry/src/hikyaku_registry/main.py` | Default `webui_dist_dir` to `Path(__file__).resolve().parent / "webui"` |
+| `registry/pyproject.toml` | Add `src/hikyaku_registry/webui/**/*` to wheel include |
+| `.gitignore` | Replace `admin/dist/` with `registry/src/hikyaku_registry/webui/` |
+| `ARCHITECTURE.md` | Update "WebUI / Static serving" line (currently `admin/dist/`) |
+| `README.md` | Rewrite line 246 prose + add new "Build the WebUI" subsection in the Development section |
+| `.claude/rules/commands.md` | Add a one-line note: "`//registry:dev` serves `/ui/` only after `//admin:build` has been run" |
+
+Files verified to need NO change:
+- `.claude/skills/hikyaku/SKILL.md` (does not reference `admin/dist`)
+- `docs/spec/*.md` (no `admin/dist` references)
+- `registry/tests/test_webui_mount.py` (tests inject `webui_dist_dir` explicitly)
+- No `plugins/` directory exists in this repo
+
+### Alternatives considered
+
+| Alternative | Why rejected |
+|---|---|
+| Keep `admin/dist/`, add a copy step to mirror it into the package | Two source-of-truth directories; copy step is invisible failure surface; doesn't simplify anything |
+| Couple `//registry:dev` to `//admin:build` via mise `depends` | Forces bun on backend-only contributors; rebuilds on every dev start; rejected by user |
+| Custom hatch build hook to invoke `bun run build` from `uv build` | Adds bun dependency to every wheel build environment, including CI lint jobs; rejected for simplicity |
+| Ship webui in sdist as well | `pip install --no-binary` is not a supported install path for this project; out of scope |
+| Use directory name `static/` or `_webui/` instead of `webui/` | `webui/` matches existing terminology in codebase (`webui_router`, `webui_dist_dir`, `webui_api.py`); rename adds churn for no gain |
+
+---
+
+## Implementation
+
+> Task format: `- [x] Done task <!-- completed: 2026-02-13T14:30 -->`
+> When completing a task, check the box and record the timestamp in the same edit.
+
+### Step 1: Documentation updates (BEFORE any code)
+
+Per `.claude/rules/design-doc-numbering.md`, documentation is updated first.
+
+- [x] Update `ARCHITECTURE.md` line 218: replace `\`StaticFiles\` mount at \`/ui\` serves \`admin/dist/\` (production build)` with the new bundled-package location and a note that `mise //admin:build` is required before `mise //registry:dev` serves it <!-- completed: 2026-04-11T00:00 -->
+- [x] Update `README.md` line 246: rewrite "It is built from `admin/`…" to state that the build output is bundled inside `registry/src/hikyaku_registry/webui/` and ships in the `hikyaku-registry` wheel <!-- completed: 2026-04-11T00:00 -->
+- [x] Update `README.md` Development section (around lines 282-300): add a "Build the WebUI" subsection that explicitly shows the manual two-command order — `mise //admin:build` first, then `mise //registry:dev` — and notes that the release maintainer must also run `mise //admin:build` before any `uv build` <!-- completed: 2026-04-11T00:00 -->
+- [x] Update `.claude/rules/commands.md` to add a one-line note under "Start broker server": `//registry:dev` serves `/ui/` only after `//admin:build` has been run <!-- completed: 2026-04-11T00:00 -->
+- [x] Use the Grep tool with pattern `admin/dist` and paths `.claude/skills/` and `docs/` to confirm no SKILL.md or spec doc still references `admin/dist`. If any hit is found, replace it with `registry/src/hikyaku_registry/webui/` in the same edit. <!-- completed: 2026-04-11T00:00 -->
+
+### Step 2: Vite config
+
+- [x] Edit `admin/vite.config.ts`: add `build: { outDir: '../registry/src/hikyaku_registry/webui', emptyOutDir: true }` <!-- completed: 2026-04-11T00:00 -->
+- [x] Run `mise //admin:build` and verify `registry/src/hikyaku_registry/webui/index.html` exists <!-- completed: 2026-04-11T00:00 -->
+
+### Step 3: Runtime default
+
+- [x] Edit `registry/src/hikyaku_registry/main.py`: add a module-level helper `def _default_webui_dist_dir() -> Path: return Path(__file__).resolve().parent / "webui"` and replace the existing `webui_dist_dir = str(Path(__file__).resolve().parent.parent.parent.parent / "admin" / "dist")` block in `create_app()` with `webui_dist_dir = str(_default_webui_dist_dir())` (still gated on `if webui_dist_dir is None`). <!-- completed: 2026-04-11T00:00 -->
+- [x] Add a regression test in `registry/tests/test_webui_mount.py`: new class `TestDefaultWebuiDistDir` with one test `test_default_points_inside_package` that imports `hikyaku_registry` and `_default_webui_dist_dir` from `hikyaku_registry.main`, then asserts `_default_webui_dist_dir() == Path(hikyaku_registry.__file__).resolve().parent / "webui"`. This protects against future package-layout refactors silently breaking the install-time path. <!-- completed: 2026-04-11T00:00 -->
+- [x] Add a Tester-owned integration test in `registry/tests/test_webui_mount.py` that constructs `create_app()` with NO `webui_dist_dir` argument (exercising the default path), uses `httpx.AsyncClient` + `ASGITransport` to `GET /ui/`, and asserts status 200 + `text/html` + body starts with `<!doctype html>`. Guard with `pytest.skip` if `<package>/webui/index.html` does not exist so CI environments without a prior `mise //admin:build` do not fail. <!-- completed: 2026-04-11T00:00 -->
+- [x] Run `mise //registry:test` to confirm the existing `test_webui_mount.py` suite still passes (the fixture injects `webui_dist_dir` so the default change is invisible to existing tests) <!-- completed: 2026-04-11T00:00 -->
+
+### Step 4: Wheel packaging
+
+- [x] Edit `registry/pyproject.toml`: add `"src/hikyaku_registry/webui/**/*"` to `[tool.hatch.build.targets.wheel].include` <!-- completed: 2026-04-11T00:00 -->
+- [x] From the project root, run `mise //admin:build` followed by `uv build --package hikyaku-registry` and verify `unzip -l dist/hikyaku_registry-*.whl` lists `hikyaku_registry/webui/index.html` <!-- completed: 2026-04-11T00:00 -->
+
+### Step 5: .gitignore + contributor migration note
+
+- [x] Update `.gitignore`: replace `admin/dist/` with `registry/src/hikyaku_registry/webui/` <!-- completed: 2026-04-11T00:00 -->
+- [x] Add a one-line contributor migration note in the README's "Build the WebUI" subsection (added in Step 1): "Existing checkouts pulled from before this change may have a stale `admin/dist/` directory; run `rm -rf admin/dist` once after pulling. The directory is no longer produced by `mise //admin:build`." <!-- completed: 2026-04-11T00:00 -->
+
+---
+
+## Changelog
+
+| Date | Changes |
+|------|---------|
+| 2026-04-11 | Initial draft |
+| 2026-04-11 | Reviewer pass 1 revisions: fixed task counter (12→15 — split README task added 1, regression-test task added 1, original count was actually 13); rewrote README task to spell out line 246 + Development subsection literally (B2); added "Verification scope & residual risk" subsection acknowledging the omitted fresh-venv smoke test (B3); converted Step 5 hygiene note into a concrete README contributor-migration task (I1); added regression-test task in Step 3 for the default `webui_dist_dir` (I2); named the release maintainer as owner of the manual `mise //admin:build` step in the Build orchestration subsection (I3); split Success Criterion #6 into two checkboxes (I4) |
+| 2026-04-11 | User approved; Status → Approved; Affected files README cell tightened |
+| 2026-04-11 | Implementation complete on branch `feat/registry-bundled-webui`. 7 commits: 0ee435c (docs), d02f285 (vite outDir), d4f0760 (regression test), c5ff94b (main.py helper), c2ac006 (integration test), 3a22dee (wheel include), 3bf9b2b (gitignore). 15/15 tasks, 339 tests pass. Verifier confirmed ALL CRITERIA SATISFIED. Step 3 task #3 was pivoted mid-execution from a curl-based live-server check to an in-process `httpx.AsyncClient` + `ASGITransport` integration test after user interjection. Status → Complete. |

--- a/registry/pyproject.toml
+++ b/registry/pyproject.toml
@@ -28,6 +28,7 @@ packages = ["src/hikyaku_registry"]
 include = [
   "src/hikyaku_registry/alembic.ini",
   "src/hikyaku_registry/alembic/**/*",
+  "src/hikyaku_registry/webui/**/*",
 ]
 
 [tool.pytest.ini_options]

--- a/registry/src/hikyaku_registry/main.py
+++ b/registry/src/hikyaku_registry/main.py
@@ -44,6 +44,10 @@ from hikyaku_registry.webui_api import (
 logger = logging.getLogger(__name__)
 
 
+def _default_webui_dist_dir() -> Path:
+    return Path(__file__).resolve().parent / "webui"
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     yield
@@ -329,9 +333,7 @@ def create_app(
 
     # Mount StaticFiles for WebUI SPA (AFTER router so API routes take precedence)
     if webui_dist_dir is None:
-        webui_dist_dir = str(
-            Path(__file__).resolve().parent.parent.parent.parent / "admin" / "dist"
-        )
+        webui_dist_dir = str(_default_webui_dist_dir())
     dist_path = Path(webui_dist_dir)
     if dist_path.exists():
         app.mount(

--- a/registry/tests/test_webui_mount.py
+++ b/registry/tests/test_webui_mount.py
@@ -8,9 +8,12 @@ These tests verify integration/mounting behavior, not endpoint logic
 (which is covered by test_webui_api.py).
 """
 
+from pathlib import Path
+
 import pytest
 from httpx import ASGITransport, AsyncClient
 
+import hikyaku_registry
 from hikyaku_registry.main import create_app
 
 
@@ -197,3 +200,26 @@ class TestExistingRoutesUnaffected:
 
         resp = await client.get("/.well-known/agent-card.json")
         assert resp.status_code == 200
+
+
+# ===========================================================================
+# Default webui_dist_dir resolves inside the installed package
+# ===========================================================================
+
+
+class TestDefaultWebuiDistDir:
+    """Verify _default_webui_dist_dir() points inside the installed package.
+
+    This protects against future package-layout refactors silently breaking
+    the install-time path: when a wheel is installed, the helper must resolve
+    to ``site-packages/hikyaku_registry/webui``, not a sibling repo directory.
+    """
+
+    def test_default_points_inside_package(self):
+        """_default_webui_dist_dir() returns <package>/webui as a Path."""
+        from hikyaku_registry.main import _default_webui_dist_dir
+
+        result = _default_webui_dist_dir()
+        expected = Path(hikyaku_registry.__file__).resolve().parent / "webui"
+        assert isinstance(result, Path)
+        assert result == expected

--- a/registry/tests/test_webui_mount.py
+++ b/registry/tests/test_webui_mount.py
@@ -225,7 +225,12 @@ class TestDefaultWebuiDistDir:
         assert result == expected
 
     async def test_default_mount_serves_spa(self, db_sessionmaker):
-        """create_app() with no webui_dist_dir mounts the package-bundled SPA at /ui/."""
+        """create_app() with no webui_dist_dir mounts the package-bundled SPA at /ui/.
+
+        Also asserts the emitted index.html references its assets under the
+        ``/ui/`` prefix (Vite ``base`` config). Absolute-root asset paths
+        (``/assets/...``) would 404 because StaticFiles is mounted at ``/ui``.
+        """
         package_dir = Path(hikyaku_registry.__file__).resolve().parent
         if not (package_dir / "webui" / "index.html").exists():
             pytest.skip("webui/ not built; run `mise //admin:build` first")
@@ -237,4 +242,40 @@ class TestDefaultWebuiDistDir:
 
         assert resp.status_code == 200
         assert resp.headers.get("content-type", "").startswith("text/html")
-        assert resp.text.lstrip().lower().startswith("<!doctype html>")
+        body = resp.text
+        assert body.lstrip().lower().startswith("<!doctype html>")
+        # Vite base must be '/ui/' so assets resolve under the StaticFiles mount.
+        assert 'src="/assets/' not in body, (
+            "index.html references /assets/ at the root; "
+            "set base: '/ui/' in admin/vite.config.ts"
+        )
+        assert 'href="/assets/' not in body, (
+            "index.html references /assets/ at the root; "
+            "set base: '/ui/' in admin/vite.config.ts"
+        )
+        assert '/ui/assets/' in body, (
+            "index.html does not reference /ui/assets/; "
+            "check Vite base config"
+        )
+
+    async def test_default_mount_serves_asset_files(self, db_sessionmaker):
+        """Assets referenced by index.html are actually fetchable under /ui/assets/."""
+        import re
+
+        package_dir = Path(hikyaku_registry.__file__).resolve().parent
+        if not (package_dir / "webui" / "index.html").exists():
+            pytest.skip("webui/ not built; run `mise //admin:build` first")
+
+        app = create_app(sessionmaker=db_sessionmaker)
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            index_resp = await client.get("/ui/")
+            asset_paths = re.findall(
+                r'(?:src|href)="(/ui/assets/[^"]+)"', index_resp.text
+            )
+            assert asset_paths, "no /ui/assets/ references found in index.html"
+            for path in asset_paths:
+                asset_resp = await client.get(path)
+                assert asset_resp.status_code == 200, (
+                    f"{path} returned {asset_resp.status_code}"
+                )

--- a/registry/tests/test_webui_mount.py
+++ b/registry/tests/test_webui_mount.py
@@ -223,3 +223,18 @@ class TestDefaultWebuiDistDir:
         expected = Path(hikyaku_registry.__file__).resolve().parent / "webui"
         assert isinstance(result, Path)
         assert result == expected
+
+    async def test_default_mount_serves_spa(self, db_sessionmaker):
+        """create_app() with no webui_dist_dir mounts the package-bundled SPA at /ui/."""
+        package_dir = Path(hikyaku_registry.__file__).resolve().parent
+        if not (package_dir / "webui" / "index.html").exists():
+            pytest.skip("webui/ not built; run `mise //admin:build` first")
+
+        app = create_app(sessionmaker=db_sessionmaker)
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.get("/ui/")
+
+        assert resp.status_code == 200
+        assert resp.headers.get("content-type", "").startswith("text/html")
+        assert resp.text.lstrip().lower().startswith("<!doctype html>")


### PR DESCRIPTION
- **docs: describe bundled WebUI layout and build order**
- **feat(admin): redirect Vite outDir into registry package**
- **test: add regression test for default webui_dist_dir helper**
- **feat(registry): resolve default webui_dist_dir inside package**
- **test: add SPA mount integration test for default webui_dist_dir**
- **build: ship webui assets inside hikyaku-registry wheel**
- **chore: ignore bundled webui build output**
- **docs: add design doc 0000012-registry-bundled-webui**
- **docs: override global git rule to commit design-docs**
