### PR TITLE
feat/0000044 pytest functional style

### DIFF
--- a/cafleet/tests/test_alembic_0002_upgrade.py
+++ b/cafleet/tests/test_alembic_0002_upgrade.py
@@ -31,272 +31,279 @@ def db_at_0001(tmp_path):
     return db_path
 
 
-class TestMigration0002Upgrade:
-    def test_sessions_table_created(self, db_at_0001):
-        cfg = _make_alembic_cfg(db_at_0001)
-        command.upgrade(cfg, "0002_local_simplification")
+def test_migration_0002_upgrade__sessions_table_created(db_at_0001):
+    cfg = _make_alembic_cfg(db_at_0001)
+    command.upgrade(cfg, "0002_local_simplification")
 
-        engine = create_engine(f"sqlite:///{db_at_0001}")
-        try:
-            insp = inspect(engine)
-            tables = set(insp.get_table_names())
-            assert "sessions" in tables
+    engine = create_engine(f"sqlite:///{db_at_0001}")
+    try:
+        insp = inspect(engine)
+        tables = set(insp.get_table_names())
+        assert "sessions" in tables
 
-            cols = {col["name"] for col in insp.get_columns("sessions")}
-            assert {"session_id", "label", "created_at"} <= cols
-        finally:
-            engine.dispose()
+        cols = {col["name"] for col in insp.get_columns("sessions")}
+        assert {"session_id", "label", "created_at"} <= cols
+    finally:
+        engine.dispose()
 
-    def test_api_keys_table_dropped(self, db_at_0001):
-        cfg = _make_alembic_cfg(db_at_0001)
-        command.upgrade(cfg, "0002_local_simplification")
 
-        engine = create_engine(f"sqlite:///{db_at_0001}")
-        try:
-            insp = inspect(engine)
-            tables = set(insp.get_table_names())
-            assert "api_keys" not in tables
-        finally:
-            engine.dispose()
+def test_migration_0002_upgrade__api_keys_table_dropped(db_at_0001):
+    cfg = _make_alembic_cfg(db_at_0001)
+    command.upgrade(cfg, "0002_local_simplification")
 
-    def test_agents_column_renamed_to_session_id(self, db_at_0001):
-        cfg = _make_alembic_cfg(db_at_0001)
-        command.upgrade(cfg, "0002_local_simplification")
+    engine = create_engine(f"sqlite:///{db_at_0001}")
+    try:
+        insp = inspect(engine)
+        tables = set(insp.get_table_names())
+        assert "api_keys" not in tables
+    finally:
+        engine.dispose()
 
-        engine = create_engine(f"sqlite:///{db_at_0001}")
-        try:
-            insp = inspect(engine)
-            cols = {col["name"] for col in insp.get_columns("agents")}
-            assert "session_id" in cols
-            assert "tenant_id" not in cols
-        finally:
-            engine.dispose()
 
-    def test_session_seeded_from_api_key(self, db_at_0001):
-        engine = create_engine(f"sqlite:///{db_at_0001}")
-        try:
-            with engine.begin() as conn:
-                conn.execute(
-                    text(
-                        "INSERT INTO api_keys "
-                        "(api_key_hash, owner_sub, key_prefix, status, created_at) "
-                        "VALUES (:hash, :owner, :prefix, :status, :created)"
-                    ),
-                    {
-                        "hash": "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
-                        "owner": "auth0|test-owner",
-                        "prefix": "hky_abcd",
-                        "status": "active",
-                        "created": _now_iso(),
-                    },
-                )
-        finally:
-            engine.dispose()
+def test_migration_0002_upgrade__agents_column_renamed_to_session_id(db_at_0001):
+    cfg = _make_alembic_cfg(db_at_0001)
+    command.upgrade(cfg, "0002_local_simplification")
 
-        cfg = _make_alembic_cfg(db_at_0001)
-        command.upgrade(cfg, "0002_local_simplification")
+    engine = create_engine(f"sqlite:///{db_at_0001}")
+    try:
+        insp = inspect(engine)
+        cols = {col["name"] for col in insp.get_columns("agents")}
+        assert "session_id" in cols
+        assert "tenant_id" not in cols
+    finally:
+        engine.dispose()
 
-        engine = create_engine(f"sqlite:///{db_at_0001}")
-        try:
-            with engine.connect() as conn:
-                rows = conn.execute(
-                    text("SELECT session_id, label, created_at FROM sessions")
-                ).fetchall()
 
-            assert len(rows) == 1
-            session_id, label, created_at = rows[0]
-            assert (
-                session_id
-                == "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
+def test_migration_0002_upgrade__session_seeded_from_api_key(db_at_0001):
+    engine = create_engine(f"sqlite:///{db_at_0001}")
+    try:
+        with engine.begin() as conn:
+            conn.execute(
+                text(
+                    "INSERT INTO api_keys "
+                    "(api_key_hash, owner_sub, key_prefix, status, created_at) "
+                    "VALUES (:hash, :owner, :prefix, :status, :created)"
+                ),
+                {
+                    "hash": "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+                    "owner": "auth0|test-owner",
+                    "prefix": "hky_abcd",
+                    "status": "active",
+                    "created": _now_iso(),
+                },
             )
-            assert label == "legacy-hky_abcd"
-            assert created_at is not None
-        finally:
-            engine.dispose()
+    finally:
+        engine.dispose()
 
-    def test_agent_fk_valid_after_upgrade(self, db_at_0001):
-        api_key_hash = (
-            "beef0000beef0000beef0000beef0000beef0000beef0000beef0000beef0000"
+    cfg = _make_alembic_cfg(db_at_0001)
+    command.upgrade(cfg, "0002_local_simplification")
+
+    engine = create_engine(f"sqlite:///{db_at_0001}")
+    try:
+        with engine.connect() as conn:
+            rows = conn.execute(
+                text("SELECT session_id, label, created_at FROM sessions")
+            ).fetchall()
+
+        assert len(rows) == 1
+        session_id, label, created_at = rows[0]
+        assert (
+            session_id
+            == "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
         )
-        agent_id = "agent-migration-test"
-        now = _now_iso()
-
-        engine = create_engine(f"sqlite:///{db_at_0001}")
-        try:
-            with engine.begin() as conn:
-                conn.execute(
-                    text(
-                        "INSERT INTO api_keys "
-                        "(api_key_hash, owner_sub, key_prefix, status, created_at) "
-                        "VALUES (:hash, :owner, :prefix, :status, :created)"
-                    ),
-                    {
-                        "hash": api_key_hash,
-                        "owner": "auth0|fk-test",
-                        "prefix": "hky_beef",
-                        "status": "active",
-                        "created": now,
-                    },
-                )
-                conn.execute(
-                    text(
-                        "INSERT INTO agents "
-                        "(agent_id, tenant_id, name, description, status, "
-                        " registered_at, agent_card_json) "
-                        "VALUES (:aid, :tid, :name, :desc, :status, :at, :card)"
-                    ),
-                    {
-                        "aid": agent_id,
-                        "tid": api_key_hash,
-                        "name": "Test",
-                        "desc": "Test agent",
-                        "status": "active",
-                        "at": now,
-                        "card": "{}",
-                    },
-                )
-        finally:
-            engine.dispose()
-
-        cfg = _make_alembic_cfg(db_at_0001)
-        command.upgrade(cfg, "0002_local_simplification")
-
-        engine = create_engine(f"sqlite:///{db_at_0001}")
-        try:
-            with engine.connect() as conn:
-                row = conn.execute(
-                    text("SELECT session_id FROM agents WHERE agent_id = :aid"),
-                    {"aid": agent_id},
-                ).fetchone()
-                assert row is not None
-                assert row[0] == api_key_hash
-
-                sess_row = conn.execute(
-                    text("SELECT session_id FROM sessions WHERE session_id = :sid"),
-                    {"sid": api_key_hash},
-                ).fetchone()
-                assert sess_row is not None
-        finally:
-            engine.dispose()
-
-    def test_revoked_api_key_also_seeded(self, db_at_0001):
-        """Revoked keys must also be seeded to prevent FK violations for agents
-        whose tenant_id referenced a revoked key."""
-        active_hash = "aaaa0000" * 8
-        revoked_hash = "bbbb0000" * 8
-        now = _now_iso()
-
-        engine = create_engine(f"sqlite:///{db_at_0001}")
-        try:
-            with engine.begin() as conn:
-                conn.execute(
-                    text(
-                        "INSERT INTO api_keys "
-                        "(api_key_hash, owner_sub, key_prefix, status, created_at) "
-                        "VALUES (:hash, :owner, :prefix, :status, :created)"
-                    ),
-                    {
-                        "hash": active_hash,
-                        "owner": "auth0|owner-active",
-                        "prefix": "hky_aaaa",
-                        "status": "active",
-                        "created": now,
-                    },
-                )
-                conn.execute(
-                    text(
-                        "INSERT INTO api_keys "
-                        "(api_key_hash, owner_sub, key_prefix, status, created_at) "
-                        "VALUES (:hash, :owner, :prefix, :status, :created)"
-                    ),
-                    {
-                        "hash": revoked_hash,
-                        "owner": "auth0|owner-revoked",
-                        "prefix": "hky_bbbb",
-                        "status": "revoked",
-                        "created": now,
-                    },
-                )
-        finally:
-            engine.dispose()
-
-        cfg = _make_alembic_cfg(db_at_0001)
-        command.upgrade(cfg, "0002_local_simplification")
-
-        engine = create_engine(f"sqlite:///{db_at_0001}")
-        try:
-            with engine.connect() as conn:
-                rows = conn.execute(
-                    text("SELECT session_id FROM sessions ORDER BY session_id")
-                ).fetchall()
-            session_ids = {row[0] for row in rows}
-            assert active_hash in session_ids
-            assert revoked_hash in session_ids
-        finally:
-            engine.dispose()
-
-    def test_fresh_db_upgrade_no_op_on_empty_api_keys(self, db_at_0001):
-        cfg = _make_alembic_cfg(db_at_0001)
-        command.upgrade(cfg, "0002_local_simplification")
-
-        engine = create_engine(f"sqlite:///{db_at_0001}")
-        try:
-            with engine.connect() as conn:
-                rows = conn.execute(text("SELECT COUNT(*) FROM sessions")).fetchone()
-            assert rows[0] == 0
-        finally:
-            engine.dispose()
-
-    def test_idx_agents_session_status_exists(self, db_at_0001):
-        cfg = _make_alembic_cfg(db_at_0001)
-        command.upgrade(cfg, "0002_local_simplification")
-
-        engine = create_engine(f"sqlite:///{db_at_0001}")
-        try:
-            insp = inspect(engine)
-            indexes = insp.get_indexes("agents")
-            match = [
-                idx for idx in indexes if idx["name"] == "idx_agents_session_status"
-            ]
-            assert len(match) == 1
-            assert "session_id" in match[0]["column_names"]
-            assert "status" in match[0]["column_names"]
-        finally:
-            engine.dispose()
-
-    def test_idx_agents_tenant_status_gone(self, db_at_0001):
-        cfg = _make_alembic_cfg(db_at_0001)
-        command.upgrade(cfg, "0002_local_simplification")
-
-        engine = create_engine(f"sqlite:///{db_at_0001}")
-        try:
-            insp = inspect(engine)
-            indexes = insp.get_indexes("agents")
-            old = [idx for idx in indexes if idx["name"] == "idx_agents_tenant_status"]
-            assert len(old) == 0
-        finally:
-            engine.dispose()
-
-    def test_alembic_version_updated(self, db_at_0001):
-        cfg = _make_alembic_cfg(db_at_0001)
-        command.upgrade(cfg, "0002_local_simplification")
-
-        engine = create_engine(f"sqlite:///{db_at_0001}")
-        try:
-            with engine.connect() as conn:
-                rows = conn.execute(
-                    text("SELECT version_num FROM alembic_version")
-                ).fetchall()
-            assert len(rows) == 1
-            assert rows[0][0] == "0002_local_simplification"
-        finally:
-            engine.dispose()
+        assert label == "legacy-hky_abcd"
+        assert created_at is not None
+    finally:
+        engine.dispose()
 
 
-class TestMigration0002Downgrade:
-    def test_downgrade_raises_not_implemented(self, db_at_0001):
-        cfg = _make_alembic_cfg(db_at_0001)
-        command.upgrade(cfg, "0002_local_simplification")
+def test_migration_0002_upgrade__agent_fk_valid_after_upgrade(db_at_0001):
+    api_key_hash = (
+        "beef0000beef0000beef0000beef0000beef0000beef0000beef0000beef0000"
+    )
+    agent_id = "agent-migration-test"
+    now = _now_iso()
 
-        with pytest.raises(NotImplementedError, match="one-way migration"):
-            command.downgrade(cfg, "0001")
+    engine = create_engine(f"sqlite:///{db_at_0001}")
+    try:
+        with engine.begin() as conn:
+            conn.execute(
+                text(
+                    "INSERT INTO api_keys "
+                    "(api_key_hash, owner_sub, key_prefix, status, created_at) "
+                    "VALUES (:hash, :owner, :prefix, :status, :created)"
+                ),
+                {
+                    "hash": api_key_hash,
+                    "owner": "auth0|fk-test",
+                    "prefix": "hky_beef",
+                    "status": "active",
+                    "created": now,
+                },
+            )
+            conn.execute(
+                text(
+                    "INSERT INTO agents "
+                    "(agent_id, tenant_id, name, description, status, "
+                    " registered_at, agent_card_json) "
+                    "VALUES (:aid, :tid, :name, :desc, :status, :at, :card)"
+                ),
+                {
+                    "aid": agent_id,
+                    "tid": api_key_hash,
+                    "name": "Test",
+                    "desc": "Test agent",
+                    "status": "active",
+                    "at": now,
+                    "card": "{}",
+                },
+            )
+    finally:
+        engine.dispose()
+
+    cfg = _make_alembic_cfg(db_at_0001)
+    command.upgrade(cfg, "0002_local_simplification")
+
+    engine = create_engine(f"sqlite:///{db_at_0001}")
+    try:
+        with engine.connect() as conn:
+            row = conn.execute(
+                text("SELECT session_id FROM agents WHERE agent_id = :aid"),
+                {"aid": agent_id},
+            ).fetchone()
+            assert row is not None
+            assert row[0] == api_key_hash
+
+            sess_row = conn.execute(
+                text("SELECT session_id FROM sessions WHERE session_id = :sid"),
+                {"sid": api_key_hash},
+            ).fetchone()
+            assert sess_row is not None
+    finally:
+        engine.dispose()
+
+
+def test_migration_0002_upgrade__revoked_api_key_also_seeded(db_at_0001):
+    """Revoked keys must also be seeded to prevent FK violations for agents
+    whose tenant_id referenced a revoked key."""
+    active_hash = "aaaa0000" * 8
+    revoked_hash = "bbbb0000" * 8
+    now = _now_iso()
+
+    engine = create_engine(f"sqlite:///{db_at_0001}")
+    try:
+        with engine.begin() as conn:
+            conn.execute(
+                text(
+                    "INSERT INTO api_keys "
+                    "(api_key_hash, owner_sub, key_prefix, status, created_at) "
+                    "VALUES (:hash, :owner, :prefix, :status, :created)"
+                ),
+                {
+                    "hash": active_hash,
+                    "owner": "auth0|owner-active",
+                    "prefix": "hky_aaaa",
+                    "status": "active",
+                    "created": now,
+                },
+            )
+            conn.execute(
+                text(
+                    "INSERT INTO api_keys "
+                    "(api_key_hash, owner_sub, key_prefix, status, created_at) "
+                    "VALUES (:hash, :owner, :prefix, :status, :created)"
+                ),
+                {
+                    "hash": revoked_hash,
+                    "owner": "auth0|owner-revoked",
+                    "prefix": "hky_bbbb",
+                    "status": "revoked",
+                    "created": now,
+                },
+            )
+    finally:
+        engine.dispose()
+
+    cfg = _make_alembic_cfg(db_at_0001)
+    command.upgrade(cfg, "0002_local_simplification")
+
+    engine = create_engine(f"sqlite:///{db_at_0001}")
+    try:
+        with engine.connect() as conn:
+            rows = conn.execute(
+                text("SELECT session_id FROM sessions ORDER BY session_id")
+            ).fetchall()
+        session_ids = {row[0] for row in rows}
+        assert active_hash in session_ids
+        assert revoked_hash in session_ids
+    finally:
+        engine.dispose()
+
+
+def test_migration_0002_upgrade__fresh_db_upgrade_no_op_on_empty_api_keys(db_at_0001):
+    cfg = _make_alembic_cfg(db_at_0001)
+    command.upgrade(cfg, "0002_local_simplification")
+
+    engine = create_engine(f"sqlite:///{db_at_0001}")
+    try:
+        with engine.connect() as conn:
+            rows = conn.execute(text("SELECT COUNT(*) FROM sessions")).fetchone()
+        assert rows[0] == 0
+    finally:
+        engine.dispose()
+
+
+def test_migration_0002_upgrade__idx_agents_session_status_exists(db_at_0001):
+    cfg = _make_alembic_cfg(db_at_0001)
+    command.upgrade(cfg, "0002_local_simplification")
+
+    engine = create_engine(f"sqlite:///{db_at_0001}")
+    try:
+        insp = inspect(engine)
+        indexes = insp.get_indexes("agents")
+        match = [
+            idx for idx in indexes if idx["name"] == "idx_agents_session_status"
+        ]
+        assert len(match) == 1
+        assert "session_id" in match[0]["column_names"]
+        assert "status" in match[0]["column_names"]
+    finally:
+        engine.dispose()
+
+
+def test_migration_0002_upgrade__idx_agents_tenant_status_gone(db_at_0001):
+    cfg = _make_alembic_cfg(db_at_0001)
+    command.upgrade(cfg, "0002_local_simplification")
+
+    engine = create_engine(f"sqlite:///{db_at_0001}")
+    try:
+        insp = inspect(engine)
+        indexes = insp.get_indexes("agents")
+        old = [idx for idx in indexes if idx["name"] == "idx_agents_tenant_status"]
+        assert len(old) == 0
+    finally:
+        engine.dispose()
+
+
+def test_migration_0002_upgrade__alembic_version_updated(db_at_0001):
+    cfg = _make_alembic_cfg(db_at_0001)
+    command.upgrade(cfg, "0002_local_simplification")
+
+    engine = create_engine(f"sqlite:///{db_at_0001}")
+    try:
+        with engine.connect() as conn:
+            rows = conn.execute(
+                text("SELECT version_num FROM alembic_version")
+            ).fetchall()
+        assert len(rows) == 1
+        assert rows[0][0] == "0002_local_simplification"
+    finally:
+        engine.dispose()
+
+
+def test_migration_0002_downgrade__downgrade_raises_not_implemented(db_at_0001):
+    cfg = _make_alembic_cfg(db_at_0001)
+    command.upgrade(cfg, "0002_local_simplification")
+
+    with pytest.raises(NotImplementedError, match="one-way migration"):
+        command.downgrade(cfg, "0001")

--- a/cafleet/tests/test_alembic_0002_upgrade.py
+++ b/cafleet/tests/test_alembic_0002_upgrade.py
@@ -118,9 +118,7 @@ def test_migration_0002_upgrade__session_seeded_from_api_key(db_at_0001):
 
 
 def test_migration_0002_upgrade__agent_fk_valid_after_upgrade(db_at_0001):
-    api_key_hash = (
-        "beef0000beef0000beef0000beef0000beef0000beef0000beef0000beef0000"
-    )
+    api_key_hash = "beef0000beef0000beef0000beef0000beef0000beef0000beef0000beef0000"
     agent_id = "agent-migration-test"
     now = _now_iso()
 
@@ -261,9 +259,7 @@ def test_migration_0002_upgrade__idx_agents_session_status_exists(db_at_0001):
     try:
         insp = inspect(engine)
         indexes = insp.get_indexes("agents")
-        match = [
-            idx for idx in indexes if idx["name"] == "idx_agents_session_status"
-        ]
+        match = [idx for idx in indexes if idx["name"] == "idx_agents_session_status"]
         assert len(match) == 1
         assert "session_id" in match[0]["column_names"]
         assert "status" in match[0]["column_names"]

--- a/cafleet/tests/test_alembic_0006_upgrade.py
+++ b/cafleet/tests/test_alembic_0006_upgrade.py
@@ -243,7 +243,9 @@ def test_migration_0006_upgrade_idempotent__double_upgrade_is_idempotent(db_at_0
         engine.dispose()
 
 
-def test_migration_0006_upgrade_idempotent__idempotent_preserves_original_administrator_id(db_at_0005):
+def test_migration_0006_upgrade_idempotent__idempotent_preserves_original_administrator_id(
+    db_at_0005,
+):
     sid = str(uuid.uuid4())
     created_at = "2026-04-04T04:04:04+00:00"
 
@@ -281,7 +283,9 @@ def test_migration_0006_upgrade_idempotent__idempotent_preserves_original_admini
 # FK enforcement, not our migration. ---
 
 
-def test_migration_0006_downgrade_smoke__downgrade_removes_administrator_on_empty_session(db_at_0005):
+def test_migration_0006_downgrade_smoke__downgrade_removes_administrator_on_empty_session(
+    db_at_0005,
+):
     sid = str(uuid.uuid4())
     created_at = "2026-05-05T05:05:05+00:00"
 

--- a/cafleet/tests/test_alembic_0006_upgrade.py
+++ b/cafleet/tests/test_alembic_0006_upgrade.py
@@ -105,212 +105,213 @@ def db_at_0005(tmp_path):
     return db_path
 
 
-class TestMigration0006UpgradeSeed:
-    def test_seeds_one_administrator_per_session(self, db_at_0005):
-        from cafleet.broker import ADMINISTRATOR_KIND
+def test_migration_0006_upgrade_seed__seeds_one_administrator_per_session(db_at_0005):
+    from cafleet.broker import ADMINISTRATOR_KIND
 
-        sid_a = str(uuid.uuid4())
-        sid_b = str(uuid.uuid4())
-        created_at_a = "2026-01-01T00:00:00+00:00"
-        created_at_b = "2026-02-02T12:34:56+00:00"
+    sid_a = str(uuid.uuid4())
+    sid_b = str(uuid.uuid4())
+    created_at_a = "2026-01-01T00:00:00+00:00"
+    created_at_b = "2026-02-02T12:34:56+00:00"
 
-        engine = create_engine(f"sqlite:///{db_at_0005}")
-        try:
-            _seed_session(engine, session_id=sid_a, created_at=created_at_a, label="a")
-            _seed_session(engine, session_id=sid_b, created_at=created_at_b, label="b")
-            _seed_user_agent(
-                engine,
-                agent_id=str(uuid.uuid4()),
-                session_id=sid_a,
-                name="user-1",
-                registered_at=created_at_a,
-            )
-            _seed_user_agent(
-                engine,
-                agent_id=str(uuid.uuid4()),
-                session_id=sid_a,
-                name="user-2",
-                registered_at=created_at_a,
-            )
-            # Session B has no user agents — it must still gain an Administrator.
-        finally:
-            engine.dispose()
+    engine = create_engine(f"sqlite:///{db_at_0005}")
+    try:
+        _seed_session(engine, session_id=sid_a, created_at=created_at_a, label="a")
+        _seed_session(engine, session_id=sid_b, created_at=created_at_b, label="b")
+        _seed_user_agent(
+            engine,
+            agent_id=str(uuid.uuid4()),
+            session_id=sid_a,
+            name="user-1",
+            registered_at=created_at_a,
+        )
+        _seed_user_agent(
+            engine,
+            agent_id=str(uuid.uuid4()),
+            session_id=sid_a,
+            name="user-2",
+            registered_at=created_at_a,
+        )
+        # Session B has no user agents — it must still gain an Administrator.
+    finally:
+        engine.dispose()
 
-        cfg = _make_alembic_cfg(db_at_0005)
-        command.upgrade(cfg, "head")
+    cfg = _make_alembic_cfg(db_at_0005)
+    command.upgrade(cfg, "head")
 
-        engine = create_engine(f"sqlite:///{db_at_0005}")
-        try:
-            admins_a = _fetch_administrator_rows(engine, sid_a)
-            admins_b = _fetch_administrator_rows(engine, sid_b)
+    engine = create_engine(f"sqlite:///{db_at_0005}")
+    try:
+        admins_a = _fetch_administrator_rows(engine, sid_a)
+        admins_b = _fetch_administrator_rows(engine, sid_b)
 
-            assert len(admins_a) == 1
-            assert len(admins_b) == 1
+        assert len(admins_a) == 1
+        assert len(admins_b) == 1
 
-            for admins, expected_created_at in (
-                (admins_a, created_at_a),
-                (admins_b, created_at_b),
-            ):
-                row = admins[0]
-                assert row["name"] == "Administrator"
-                assert row["status"] == "active"
-                assert row["registered_at"] == expected_created_at
-                uuid.UUID(row["agent_id"])
-                card = json.loads(row["agent_card_json"])
-                assert card["cafleet"]["kind"] == ADMINISTRATOR_KIND
-                assert card["name"] == "Administrator"
-                assert card["skills"] == []
-        finally:
-            engine.dispose()
-
-    def test_seed_preserves_existing_user_agents(self, db_at_0005):
-        sid = str(uuid.uuid4())
-        created_at = "2026-01-01T00:00:00+00:00"
-        user_id = str(uuid.uuid4())
-
-        engine = create_engine(f"sqlite:///{db_at_0005}")
-        try:
-            _seed_session(engine, session_id=sid, created_at=created_at)
-            _seed_user_agent(
-                engine,
-                agent_id=user_id,
-                session_id=sid,
-                name="survivor",
-                registered_at=created_at,
-            )
-        finally:
-            engine.dispose()
-
-        cfg = _make_alembic_cfg(db_at_0005)
-        command.upgrade(cfg, "head")
-
-        engine = create_engine(f"sqlite:///{db_at_0005}")
-        try:
-            with engine.connect() as conn:
-                row = conn.execute(
-                    text("SELECT name, status FROM agents WHERE agent_id = :aid"),
-                    {"aid": user_id},
-                ).fetchone()
-            assert row is not None
-            assert row[0] == "survivor"
-            assert row[1] == "active"
-        finally:
-            engine.dispose()
-
-    def test_no_sessions_no_administrators(self, db_at_0005):
-        cfg = _make_alembic_cfg(db_at_0005)
-        command.upgrade(cfg, "head")
-
-        engine = create_engine(f"sqlite:///{db_at_0005}")
-        try:
-            with engine.connect() as conn:
-                (count,) = conn.execute(
-                    text(
-                        "SELECT COUNT(*) FROM agents "
-                        "WHERE json_extract(agent_card_json, '$.cafleet.kind') "
-                        "      = 'builtin-administrator'"
-                    )
-                ).fetchone()
-            assert count == 0
-        finally:
-            engine.dispose()
+        for admins, expected_created_at in (
+            (admins_a, created_at_a),
+            (admins_b, created_at_b),
+        ):
+            row = admins[0]
+            assert row["name"] == "Administrator"
+            assert row["status"] == "active"
+            assert row["registered_at"] == expected_created_at
+            uuid.UUID(row["agent_id"])
+            card = json.loads(row["agent_card_json"])
+            assert card["cafleet"]["kind"] == ADMINISTRATOR_KIND
+            assert card["name"] == "Administrator"
+            assert card["skills"] == []
+    finally:
+        engine.dispose()
 
 
-class TestMigration0006UpgradeIdempotent:
-    def test_double_upgrade_is_idempotent(self, db_at_0005):
-        sid_a = str(uuid.uuid4())
-        sid_b = str(uuid.uuid4())
-        created_at = "2026-03-03T03:03:03+00:00"
+def test_migration_0006_upgrade_seed__seed_preserves_existing_user_agents(db_at_0005):
+    sid = str(uuid.uuid4())
+    created_at = "2026-01-01T00:00:00+00:00"
+    user_id = str(uuid.uuid4())
 
-        engine = create_engine(f"sqlite:///{db_at_0005}")
-        try:
-            _seed_session(engine, session_id=sid_a, created_at=created_at)
-            _seed_session(engine, session_id=sid_b, created_at=created_at)
-        finally:
-            engine.dispose()
+    engine = create_engine(f"sqlite:///{db_at_0005}")
+    try:
+        _seed_session(engine, session_id=sid, created_at=created_at)
+        _seed_user_agent(
+            engine,
+            agent_id=user_id,
+            session_id=sid,
+            name="survivor",
+            registered_at=created_at,
+        )
+    finally:
+        engine.dispose()
 
-        cfg = _make_alembic_cfg(db_at_0005)
-        command.upgrade(cfg, "head")
-        command.upgrade(cfg, "head")
+    cfg = _make_alembic_cfg(db_at_0005)
+    command.upgrade(cfg, "head")
 
-        engine = create_engine(f"sqlite:///{db_at_0005}")
-        try:
-            admins_a = _fetch_administrator_rows(engine, sid_a)
-            admins_b = _fetch_administrator_rows(engine, sid_b)
-            assert len(admins_a) == 1
-            assert len(admins_b) == 1
-        finally:
-            engine.dispose()
-
-    def test_idempotent_preserves_original_administrator_id(self, db_at_0005):
-        sid = str(uuid.uuid4())
-        created_at = "2026-04-04T04:04:04+00:00"
-
-        engine = create_engine(f"sqlite:///{db_at_0005}")
-        try:
-            _seed_session(engine, session_id=sid, created_at=created_at)
-        finally:
-            engine.dispose()
-
-        cfg = _make_alembic_cfg(db_at_0005)
-        command.upgrade(cfg, "head")
-
-        engine = create_engine(f"sqlite:///{db_at_0005}")
-        try:
-            first_admins = _fetch_administrator_rows(engine, sid)
-            assert len(first_admins) == 1
-            first_id = first_admins[0]["agent_id"]
-        finally:
-            engine.dispose()
-
-        command.upgrade(cfg, "head")
-
-        engine = create_engine(f"sqlite:///{db_at_0005}")
-        try:
-            second_admins = _fetch_administrator_rows(engine, sid)
-            assert len(second_admins) == 1
-            assert second_admins[0]["agent_id"] == first_id
-        finally:
-            engine.dispose()
+    engine = create_engine(f"sqlite:///{db_at_0005}")
+    try:
+        with engine.connect() as conn:
+            row = conn.execute(
+                text("SELECT name, status FROM agents WHERE agent_id = :aid"),
+                {"aid": user_id},
+            ).fetchone()
+        assert row is not None
+        assert row[0] == "survivor"
+        assert row[1] == "active"
+    finally:
+        engine.dispose()
 
 
-class TestMigration0006DowngradeSmoke:
-    """Only tests task-free sessions. The non-empty case is out of scope:
-    ``tasks.context_id`` uses ``ON DELETE RESTRICT``, so downgrading with
-    existing task references would test SQLite FK enforcement, not our migration.
-    """
+def test_migration_0006_upgrade_seed__no_sessions_no_administrators(db_at_0005):
+    cfg = _make_alembic_cfg(db_at_0005)
+    command.upgrade(cfg, "head")
 
-    def test_downgrade_removes_administrator_on_empty_session(self, db_at_0005):
-        sid = str(uuid.uuid4())
-        created_at = "2026-05-05T05:05:05+00:00"
+    engine = create_engine(f"sqlite:///{db_at_0005}")
+    try:
+        with engine.connect() as conn:
+            (count,) = conn.execute(
+                text(
+                    "SELECT COUNT(*) FROM agents "
+                    "WHERE json_extract(agent_card_json, '$.cafleet.kind') "
+                    "      = 'builtin-administrator'"
+                )
+            ).fetchone()
+        assert count == 0
+    finally:
+        engine.dispose()
 
-        engine = create_engine(f"sqlite:///{db_at_0005}")
-        try:
-            _seed_session(engine, session_id=sid, created_at=created_at)
-        finally:
-            engine.dispose()
 
-        cfg = _make_alembic_cfg(db_at_0005)
-        command.upgrade(cfg, "0006")
+def test_migration_0006_upgrade_idempotent__double_upgrade_is_idempotent(db_at_0005):
+    sid_a = str(uuid.uuid4())
+    sid_b = str(uuid.uuid4())
+    created_at = "2026-03-03T03:03:03+00:00"
 
-        engine = create_engine(f"sqlite:///{db_at_0005}")
-        try:
-            admins = _fetch_administrator_rows(engine, sid)
-            assert len(admins) == 1
-        finally:
-            engine.dispose()
+    engine = create_engine(f"sqlite:///{db_at_0005}")
+    try:
+        _seed_session(engine, session_id=sid_a, created_at=created_at)
+        _seed_session(engine, session_id=sid_b, created_at=created_at)
+    finally:
+        engine.dispose()
 
-        command.downgrade(cfg, "0005")
+    cfg = _make_alembic_cfg(db_at_0005)
+    command.upgrade(cfg, "head")
+    command.upgrade(cfg, "head")
 
-        engine = create_engine(f"sqlite:///{db_at_0005}")
-        try:
-            admins = _fetch_administrator_rows(engine, sid)
-            assert len(admins) == 0
+    engine = create_engine(f"sqlite:///{db_at_0005}")
+    try:
+        admins_a = _fetch_administrator_rows(engine, sid_a)
+        admins_b = _fetch_administrator_rows(engine, sid_b)
+        assert len(admins_a) == 1
+        assert len(admins_b) == 1
+    finally:
+        engine.dispose()
 
-            with engine.connect() as conn:
-                (version,) = conn.execute(
-                    text("SELECT version_num FROM alembic_version")
-                ).fetchone()
-            assert version == "0005"
-        finally:
-            engine.dispose()
+
+def test_migration_0006_upgrade_idempotent__idempotent_preserves_original_administrator_id(db_at_0005):
+    sid = str(uuid.uuid4())
+    created_at = "2026-04-04T04:04:04+00:00"
+
+    engine = create_engine(f"sqlite:///{db_at_0005}")
+    try:
+        _seed_session(engine, session_id=sid, created_at=created_at)
+    finally:
+        engine.dispose()
+
+    cfg = _make_alembic_cfg(db_at_0005)
+    command.upgrade(cfg, "head")
+
+    engine = create_engine(f"sqlite:///{db_at_0005}")
+    try:
+        first_admins = _fetch_administrator_rows(engine, sid)
+        assert len(first_admins) == 1
+        first_id = first_admins[0]["agent_id"]
+    finally:
+        engine.dispose()
+
+    command.upgrade(cfg, "head")
+
+    engine = create_engine(f"sqlite:///{db_at_0005}")
+    try:
+        second_admins = _fetch_administrator_rows(engine, sid)
+        assert len(second_admins) == 1
+        assert second_admins[0]["agent_id"] == first_id
+    finally:
+        engine.dispose()
+
+
+# --- migration_0006_downgrade_smoke: only tests task-free sessions. The
+# non-empty case is out of scope: ``tasks.context_id`` uses ``ON DELETE
+# RESTRICT``, so downgrading with existing task references would test SQLite
+# FK enforcement, not our migration. ---
+
+
+def test_migration_0006_downgrade_smoke__downgrade_removes_administrator_on_empty_session(db_at_0005):
+    sid = str(uuid.uuid4())
+    created_at = "2026-05-05T05:05:05+00:00"
+
+    engine = create_engine(f"sqlite:///{db_at_0005}")
+    try:
+        _seed_session(engine, session_id=sid, created_at=created_at)
+    finally:
+        engine.dispose()
+
+    cfg = _make_alembic_cfg(db_at_0005)
+    command.upgrade(cfg, "0006")
+
+    engine = create_engine(f"sqlite:///{db_at_0005}")
+    try:
+        admins = _fetch_administrator_rows(engine, sid)
+        assert len(admins) == 1
+    finally:
+        engine.dispose()
+
+    command.downgrade(cfg, "0005")
+
+    engine = create_engine(f"sqlite:///{db_at_0005}")
+    try:
+        admins = _fetch_administrator_rows(engine, sid)
+        assert len(admins) == 0
+
+        with engine.connect() as conn:
+            (version,) = conn.execute(
+                text("SELECT version_num FROM alembic_version")
+            ).fetchone()
+        assert version == "0005"
+    finally:
+        engine.dispose()

--- a/cafleet/tests/test_alembic_0008_upgrade.py
+++ b/cafleet/tests/test_alembic_0008_upgrade.py
@@ -140,7 +140,9 @@ def test_migration_0008_upgrade__renames_root_director_name_and_card(db_at_0007)
         engine.dispose()
 
 
-def test_migration_0008_upgrade__leaves_user_agents_named_director_untouched(db_at_0007):
+def test_migration_0008_upgrade__leaves_user_agents_named_director_untouched(
+    db_at_0007,
+):
     sid = str(uuid.uuid4())
     director_id = str(uuid.uuid4())
     user_id = str(uuid.uuid4())

--- a/cafleet/tests/test_alembic_0008_upgrade.py
+++ b/cafleet/tests/test_alembic_0008_upgrade.py
@@ -111,163 +111,162 @@ def db_at_0007(tmp_path):
     return db_path
 
 
-class TestMigration0008Upgrade:
-    def test_renames_root_director_name_and_card(self, db_at_0007):
-        sid = str(uuid.uuid4())
-        director_id = str(uuid.uuid4())
-        created_at = "2026-04-01T00:00:00+00:00"
+def test_migration_0008_upgrade__renames_root_director_name_and_card(db_at_0007):
+    sid = str(uuid.uuid4())
+    director_id = str(uuid.uuid4())
+    created_at = "2026-04-01T00:00:00+00:00"
 
-        engine = create_engine(f"sqlite:///{db_at_0007}")
-        try:
-            _insert_session_with_director(
-                engine,
-                session_id=sid,
-                created_at=created_at,
-                director_agent_id=director_id,
-            )
-        finally:
-            engine.dispose()
+    engine = create_engine(f"sqlite:///{db_at_0007}")
+    try:
+        _insert_session_with_director(
+            engine,
+            session_id=sid,
+            created_at=created_at,
+            director_agent_id=director_id,
+        )
+    finally:
+        engine.dispose()
 
-        cfg = _make_alembic_cfg(db_at_0007)
-        command.upgrade(cfg, "head")
+    cfg = _make_alembic_cfg(db_at_0007)
+    command.upgrade(cfg, "head")
 
-        engine = create_engine(f"sqlite:///{db_at_0007}")
-        try:
-            name, card_json = _fetch_agent(engine, director_id)
-            assert name == "Director"
-            card = json.loads(card_json)
-            assert card["name"] == "Director"
-        finally:
-            engine.dispose()
-
-    def test_leaves_user_agents_named_director_untouched(self, db_at_0007):
-        sid = str(uuid.uuid4())
-        director_id = str(uuid.uuid4())
-        user_id = str(uuid.uuid4())
-        created_at = "2026-04-02T00:00:00+00:00"
-
-        engine = create_engine(f"sqlite:///{db_at_0007}")
-        try:
-            _insert_session_with_director(
-                engine,
-                session_id=sid,
-                created_at=created_at,
-                director_agent_id=director_id,
-            )
-            _insert_user_agent(
-                engine,
-                agent_id=user_id,
-                session_id=sid,
-                name="director-1",
-                registered_at=created_at,
-            )
-        finally:
-            engine.dispose()
-
-        cfg = _make_alembic_cfg(db_at_0007)
-        command.upgrade(cfg, "head")
-
-        engine = create_engine(f"sqlite:///{db_at_0007}")
-        try:
-            user_name, user_card_json = _fetch_agent(engine, user_id)
-            assert user_name == "director-1"
-            user_card = json.loads(user_card_json)
-            assert user_card["name"] == "director-1"
-        finally:
-            engine.dispose()
-
-    def test_renames_director_across_multiple_sessions(self, db_at_0007):
-        sid_a = str(uuid.uuid4())
-        sid_b = str(uuid.uuid4())
-        dir_a = str(uuid.uuid4())
-        dir_b = str(uuid.uuid4())
-        created_at = "2026-04-03T00:00:00+00:00"
-
-        engine = create_engine(f"sqlite:///{db_at_0007}")
-        try:
-            _insert_session_with_director(
-                engine,
-                session_id=sid_a,
-                created_at=created_at,
-                director_agent_id=dir_a,
-            )
-            _insert_session_with_director(
-                engine,
-                session_id=sid_b,
-                created_at=created_at,
-                director_agent_id=dir_b,
-            )
-        finally:
-            engine.dispose()
-
-        cfg = _make_alembic_cfg(db_at_0007)
-        command.upgrade(cfg, "head")
-
-        engine = create_engine(f"sqlite:///{db_at_0007}")
-        try:
-            for aid in (dir_a, dir_b):
-                name, card_json = _fetch_agent(engine, aid)
-                assert name == "Director"
-                assert json.loads(card_json)["name"] == "Director"
-        finally:
-            engine.dispose()
+    engine = create_engine(f"sqlite:///{db_at_0007}")
+    try:
+        name, card_json = _fetch_agent(engine, director_id)
+        assert name == "Director"
+        card = json.loads(card_json)
+        assert card["name"] == "Director"
+    finally:
+        engine.dispose()
 
 
-class TestMigration0008Idempotent:
-    def test_double_upgrade_is_noop(self, db_at_0007):
-        sid = str(uuid.uuid4())
-        director_id = str(uuid.uuid4())
-        created_at = "2026-04-04T00:00:00+00:00"
+def test_migration_0008_upgrade__leaves_user_agents_named_director_untouched(db_at_0007):
+    sid = str(uuid.uuid4())
+    director_id = str(uuid.uuid4())
+    user_id = str(uuid.uuid4())
+    created_at = "2026-04-02T00:00:00+00:00"
 
-        engine = create_engine(f"sqlite:///{db_at_0007}")
-        try:
-            _insert_session_with_director(
-                engine,
-                session_id=sid,
-                created_at=created_at,
-                director_agent_id=director_id,
-            )
-        finally:
-            engine.dispose()
+    engine = create_engine(f"sqlite:///{db_at_0007}")
+    try:
+        _insert_session_with_director(
+            engine,
+            session_id=sid,
+            created_at=created_at,
+            director_agent_id=director_id,
+        )
+        _insert_user_agent(
+            engine,
+            agent_id=user_id,
+            session_id=sid,
+            name="director-1",
+            registered_at=created_at,
+        )
+    finally:
+        engine.dispose()
 
-        cfg = _make_alembic_cfg(db_at_0007)
-        command.upgrade(cfg, "head")
-        command.upgrade(cfg, "head")
+    cfg = _make_alembic_cfg(db_at_0007)
+    command.upgrade(cfg, "head")
 
-        engine = create_engine(f"sqlite:///{db_at_0007}")
-        try:
-            name, card_json = _fetch_agent(engine, director_id)
+    engine = create_engine(f"sqlite:///{db_at_0007}")
+    try:
+        user_name, user_card_json = _fetch_agent(engine, user_id)
+        assert user_name == "director-1"
+        user_card = json.loads(user_card_json)
+        assert user_card["name"] == "director-1"
+    finally:
+        engine.dispose()
+
+
+def test_migration_0008_upgrade__renames_director_across_multiple_sessions(db_at_0007):
+    sid_a = str(uuid.uuid4())
+    sid_b = str(uuid.uuid4())
+    dir_a = str(uuid.uuid4())
+    dir_b = str(uuid.uuid4())
+    created_at = "2026-04-03T00:00:00+00:00"
+
+    engine = create_engine(f"sqlite:///{db_at_0007}")
+    try:
+        _insert_session_with_director(
+            engine,
+            session_id=sid_a,
+            created_at=created_at,
+            director_agent_id=dir_a,
+        )
+        _insert_session_with_director(
+            engine,
+            session_id=sid_b,
+            created_at=created_at,
+            director_agent_id=dir_b,
+        )
+    finally:
+        engine.dispose()
+
+    cfg = _make_alembic_cfg(db_at_0007)
+    command.upgrade(cfg, "head")
+
+    engine = create_engine(f"sqlite:///{db_at_0007}")
+    try:
+        for aid in (dir_a, dir_b):
+            name, card_json = _fetch_agent(engine, aid)
             assert name == "Director"
             assert json.loads(card_json)["name"] == "Director"
-        finally:
-            engine.dispose()
+    finally:
+        engine.dispose()
 
 
-class TestMigration0008Downgrade:
-    def test_downgrade_restores_lowercase_name(self, db_at_0007):
-        sid = str(uuid.uuid4())
-        director_id = str(uuid.uuid4())
-        created_at = "2026-04-05T00:00:00+00:00"
+def test_migration_0008_idempotent__double_upgrade_is_noop(db_at_0007):
+    sid = str(uuid.uuid4())
+    director_id = str(uuid.uuid4())
+    created_at = "2026-04-04T00:00:00+00:00"
 
-        engine = create_engine(f"sqlite:///{db_at_0007}")
-        try:
-            _insert_session_with_director(
-                engine,
-                session_id=sid,
-                created_at=created_at,
-                director_agent_id=director_id,
-            )
-        finally:
-            engine.dispose()
+    engine = create_engine(f"sqlite:///{db_at_0007}")
+    try:
+        _insert_session_with_director(
+            engine,
+            session_id=sid,
+            created_at=created_at,
+            director_agent_id=director_id,
+        )
+    finally:
+        engine.dispose()
 
-        cfg = _make_alembic_cfg(db_at_0007)
-        command.upgrade(cfg, "0008")
-        command.downgrade(cfg, "0007")
+    cfg = _make_alembic_cfg(db_at_0007)
+    command.upgrade(cfg, "head")
+    command.upgrade(cfg, "head")
 
-        engine = create_engine(f"sqlite:///{db_at_0007}")
-        try:
-            name, card_json = _fetch_agent(engine, director_id)
-            assert name == "director"
-            assert json.loads(card_json)["name"] == "director"
-        finally:
-            engine.dispose()
+    engine = create_engine(f"sqlite:///{db_at_0007}")
+    try:
+        name, card_json = _fetch_agent(engine, director_id)
+        assert name == "Director"
+        assert json.loads(card_json)["name"] == "Director"
+    finally:
+        engine.dispose()
+
+
+def test_migration_0008_downgrade__downgrade_restores_lowercase_name(db_at_0007):
+    sid = str(uuid.uuid4())
+    director_id = str(uuid.uuid4())
+    created_at = "2026-04-05T00:00:00+00:00"
+
+    engine = create_engine(f"sqlite:///{db_at_0007}")
+    try:
+        _insert_session_with_director(
+            engine,
+            session_id=sid,
+            created_at=created_at,
+            director_agent_id=director_id,
+        )
+    finally:
+        engine.dispose()
+
+    cfg = _make_alembic_cfg(db_at_0007)
+    command.upgrade(cfg, "0008")
+    command.downgrade(cfg, "0007")
+
+    engine = create_engine(f"sqlite:///{db_at_0007}")
+    try:
+        name, card_json = _fetch_agent(engine, director_id)
+        assert name == "director"
+        assert json.loads(card_json)["name"] == "director"
+    finally:
+        engine.dispose()

--- a/cafleet/tests/test_broker_administrator.py
+++ b/cafleet/tests/test_broker_administrator.py
@@ -23,92 +23,102 @@ def _create_session_with_ctx():
     return broker.create_session(director_context=_FAKE_DIRECTOR_CTX)
 
 
-class TestAdministratorKindConstant:
-    def test_constant_exists_and_is_importable(self):
-        assert ADMINISTRATOR_KIND is not None
-
-    def test_constant_value_is_builtin_administrator(self):
-        assert ADMINISTRATOR_KIND == "builtin-administrator"
-
-    def test_constant_is_string(self):
-        assert isinstance(ADMINISTRATOR_KIND, str)
+def test_administrator_kind_constant__constant_exists_and_is_importable():
+    assert ADMINISTRATOR_KIND is not None
 
 
-class TestIsAdministrator:
-    def test_returns_true_for_canonical_administrator_card(self):
-        payload = {
-            "name": "Administrator",
-            "description": "Built-in administrator agent for session 3f9a1b2c",
-            "skills": [],
-            "cafleet": {"kind": ADMINISTRATOR_KIND},
-        }
-        assert _is_administrator(json.dumps(payload)) is True
-
-    def test_returns_true_for_hand_built_administrator_card(self):
-        payload = {
-            "name": "Administrator",
-            "description": "anything",
-            "skills": [],
-            "cafleet": {"kind": "builtin-administrator"},
-        }
-        assert _is_administrator(json.dumps(payload)) is True
-
-    def test_returns_false_for_normal_user_card(self):
-        payload = {
-            "name": "Claude-B",
-            "description": "Reviewer",
-            "skills": [],
-        }
-        assert _is_administrator(json.dumps(payload)) is False
-
-    def test_returns_false_when_cafleet_key_missing(self):
-        payload = {"name": "x", "description": "y", "skills": []}
-        assert _is_administrator(json.dumps(payload)) is False
-
-    def test_returns_false_when_cafleet_kind_missing(self):
-        payload = {
-            "name": "x",
-            "description": "y",
-            "skills": [],
-            "cafleet": {"other": "value"},
-        }
-        assert _is_administrator(json.dumps(payload)) is False
-
-    def test_returns_false_when_cafleet_kind_is_different_value(self):
-        payload = {
-            "name": "x",
-            "description": "y",
-            "skills": [],
-            "cafleet": {"kind": "user"},
-        }
-        assert _is_administrator(json.dumps(payload)) is False
-
-    def test_returns_false_for_malformed_json(self):
-        assert _is_administrator("{not valid json") is False
-
-    def test_returns_false_for_empty_string(self):
-        assert _is_administrator("") is False
-
-    def test_returns_false_for_none(self):
-        assert _is_administrator(None) is False
+def test_administrator_kind_constant__constant_value_is_builtin_administrator():
+    assert ADMINISTRATOR_KIND == "builtin-administrator"
 
 
-class TestAdministratorProtectedError:
-    def test_class_is_importable(self):
-        assert AdministratorProtectedError is not None
+def test_administrator_kind_constant__constant_is_string():
+    assert isinstance(ADMINISTRATOR_KIND, str)
 
-    def test_is_subclass_of_exception(self):
-        assert issubclass(AdministratorProtectedError, Exception)
 
-    def test_can_be_raised_and_caught(self):
-        with pytest.raises(AdministratorProtectedError):
-            raise AdministratorProtectedError("Administrator cannot be deregistered")
+def test_is_administrator__returns_true_for_canonical_administrator_card():
+    payload = {
+        "name": "Administrator",
+        "description": "Built-in administrator agent for session 3f9a1b2c",
+        "skills": [],
+        "cafleet": {"kind": ADMINISTRATOR_KIND},
+    }
+    assert _is_administrator(json.dumps(payload)) is True
 
-    def test_preserves_message(self):
-        msg = "Administrator cannot be a director"
-        with pytest.raises(AdministratorProtectedError) as exc_info:
-            raise AdministratorProtectedError(msg)
-        assert msg in str(exc_info.value)
+
+def test_is_administrator__returns_true_for_hand_built_administrator_card():
+    payload = {
+        "name": "Administrator",
+        "description": "anything",
+        "skills": [],
+        "cafleet": {"kind": "builtin-administrator"},
+    }
+    assert _is_administrator(json.dumps(payload)) is True
+
+
+def test_is_administrator__returns_false_for_normal_user_card():
+    payload = {
+        "name": "Claude-B",
+        "description": "Reviewer",
+        "skills": [],
+    }
+    assert _is_administrator(json.dumps(payload)) is False
+
+
+def test_is_administrator__returns_false_when_cafleet_key_missing():
+    payload = {"name": "x", "description": "y", "skills": []}
+    assert _is_administrator(json.dumps(payload)) is False
+
+
+def test_is_administrator__returns_false_when_cafleet_kind_missing():
+    payload = {
+        "name": "x",
+        "description": "y",
+        "skills": [],
+        "cafleet": {"other": "value"},
+    }
+    assert _is_administrator(json.dumps(payload)) is False
+
+
+def test_is_administrator__returns_false_when_cafleet_kind_is_different_value():
+    payload = {
+        "name": "x",
+        "description": "y",
+        "skills": [],
+        "cafleet": {"kind": "user"},
+    }
+    assert _is_administrator(json.dumps(payload)) is False
+
+
+def test_is_administrator__returns_false_for_malformed_json():
+    assert _is_administrator("{not valid json") is False
+
+
+def test_is_administrator__returns_false_for_empty_string():
+    assert _is_administrator("") is False
+
+
+def test_is_administrator__returns_false_for_none():
+    assert _is_administrator(None) is False
+
+
+def test_administrator_protected_error__class_is_importable():
+    assert AdministratorProtectedError is not None
+
+
+def test_administrator_protected_error__is_subclass_of_exception():
+    assert issubclass(AdministratorProtectedError, Exception)
+
+
+def test_administrator_protected_error__can_be_raised_and_caught():
+    with pytest.raises(AdministratorProtectedError):
+        raise AdministratorProtectedError("Administrator cannot be deregistered")
+
+
+def test_administrator_protected_error__preserves_message():
+    msg = "Administrator cannot be a director"
+    with pytest.raises(AdministratorProtectedError) as exc_info:
+        raise AdministratorProtectedError(msg)
+    assert msg in str(exc_info.value)
 
 
 @pytest.fixture
@@ -128,112 +138,114 @@ def broker_db(sync_sessionmaker, _patch_broker):
     return sync_sessionmaker
 
 
-class TestDeregisterAdministratorGuard:
-    def test_raises_administrator_protected_error(self, broker_db):
-        session = _create_session_with_ctx()
-        admin_id = session["administrator_agent_id"]
+def test_deregister_administrator_guard__raises_administrator_protected_error(broker_db):
+    session = _create_session_with_ctx()
+    admin_id = session["administrator_agent_id"]
 
-        with pytest.raises(AdministratorProtectedError) as exc_info:
-            broker.deregister_agent(admin_id)
+    with pytest.raises(AdministratorProtectedError) as exc_info:
+        broker.deregister_agent(admin_id)
 
-        assert "Administrator cannot be deregistered" in str(exc_info.value)
-
-    def test_admin_row_still_active_after_failed_deregister(self, broker_db):
-        session = _create_session_with_ctx()
-        admin_id = session["administrator_agent_id"]
-
-        with pytest.raises(AdministratorProtectedError):
-            broker.deregister_agent(admin_id)
-
-        with broker_db() as s:
-            row = s.query(Agent).filter(Agent.agent_id == admin_id).one()
-        assert row.status == "active"
-        assert row.deregistered_at is None
-
-    def test_deregistering_user_agent_still_works(self, broker_db):
-        session = _create_session_with_ctx()
-        sid = session["session_id"]
-        user = broker.register_agent(
-            session_id=sid, name="user", description="A test user"
-        )
-
-        result = broker.deregister_agent(user["agent_id"])
-        assert result is True
-
-        names = {a["name"] for a in broker.list_agents(sid)}
-        assert names == {"Director", "Administrator"}
+    assert "Administrator cannot be deregistered" in str(exc_info.value)
 
 
-class TestRegisterAgentPlacementAdministratorGuard:
-    def test_raises_when_director_is_administrator(self, broker_db):
-        session = _create_session_with_ctx()
-        sid = session["session_id"]
-        admin_id = session["administrator_agent_id"]
+def test_deregister_administrator_guard__admin_row_still_active_after_failed_deregister(broker_db):
+    session = _create_session_with_ctx()
+    admin_id = session["administrator_agent_id"]
 
-        placement = {
-            "director_agent_id": admin_id,
-            "tmux_session": "main",
-            "tmux_window_id": "@1",
-            "tmux_pane_id": None,
-            "coding_agent": "claude",
-        }
-        with pytest.raises(AdministratorProtectedError) as exc_info:
-            broker.register_agent(
-                session_id=sid,
-                name="member",
-                description="member placed under Admin",
-                placement=placement,
-            )
+    with pytest.raises(AdministratorProtectedError):
+        broker.deregister_agent(admin_id)
 
-        assert "Administrator cannot be a director" in str(exc_info.value)
+    with broker_db() as s:
+        row = s.query(Agent).filter(Agent.agent_id == admin_id).one()
+    assert row.status == "active"
+    assert row.deregistered_at is None
 
-    def test_admin_director_rejection_does_not_create_member(self, broker_db):
-        session = _create_session_with_ctx()
-        sid = session["session_id"]
-        admin_id = session["administrator_agent_id"]
 
-        placement = {
-            "director_agent_id": admin_id,
-            "tmux_session": "main",
-            "tmux_window_id": "@1",
-            "tmux_pane_id": None,
-            "coding_agent": "claude",
-        }
-        with pytest.raises(AdministratorProtectedError):
-            broker.register_agent(
-                session_id=sid,
-                name="rejected-member",
-                description="should not exist",
-                placement=placement,
-            )
+def test_deregister_administrator_guard__deregistering_user_agent_still_works(broker_db):
+    session = _create_session_with_ctx()
+    sid = session["session_id"]
+    user = broker.register_agent(
+        session_id=sid, name="user", description="A test user"
+    )
 
-        names = {a["name"] for a in broker.list_agents(sid)}
-        assert "rejected-member" not in names
-        assert names == {"Director", "Administrator"}
+    result = broker.deregister_agent(user["agent_id"])
+    assert result is True
 
-    def test_placement_with_user_agent_director_still_works(self, broker_db):
-        session = _create_session_with_ctx()
-        sid = session["session_id"]
+    names = {a["name"] for a in broker.list_agents(sid)}
+    assert names == {"Director", "Administrator"}
 
-        director = broker.register_agent(
-            session_id=sid, name="director", description="a user director"
-        )
 
-        placement = {
-            "director_agent_id": director["agent_id"],
-            "tmux_session": "main",
-            "tmux_window_id": "@1",
-            "tmux_pane_id": None,
-            "coding_agent": "claude",
-        }
-        member = broker.register_agent(
+def test_register_agent_placement_administrator_guard__raises_when_director_is_administrator(broker_db):
+    session = _create_session_with_ctx()
+    sid = session["session_id"]
+    admin_id = session["administrator_agent_id"]
+
+    placement = {
+        "director_agent_id": admin_id,
+        "tmux_session": "main",
+        "tmux_window_id": "@1",
+        "tmux_pane_id": None,
+        "coding_agent": "claude",
+    }
+    with pytest.raises(AdministratorProtectedError) as exc_info:
+        broker.register_agent(
             session_id=sid,
             name="member",
-            description="member of a user director",
+            description="member placed under Admin",
             placement=placement,
         )
 
-        fetched = broker.get_agent(member["agent_id"], sid)
-        assert fetched is not None
-        assert fetched["placement"] is not None
-        assert fetched["placement"]["director_agent_id"] == director["agent_id"]
+    assert "Administrator cannot be a director" in str(exc_info.value)
+
+
+def test_register_agent_placement_administrator_guard__admin_director_rejection_does_not_create_member(broker_db):
+    session = _create_session_with_ctx()
+    sid = session["session_id"]
+    admin_id = session["administrator_agent_id"]
+
+    placement = {
+        "director_agent_id": admin_id,
+        "tmux_session": "main",
+        "tmux_window_id": "@1",
+        "tmux_pane_id": None,
+        "coding_agent": "claude",
+    }
+    with pytest.raises(AdministratorProtectedError):
+        broker.register_agent(
+            session_id=sid,
+            name="rejected-member",
+            description="should not exist",
+            placement=placement,
+        )
+
+    names = {a["name"] for a in broker.list_agents(sid)}
+    assert "rejected-member" not in names
+    assert names == {"Director", "Administrator"}
+
+
+def test_register_agent_placement_administrator_guard__placement_with_user_agent_director_still_works(broker_db):
+    session = _create_session_with_ctx()
+    sid = session["session_id"]
+
+    director = broker.register_agent(
+        session_id=sid, name="director", description="a user director"
+    )
+
+    placement = {
+        "director_agent_id": director["agent_id"],
+        "tmux_session": "main",
+        "tmux_window_id": "@1",
+        "tmux_pane_id": None,
+        "coding_agent": "claude",
+    }
+    member = broker.register_agent(
+        session_id=sid,
+        name="member",
+        description="member of a user director",
+        placement=placement,
+    )
+
+    fetched = broker.get_agent(member["agent_id"], sid)
+    assert fetched is not None
+    assert fetched["placement"] is not None
+    assert fetched["placement"]["director_agent_id"] == director["agent_id"]

--- a/cafleet/tests/test_broker_administrator.py
+++ b/cafleet/tests/test_broker_administrator.py
@@ -138,7 +138,9 @@ def broker_db(sync_sessionmaker, _patch_broker):
     return sync_sessionmaker
 
 
-def test_deregister_administrator_guard__raises_administrator_protected_error(broker_db):
+def test_deregister_administrator_guard__raises_administrator_protected_error(
+    broker_db,
+):
     session = _create_session_with_ctx()
     admin_id = session["administrator_agent_id"]
 
@@ -148,7 +150,9 @@ def test_deregister_administrator_guard__raises_administrator_protected_error(br
     assert "Administrator cannot be deregistered" in str(exc_info.value)
 
 
-def test_deregister_administrator_guard__admin_row_still_active_after_failed_deregister(broker_db):
+def test_deregister_administrator_guard__admin_row_still_active_after_failed_deregister(
+    broker_db,
+):
     session = _create_session_with_ctx()
     admin_id = session["administrator_agent_id"]
 
@@ -161,12 +165,12 @@ def test_deregister_administrator_guard__admin_row_still_active_after_failed_der
     assert row.deregistered_at is None
 
 
-def test_deregister_administrator_guard__deregistering_user_agent_still_works(broker_db):
+def test_deregister_administrator_guard__deregistering_user_agent_still_works(
+    broker_db,
+):
     session = _create_session_with_ctx()
     sid = session["session_id"]
-    user = broker.register_agent(
-        session_id=sid, name="user", description="A test user"
-    )
+    user = broker.register_agent(session_id=sid, name="user", description="A test user")
 
     result = broker.deregister_agent(user["agent_id"])
     assert result is True
@@ -175,7 +179,9 @@ def test_deregister_administrator_guard__deregistering_user_agent_still_works(br
     assert names == {"Director", "Administrator"}
 
 
-def test_register_agent_placement_administrator_guard__raises_when_director_is_administrator(broker_db):
+def test_register_agent_placement_administrator_guard__raises_when_director_is_administrator(
+    broker_db,
+):
     session = _create_session_with_ctx()
     sid = session["session_id"]
     admin_id = session["administrator_agent_id"]
@@ -198,7 +204,9 @@ def test_register_agent_placement_administrator_guard__raises_when_director_is_a
     assert "Administrator cannot be a director" in str(exc_info.value)
 
 
-def test_register_agent_placement_administrator_guard__admin_director_rejection_does_not_create_member(broker_db):
+def test_register_agent_placement_administrator_guard__admin_director_rejection_does_not_create_member(
+    broker_db,
+):
     session = _create_session_with_ctx()
     sid = session["session_id"]
     admin_id = session["administrator_agent_id"]
@@ -223,7 +231,9 @@ def test_register_agent_placement_administrator_guard__admin_director_rejection_
     assert names == {"Director", "Administrator"}
 
 
-def test_register_agent_placement_administrator_guard__placement_with_user_agent_director_still_works(broker_db):
+def test_register_agent_placement_administrator_guard__placement_with_user_agent_director_still_works(
+    broker_db,
+):
     session = _create_session_with_ctx()
     sid = session["session_id"]
 

--- a/cafleet/tests/test_broker_messaging.py
+++ b/cafleet/tests/test_broker_messaging.py
@@ -65,199 +65,221 @@ def _setup_three_agents() -> tuple[str, str, str, str]:
     return sid, a["agent_id"], b["agent_id"], c["agent_id"]
 
 
-class TestSendMessage:
-    """broker.send_message(session_id, agent_id, to, text) → {"task": <dict>}."""
-
-    def test_returns_dict_with_task_key(self):
-        sid, sender, recipient = _setup_two_agents()
-        result = broker.send_message(sid, sender, recipient, "Hello")
-        assert isinstance(result, dict)
-        assert "task" in result
-
-    def test_task_has_camel_case_keys(self):
-        sid, sender, recipient = _setup_two_agents()
-        result = broker.send_message(sid, sender, recipient, "Hello")
-        task = result["task"]
-        assert "id" in task
-        assert "contextId" in task
-        assert "status" in task
-        assert "artifacts" in task
-        assert "metadata" in task
-
-    def test_task_id_is_valid_uuid(self):
-        sid, sender, recipient = _setup_two_agents()
-        result = broker.send_message(sid, sender, recipient, "Hello")
-        uuid.UUID(result["task"]["id"])
-
-    def test_context_id_is_recipient(self):
-        sid, sender, recipient = _setup_two_agents()
-        result = broker.send_message(sid, sender, recipient, "Hello")
-        assert result["task"]["contextId"] == recipient
-
-    def test_status_state_is_input_required(self):
-        sid, sender, recipient = _setup_two_agents()
-        result = broker.send_message(sid, sender, recipient, "Hello")
-        assert result["task"]["status"]["state"] == "input_required"
-
-    def test_status_has_timestamp(self):
-        sid, sender, recipient = _setup_two_agents()
-        result = broker.send_message(sid, sender, recipient, "Hello")
-        ts = result["task"]["status"]["timestamp"]
-        assert isinstance(ts, str)
-        assert "T" in ts
-
-    def test_metadata_from_agent_id(self):
-        sid, sender, recipient = _setup_two_agents()
-        result = broker.send_message(sid, sender, recipient, "Hello")
-        assert result["task"]["metadata"]["fromAgentId"] == sender
-
-    def test_metadata_to_agent_id(self):
-        sid, sender, recipient = _setup_two_agents()
-        result = broker.send_message(sid, sender, recipient, "Hello")
-        assert result["task"]["metadata"]["toAgentId"] == recipient
-
-    def test_metadata_type_is_unicast(self):
-        sid, sender, recipient = _setup_two_agents()
-        result = broker.send_message(sid, sender, recipient, "Hello")
-        assert result["task"]["metadata"]["type"] == "unicast"
-
-    def test_artifact_contains_message_text(self):
-        sid, sender, recipient = _setup_two_agents()
-        result = broker.send_message(sid, sender, recipient, "Did the API change?")
-        texts = [
-            part["text"]
-            for artifact in result["task"]["artifacts"]
-            for part in artifact["parts"]
-            if "text" in part
-        ]
-        assert "Did the API change?" in texts
-
-    def test_validates_destination_is_valid_uuid(self):
-        sid, sender, _ = _setup_two_agents()
-        with pytest.raises(ValueError, match="Invalid destination format"):
-            broker.send_message(sid, sender, "not-a-uuid", "Hello")
-
-    def test_validates_destination_agent_exists(self):
-        sid, sender, _ = _setup_two_agents()
-        fake_agent = str(uuid.uuid4())
-        with pytest.raises(ValueError, match="Destination agent not found"):
-            broker.send_message(sid, sender, fake_agent, "Hello")
-
-    def test_validates_destination_agent_is_active(self):
-        sid, sender, recipient = _setup_two_agents()
-        broker.deregister_agent(recipient)
-        with pytest.raises(ValueError, match="Destination agent not found"):
-            broker.send_message(sid, sender, recipient, "Hello")
-
-    def test_validates_destination_in_same_session(self):
-        session_a = _create_session()
-        session_b = _create_session()
-        sender = _register_agent(session_a["session_id"], name="sender")
-        recipient = _register_agent(session_b["session_id"], name="recipient")
-        with pytest.raises(ValueError, match="Destination agent not in session"):
-            broker.send_message(
-                session_a["session_id"],
-                sender["agent_id"],
-                recipient["agent_id"],
-                "cross-session",
-            )
-
-    def test_task_persisted_to_db(self):
-        sid, sender, recipient = _setup_two_agents()
-        broker.send_message(sid, sender, recipient, "persisted?")
-
-        tasks = broker.poll_tasks(recipient)
-        assert len(tasks) == 1
-        texts = [
-            p["text"]
-            for t in tasks
-            for a in t["artifacts"]
-            for p in a["parts"]
-            if "text" in p
-        ]
-        assert "persisted?" in texts
+# --- send_message: broker.send_message(session_id, agent_id, to, text) → {"task": <dict>} ---
 
 
-class TestBroadcastMessage:
-    """broker.broadcast_message(session_id, agent_id, text) → [{"task": <summary>}]."""
+def test_send_message__returns_dict_with_task_key():
+    sid, sender, recipient = _setup_two_agents()
+    result = broker.send_message(sid, sender, recipient, "Hello")
+    assert isinstance(result, dict)
+    assert "task" in result
 
-    def test_returns_list_with_summary(self):
-        sid, sender, _, _ = _setup_three_agents()
-        result = broker.broadcast_message(sid, sender, "Attention all")
-        assert isinstance(result, list)
-        assert len(result) == 1
-        assert "task" in result[0]
 
-    def test_summary_type_is_broadcast_summary(self):
-        sid, sender, _, _ = _setup_three_agents()
-        result = broker.broadcast_message(sid, sender, "Attention all")
-        summary = result[0]["task"]
-        assert summary["metadata"]["type"] == "broadcast_summary"
+def test_send_message__task_has_camel_case_keys():
+    sid, sender, recipient = _setup_two_agents()
+    result = broker.send_message(sid, sender, recipient, "Hello")
+    task = result["task"]
+    assert "id" in task
+    assert "contextId" in task
+    assert "status" in task
+    assert "artifacts" in task
+    assert "metadata" in task
 
-    def test_summary_context_id_is_sender(self):
-        sid, sender, _, _ = _setup_three_agents()
-        result = broker.broadcast_message(sid, sender, "Attention all")
-        summary = result[0]["task"]
-        assert summary["contextId"] == sender
 
-    def test_creates_delivery_tasks_for_each_recipient(self):
-        sid, sender, b_id, c_id = _setup_three_agents()
-        broker.broadcast_message(sid, sender, "Hello everyone")
+def test_send_message__task_id_is_valid_uuid():
+    sid, sender, recipient = _setup_two_agents()
+    result = broker.send_message(sid, sender, recipient, "Hello")
+    uuid.UUID(result["task"]["id"])
 
-        b_tasks = broker.poll_tasks(b_id)
-        c_tasks = broker.poll_tasks(c_id)
-        assert len(b_tasks) == 1
-        assert len(c_tasks) == 1
 
-    def test_delivery_tasks_have_origin_task_id(self):
-        sid, sender, b_id, _ = _setup_three_agents()
-        result = broker.broadcast_message(sid, sender, "Hello")
-        summary_id = result[0]["task"]["id"]
+def test_send_message__context_id_is_recipient():
+    sid, sender, recipient = _setup_two_agents()
+    result = broker.send_message(sid, sender, recipient, "Hello")
+    assert result["task"]["contextId"] == recipient
 
-        b_tasks = broker.poll_tasks(b_id)
-        assert len(b_tasks) == 1
-        assert b_tasks[0]["metadata"]["originTaskId"] == summary_id
 
-    def test_delivery_tasks_type_is_unicast(self):
-        sid, sender, b_id, _ = _setup_three_agents()
-        broker.broadcast_message(sid, sender, "Hello")
+def test_send_message__status_state_is_input_required():
+    sid, sender, recipient = _setup_two_agents()
+    result = broker.send_message(sid, sender, recipient, "Hello")
+    assert result["task"]["status"]["state"] == "input_required"
 
-        b_tasks = broker.poll_tasks(b_id)
-        assert len(b_tasks) == 1
-        assert b_tasks[0]["metadata"]["type"] == "unicast"
 
-    def test_excludes_sender_from_recipients(self):
-        sid, sender, _, _ = _setup_three_agents()
-        broker.broadcast_message(sid, sender, "Hello")
+def test_send_message__status_has_timestamp():
+    sid, sender, recipient = _setup_two_agents()
+    result = broker.send_message(sid, sender, recipient, "Hello")
+    ts = result["task"]["status"]["timestamp"]
+    assert isinstance(ts, str)
+    assert "T" in ts
 
-        sender_tasks = broker.poll_tasks(sender)
-        delivery_tasks = [t for t in sender_tasks if t["metadata"]["type"] == "unicast"]
-        assert len(delivery_tasks) == 0
 
-    def test_broadcast_with_no_other_agents(self):
-        session = _create_session()
-        sid = session["session_id"]
-        lone_agent = _register_agent(sid, name="lonely")
+def test_send_message__metadata_from_agent_id():
+    sid, sender, recipient = _setup_two_agents()
+    result = broker.send_message(sid, sender, recipient, "Hello")
+    assert result["task"]["metadata"]["fromAgentId"] == sender
 
-        result = broker.broadcast_message(sid, lone_agent["agent_id"], "Anyone?")
-        assert isinstance(result, list)
-        assert len(result) == 1
-        summary = result[0]["task"]
-        assert summary["metadata"]["type"] == "broadcast_summary"
 
-    def test_delivery_task_contains_message_text(self):
-        sid, sender, b_id, _ = _setup_three_agents()
-        broker.broadcast_message(sid, sender, "Important update")
+def test_send_message__metadata_to_agent_id():
+    sid, sender, recipient = _setup_two_agents()
+    result = broker.send_message(sid, sender, recipient, "Hello")
+    assert result["task"]["metadata"]["toAgentId"] == recipient
 
-        b_tasks = broker.poll_tasks(b_id)
-        texts = [
-            p["text"]
-            for t in b_tasks
-            for a in t["artifacts"]
-            for p in a["parts"]
-            if "text" in p
-        ]
-        assert "Important update" in texts
+
+def test_send_message__metadata_type_is_unicast():
+    sid, sender, recipient = _setup_two_agents()
+    result = broker.send_message(sid, sender, recipient, "Hello")
+    assert result["task"]["metadata"]["type"] == "unicast"
+
+
+def test_send_message__artifact_contains_message_text():
+    sid, sender, recipient = _setup_two_agents()
+    result = broker.send_message(sid, sender, recipient, "Did the API change?")
+    texts = [
+        part["text"]
+        for artifact in result["task"]["artifacts"]
+        for part in artifact["parts"]
+        if "text" in part
+    ]
+    assert "Did the API change?" in texts
+
+
+def test_send_message__validates_destination_is_valid_uuid():
+    sid, sender, _ = _setup_two_agents()
+    with pytest.raises(ValueError, match="Invalid destination format"):
+        broker.send_message(sid, sender, "not-a-uuid", "Hello")
+
+
+def test_send_message__validates_destination_agent_exists():
+    sid, sender, _ = _setup_two_agents()
+    fake_agent = str(uuid.uuid4())
+    with pytest.raises(ValueError, match="Destination agent not found"):
+        broker.send_message(sid, sender, fake_agent, "Hello")
+
+
+def test_send_message__validates_destination_agent_is_active():
+    sid, sender, recipient = _setup_two_agents()
+    broker.deregister_agent(recipient)
+    with pytest.raises(ValueError, match="Destination agent not found"):
+        broker.send_message(sid, sender, recipient, "Hello")
+
+
+def test_send_message__validates_destination_in_same_session():
+    session_a = _create_session()
+    session_b = _create_session()
+    sender = _register_agent(session_a["session_id"], name="sender")
+    recipient = _register_agent(session_b["session_id"], name="recipient")
+    with pytest.raises(ValueError, match="Destination agent not in session"):
+        broker.send_message(
+            session_a["session_id"],
+            sender["agent_id"],
+            recipient["agent_id"],
+            "cross-session",
+        )
+
+
+def test_send_message__task_persisted_to_db():
+    sid, sender, recipient = _setup_two_agents()
+    broker.send_message(sid, sender, recipient, "persisted?")
+
+    tasks = broker.poll_tasks(recipient)
+    assert len(tasks) == 1
+    texts = [
+        p["text"]
+        for t in tasks
+        for a in t["artifacts"]
+        for p in a["parts"]
+        if "text" in p
+    ]
+    assert "persisted?" in texts
+
+
+# --- broadcast_message: broker.broadcast_message(session_id, agent_id, text) → [{"task": <summary>}] ---
+
+
+def test_broadcast_message__returns_list_with_summary():
+    sid, sender, _, _ = _setup_three_agents()
+    result = broker.broadcast_message(sid, sender, "Attention all")
+    assert isinstance(result, list)
+    assert len(result) == 1
+    assert "task" in result[0]
+
+
+def test_broadcast_message__summary_type_is_broadcast_summary():
+    sid, sender, _, _ = _setup_three_agents()
+    result = broker.broadcast_message(sid, sender, "Attention all")
+    summary = result[0]["task"]
+    assert summary["metadata"]["type"] == "broadcast_summary"
+
+
+def test_broadcast_message__summary_context_id_is_sender():
+    sid, sender, _, _ = _setup_three_agents()
+    result = broker.broadcast_message(sid, sender, "Attention all")
+    summary = result[0]["task"]
+    assert summary["contextId"] == sender
+
+
+def test_broadcast_message__creates_delivery_tasks_for_each_recipient():
+    sid, sender, b_id, c_id = _setup_three_agents()
+    broker.broadcast_message(sid, sender, "Hello everyone")
+
+    b_tasks = broker.poll_tasks(b_id)
+    c_tasks = broker.poll_tasks(c_id)
+    assert len(b_tasks) == 1
+    assert len(c_tasks) == 1
+
+
+def test_broadcast_message__delivery_tasks_have_origin_task_id():
+    sid, sender, b_id, _ = _setup_three_agents()
+    result = broker.broadcast_message(sid, sender, "Hello")
+    summary_id = result[0]["task"]["id"]
+
+    b_tasks = broker.poll_tasks(b_id)
+    assert len(b_tasks) == 1
+    assert b_tasks[0]["metadata"]["originTaskId"] == summary_id
+
+
+def test_broadcast_message__delivery_tasks_type_is_unicast():
+    sid, sender, b_id, _ = _setup_three_agents()
+    broker.broadcast_message(sid, sender, "Hello")
+
+    b_tasks = broker.poll_tasks(b_id)
+    assert len(b_tasks) == 1
+    assert b_tasks[0]["metadata"]["type"] == "unicast"
+
+
+def test_broadcast_message__excludes_sender_from_recipients():
+    sid, sender, _, _ = _setup_three_agents()
+    broker.broadcast_message(sid, sender, "Hello")
+
+    sender_tasks = broker.poll_tasks(sender)
+    delivery_tasks = [t for t in sender_tasks if t["metadata"]["type"] == "unicast"]
+    assert len(delivery_tasks) == 0
+
+
+def test_broadcast_message__broadcast_with_no_other_agents():
+    session = _create_session()
+    sid = session["session_id"]
+    lone_agent = _register_agent(sid, name="lonely")
+
+    result = broker.broadcast_message(sid, lone_agent["agent_id"], "Anyone?")
+    assert isinstance(result, list)
+    assert len(result) == 1
+    summary = result[0]["task"]
+    assert summary["metadata"]["type"] == "broadcast_summary"
+
+
+def test_broadcast_message__delivery_task_contains_message_text():
+    sid, sender, b_id, _ = _setup_three_agents()
+    broker.broadcast_message(sid, sender, "Important update")
+
+    b_tasks = broker.poll_tasks(b_id)
+    texts = [
+        p["text"]
+        for t in b_tasks
+        for a in t["artifacts"]
+        for p in a["parts"]
+        if "text" in p
+    ]
+    assert "Important update" in texts
 
 
 def _get_summary_artifact_text(result: list[dict]) -> str:
@@ -270,415 +292,443 @@ def _get_summary_artifact_text(result: list[dict]) -> str:
     return text_parts[0]
 
 
-class TestBroadcastAdministratorExclusion:
-    def test_broadcast_from_user_excludes_administrator_from_recipients(self):
-        session = _create_session()
-        sid = session["session_id"]
-        admin_id = session["administrator_agent_id"]
+def test_broadcast_administrator_exclusion__broadcast_from_user_excludes_administrator_from_recipients():
+    session = _create_session()
+    sid = session["session_id"]
+    admin_id = session["administrator_agent_id"]
 
-        sender = _register_agent(sid, name="sender")
-        user_a = _register_agent(sid, name="user-a")
-        user_b = _register_agent(sid, name="user-b")
+    sender = _register_agent(sid, name="sender")
+    user_a = _register_agent(sid, name="user-a")
+    user_b = _register_agent(sid, name="user-b")
 
-        broker.broadcast_message(sid, sender["agent_id"], "Hi all")
+    broker.broadcast_message(sid, sender["agent_id"], "Hi all")
 
-        admin_tasks = broker.poll_tasks(admin_id)
-        admin_unicasts = [t for t in admin_tasks if t["metadata"]["type"] == "unicast"]
-        assert len(admin_unicasts) == 0
+    admin_tasks = broker.poll_tasks(admin_id)
+    admin_unicasts = [t for t in admin_tasks if t["metadata"]["type"] == "unicast"]
+    assert len(admin_unicasts) == 0
 
-        a_tasks = broker.poll_tasks(user_a["agent_id"])
-        b_tasks = broker.poll_tasks(user_b["agent_id"])
-        assert len(a_tasks) == 1
-        assert len(b_tasks) == 1
-
-    def test_summary_count_reflects_post_exclusion_recipients(self):
-        session = _create_session()
-        sid = session["session_id"]
-        admin_id = session["administrator_agent_id"]
-        director_id = session["director"]["agent_id"]
-
-        sender = _register_agent(sid, name="sender")
-        user_a = _register_agent(sid, name="user-a")
-        user_b = _register_agent(sid, name="user-b")
-
-        result = broker.broadcast_message(sid, sender["agent_id"], "hey")
-
-        text = _get_summary_artifact_text(result)
-        assert text == "Broadcast sent to 3 recipients"
-
-        summary_metadata = result[0]["task"]["metadata"]
-        assert summary_metadata["recipientCount"] == 3
-
-        recipient_ids = summary_metadata["recipientIds"]
-        assert admin_id not in recipient_ids
-        assert set(recipient_ids) == {
-            user_a["agent_id"],
-            user_b["agent_id"],
-            director_id,
-        }
-
-    def test_broadcast_from_administrator_delivers_to_all_user_agents(self):
-        session = _create_session()
-        sid = session["session_id"]
-        admin_id = session["administrator_agent_id"]
-        director_id = session["director"]["agent_id"]
-
-        user_a = _register_agent(sid, name="user-a")
-        user_b = _register_agent(sid, name="user-b")
-
-        result = broker.broadcast_message(sid, admin_id, "hello from admin")
-
-        a_tasks = broker.poll_tasks(user_a["agent_id"])
-        b_tasks = broker.poll_tasks(user_b["agent_id"])
-        assert len(a_tasks) == 1
-        assert len(b_tasks) == 1
-
-        text = _get_summary_artifact_text(result)
-        assert text == "Broadcast sent to 3 recipients"
-
-        summary_metadata = result[0]["task"]["metadata"]
-        recipient_ids = summary_metadata["recipientIds"]
-        assert set(recipient_ids) == {
-            user_a["agent_id"],
-            user_b["agent_id"],
-            director_id,
-        }
-
-    def test_admin_broadcast_in_bootstrap_only_session_reaches_only_director(self):
-        session = _create_session()
-        sid = session["session_id"]
-        admin_id = session["administrator_agent_id"]
-        director_id = session["director"]["agent_id"]
-
-        result = broker.broadcast_message(sid, admin_id, "anybody?")
-
-        text = _get_summary_artifact_text(result)
-        assert text == "Broadcast sent to 1 recipients"
-
-        summary_metadata = result[0]["task"]["metadata"]
-        assert summary_metadata["recipientCount"] == 1
-        assert summary_metadata["recipientIds"] == [director_id]
+    a_tasks = broker.poll_tasks(user_a["agent_id"])
+    b_tasks = broker.poll_tasks(user_b["agent_id"])
+    assert len(a_tasks) == 1
+    assert len(b_tasks) == 1
 
 
-class TestPollTasks:
-    """broker.poll_tasks(agent_id, since, page_size, status) → list of task dicts."""
+def test_broadcast_administrator_exclusion__summary_count_reflects_post_exclusion_recipients():
+    session = _create_session()
+    sid = session["session_id"]
+    admin_id = session["administrator_agent_id"]
+    director_id = session["director"]["agent_id"]
 
-    def test_returns_empty_list_when_no_tasks(self):
-        session = _create_session()
-        agent = _register_agent(session["session_id"], name="idle")
-        result = broker.poll_tasks(agent["agent_id"])
-        assert result == []
+    sender = _register_agent(sid, name="sender")
+    user_a = _register_agent(sid, name="user-a")
+    user_b = _register_agent(sid, name="user-b")
 
-    def test_returns_tasks_for_agent(self):
-        sid, sender, recipient = _setup_two_agents()
-        broker.send_message(sid, sender, recipient, "msg1")
-        broker.send_message(sid, sender, recipient, "msg2")
+    result = broker.broadcast_message(sid, sender["agent_id"], "hey")
 
-        result = broker.poll_tasks(recipient)
-        assert len(result) == 2
+    text = _get_summary_artifact_text(result)
+    assert text == "Broadcast sent to 3 recipients"
 
-    def test_returns_camel_case_task_dicts(self):
-        sid, sender, recipient = _setup_two_agents()
-        broker.send_message(sid, sender, recipient, "Hello")
+    summary_metadata = result[0]["task"]["metadata"]
+    assert summary_metadata["recipientCount"] == 3
 
-        result = broker.poll_tasks(recipient)
-        assert len(result) == 1
-        task = result[0]
-        assert "id" in task
-        assert "contextId" in task
-        assert "status" in task
-        assert "metadata" in task
-
-    def test_ordered_by_status_timestamp_desc(self):
-        """Most recent tasks first."""
-        sid, sender, recipient = _setup_two_agents()
-        broker.send_message(sid, sender, recipient, "first")
-        broker.send_message(sid, sender, recipient, "second")
-
-        result = broker.poll_tasks(recipient)
-        assert len(result) == 2
-        ts0 = result[0]["status"]["timestamp"]
-        ts1 = result[1]["status"]["timestamp"]
-        assert ts0 >= ts1  # DESC order
-
-    def test_filters_out_broadcast_summary(self):
-        sid, sender, _b_id, _ = _setup_three_agents()
-        broker.broadcast_message(sid, sender, "broadcast")
-
-        sender_tasks = broker.poll_tasks(sender)
-        summary_tasks = [
-            t for t in sender_tasks if t["metadata"]["type"] == "broadcast_summary"
-        ]
-        assert len(summary_tasks) == 0
-
-    def test_only_returns_tasks_for_specified_agent(self):
-        """Tasks for other agents are not returned."""
-        sid, sender, recipient = _setup_two_agents()
-        broker.send_message(sid, sender, recipient, "for-recipient")
-
-        sender_tasks = broker.poll_tasks(sender)
-        # Sender should have no inbox tasks (they sent, not received)
-        assert len(sender_tasks) == 0
-
-    def test_status_filter(self):
-        """Filter tasks by status state."""
-        sid, sender, recipient = _setup_two_agents()
-        result1 = broker.send_message(sid, sender, recipient, "msg1")
-        broker.send_message(sid, sender, recipient, "msg2")
-        # ACK the first task
-        broker.ack_task(recipient, result1["task"]["id"])
-
-        # Filter by input_required
-        pending = broker.poll_tasks(recipient, status="input_required")
-        assert len(pending) == 1
-
-        # Filter by completed
-        completed = broker.poll_tasks(recipient, status="completed")
-        assert len(completed) == 1
-
-    def test_page_size_limits_results(self):
-        """page_size limits the number of returned tasks."""
-        sid, sender, recipient = _setup_two_agents()
-        broker.send_message(sid, sender, recipient, "msg1")
-        broker.send_message(sid, sender, recipient, "msg2")
-        broker.send_message(sid, sender, recipient, "msg3")
-
-        result = broker.poll_tasks(recipient, page_size=2)
-        assert len(result) == 2
-
-    def test_since_filter(self):
-        sid, sender, recipient = _setup_two_agents()
-        result1 = broker.send_message(sid, sender, recipient, "early")
-        ts = result1["task"]["status"]["timestamp"]
-
-        broker.send_message(sid, sender, recipient, "later")
-
-        result = broker.poll_tasks(recipient, since=ts)
-        assert len(result) >= 1
+    recipient_ids = summary_metadata["recipientIds"]
+    assert admin_id not in recipient_ids
+    assert set(recipient_ids) == {
+        user_a["agent_id"],
+        user_b["agent_id"],
+        director_id,
+    }
 
 
-class TestAckTask:
-    """broker.ack_task(agent_id, task_id) → {"task": <updated dict>}."""
+def test_broadcast_administrator_exclusion__broadcast_from_administrator_delivers_to_all_user_agents():
+    session = _create_session()
+    sid = session["session_id"]
+    admin_id = session["administrator_agent_id"]
+    director_id = session["director"]["agent_id"]
 
-    def test_returns_dict_with_task_key(self):
-        sid, sender, recipient = _setup_two_agents()
-        sent = broker.send_message(sid, sender, recipient, "Please ack")
-        task_id = sent["task"]["id"]
+    user_a = _register_agent(sid, name="user-a")
+    user_b = _register_agent(sid, name="user-b")
 
-        result = broker.ack_task(recipient, task_id)
-        assert isinstance(result, dict)
-        assert "task" in result
+    result = broker.broadcast_message(sid, admin_id, "hello from admin")
 
-    def test_transitions_to_completed(self):
-        sid, sender, recipient = _setup_two_agents()
-        sent = broker.send_message(sid, sender, recipient, "Ack me")
-        task_id = sent["task"]["id"]
+    a_tasks = broker.poll_tasks(user_a["agent_id"])
+    b_tasks = broker.poll_tasks(user_b["agent_id"])
+    assert len(a_tasks) == 1
+    assert len(b_tasks) == 1
 
-        result = broker.ack_task(recipient, task_id)
-        assert result["task"]["status"]["state"] == "completed"
+    text = _get_summary_artifact_text(result)
+    assert text == "Broadcast sent to 3 recipients"
 
-    def test_updates_timestamp(self):
-        sid, sender, recipient = _setup_two_agents()
-        sent = broker.send_message(sid, sender, recipient, "Ack me")
-        task_id = sent["task"]["id"]
-        original_ts = sent["task"]["status"]["timestamp"]
+    summary_metadata = result[0]["task"]["metadata"]
+    recipient_ids = summary_metadata["recipientIds"]
+    assert set(recipient_ids) == {
+        user_a["agent_id"],
+        user_b["agent_id"],
+        director_id,
+    }
 
-        result = broker.ack_task(recipient, task_id)
-        assert result["task"]["status"]["timestamp"] >= original_ts
 
-    def test_verifies_context_id_matches_agent(self):
-        """Only the recipient (context_id) can ACK."""
-        sid, sender, recipient = _setup_two_agents()
-        sent = broker.send_message(sid, sender, recipient, "Ack me")
-        task_id = sent["task"]["id"]
+def test_broadcast_administrator_exclusion__admin_broadcast_in_bootstrap_only_session_reaches_only_director():
+    session = _create_session()
+    sid = session["session_id"]
+    admin_id = session["administrator_agent_id"]
+    director_id = session["director"]["agent_id"]
 
-        # Sender should not be able to ACK
-        with pytest.raises(PermissionError):
-            broker.ack_task(sender, task_id)
+    result = broker.broadcast_message(sid, admin_id, "anybody?")
 
-    def test_verifies_state_is_input_required(self):
-        """Cannot ACK a task that is already completed."""
-        sid, sender, recipient = _setup_two_agents()
-        sent = broker.send_message(sid, sender, recipient, "Ack me")
-        task_id = sent["task"]["id"]
+    text = _get_summary_artifact_text(result)
+    assert text == "Broadcast sent to 1 recipients"
 
-        broker.ack_task(recipient, task_id)
-        # Second ACK should fail
-        with pytest.raises(ValueError, match="Cannot ACK"):
-            broker.ack_task(recipient, task_id)
+    summary_metadata = result[0]["task"]["metadata"]
+    assert summary_metadata["recipientCount"] == 1
+    assert summary_metadata["recipientIds"] == [director_id]
 
-    def test_cannot_ack_canceled_task(self):
-        """Cannot ACK a task that has been canceled."""
-        sid, sender, recipient = _setup_two_agents()
-        sent = broker.send_message(sid, sender, recipient, "Cancel me")
-        task_id = sent["task"]["id"]
 
-        broker.cancel_task(sender, task_id)
-        with pytest.raises(ValueError, match="Cannot ACK"):
-            broker.ack_task(recipient, task_id)
+# --- poll_tasks: broker.poll_tasks(agent_id, since, page_size, status) → list of task dicts ---
 
-    def test_ack_persists_state(self):
-        """After ACK, polling shows the task as completed."""
-        sid, sender, recipient = _setup_two_agents()
-        sent = broker.send_message(sid, sender, recipient, "Ack me")
-        task_id = sent["task"]["id"]
 
+def test_poll_tasks__returns_empty_list_when_no_tasks():
+    session = _create_session()
+    agent = _register_agent(session["session_id"], name="idle")
+    result = broker.poll_tasks(agent["agent_id"])
+    assert result == []
+
+
+def test_poll_tasks__returns_tasks_for_agent():
+    sid, sender, recipient = _setup_two_agents()
+    broker.send_message(sid, sender, recipient, "msg1")
+    broker.send_message(sid, sender, recipient, "msg2")
+
+    result = broker.poll_tasks(recipient)
+    assert len(result) == 2
+
+
+def test_poll_tasks__returns_camel_case_task_dicts():
+    sid, sender, recipient = _setup_two_agents()
+    broker.send_message(sid, sender, recipient, "Hello")
+
+    result = broker.poll_tasks(recipient)
+    assert len(result) == 1
+    task = result[0]
+    assert "id" in task
+    assert "contextId" in task
+    assert "status" in task
+    assert "metadata" in task
+
+
+def test_poll_tasks__ordered_by_status_timestamp_desc():
+    """Most recent tasks first."""
+    sid, sender, recipient = _setup_two_agents()
+    broker.send_message(sid, sender, recipient, "first")
+    broker.send_message(sid, sender, recipient, "second")
+
+    result = broker.poll_tasks(recipient)
+    assert len(result) == 2
+    ts0 = result[0]["status"]["timestamp"]
+    ts1 = result[1]["status"]["timestamp"]
+    assert ts0 >= ts1  # DESC order
+
+
+def test_poll_tasks__filters_out_broadcast_summary():
+    sid, sender, _b_id, _ = _setup_three_agents()
+    broker.broadcast_message(sid, sender, "broadcast")
+
+    sender_tasks = broker.poll_tasks(sender)
+    summary_tasks = [
+        t for t in sender_tasks if t["metadata"]["type"] == "broadcast_summary"
+    ]
+    assert len(summary_tasks) == 0
+
+
+def test_poll_tasks__only_returns_tasks_for_specified_agent():
+    """Tasks for other agents are not returned."""
+    sid, sender, recipient = _setup_two_agents()
+    broker.send_message(sid, sender, recipient, "for-recipient")
+
+    sender_tasks = broker.poll_tasks(sender)
+    # Sender should have no inbox tasks (they sent, not received)
+    assert len(sender_tasks) == 0
+
+
+def test_poll_tasks__status_filter():
+    """Filter tasks by status state."""
+    sid, sender, recipient = _setup_two_agents()
+    result1 = broker.send_message(sid, sender, recipient, "msg1")
+    broker.send_message(sid, sender, recipient, "msg2")
+    # ACK the first task
+    broker.ack_task(recipient, result1["task"]["id"])
+
+    # Filter by input_required
+    pending = broker.poll_tasks(recipient, status="input_required")
+    assert len(pending) == 1
+
+    # Filter by completed
+    completed = broker.poll_tasks(recipient, status="completed")
+    assert len(completed) == 1
+
+
+def test_poll_tasks__page_size_limits_results():
+    """page_size limits the number of returned tasks."""
+    sid, sender, recipient = _setup_two_agents()
+    broker.send_message(sid, sender, recipient, "msg1")
+    broker.send_message(sid, sender, recipient, "msg2")
+    broker.send_message(sid, sender, recipient, "msg3")
+
+    result = broker.poll_tasks(recipient, page_size=2)
+    assert len(result) == 2
+
+
+def test_poll_tasks__since_filter():
+    sid, sender, recipient = _setup_two_agents()
+    result1 = broker.send_message(sid, sender, recipient, "early")
+    ts = result1["task"]["status"]["timestamp"]
+
+    broker.send_message(sid, sender, recipient, "later")
+
+    result = broker.poll_tasks(recipient, since=ts)
+    assert len(result) >= 1
+
+
+# --- ack_task: broker.ack_task(agent_id, task_id) → {"task": <updated dict>} ---
+
+
+def test_ack_task__returns_dict_with_task_key():
+    sid, sender, recipient = _setup_two_agents()
+    sent = broker.send_message(sid, sender, recipient, "Please ack")
+    task_id = sent["task"]["id"]
+
+    result = broker.ack_task(recipient, task_id)
+    assert isinstance(result, dict)
+    assert "task" in result
+
+
+def test_ack_task__transitions_to_completed():
+    sid, sender, recipient = _setup_two_agents()
+    sent = broker.send_message(sid, sender, recipient, "Ack me")
+    task_id = sent["task"]["id"]
+
+    result = broker.ack_task(recipient, task_id)
+    assert result["task"]["status"]["state"] == "completed"
+
+
+def test_ack_task__updates_timestamp():
+    sid, sender, recipient = _setup_two_agents()
+    sent = broker.send_message(sid, sender, recipient, "Ack me")
+    task_id = sent["task"]["id"]
+    original_ts = sent["task"]["status"]["timestamp"]
+
+    result = broker.ack_task(recipient, task_id)
+    assert result["task"]["status"]["timestamp"] >= original_ts
+
+
+def test_ack_task__verifies_context_id_matches_agent():
+    """Only the recipient (context_id) can ACK."""
+    sid, sender, recipient = _setup_two_agents()
+    sent = broker.send_message(sid, sender, recipient, "Ack me")
+    task_id = sent["task"]["id"]
+
+    # Sender should not be able to ACK
+    with pytest.raises(PermissionError):
+        broker.ack_task(sender, task_id)
+
+
+def test_ack_task__verifies_state_is_input_required():
+    """Cannot ACK a task that is already completed."""
+    sid, sender, recipient = _setup_two_agents()
+    sent = broker.send_message(sid, sender, recipient, "Ack me")
+    task_id = sent["task"]["id"]
+
+    broker.ack_task(recipient, task_id)
+    # Second ACK should fail
+    with pytest.raises(ValueError, match="Cannot ACK"):
         broker.ack_task(recipient, task_id)
 
-        tasks = broker.poll_tasks(recipient)
-        acked = [t for t in tasks if t["id"] == task_id]
-        assert len(acked) == 1
-        assert acked[0]["status"]["state"] == "completed"
 
+def test_ack_task__cannot_ack_canceled_task():
+    """Cannot ACK a task that has been canceled."""
+    sid, sender, recipient = _setup_two_agents()
+    sent = broker.send_message(sid, sender, recipient, "Cancel me")
+    task_id = sent["task"]["id"]
 
-class TestCancelTask:
-    """broker.cancel_task(agent_id, task_id) → {"task": <updated dict>}."""
-
-    def test_returns_dict_with_task_key(self):
-        sid, sender, recipient = _setup_two_agents()
-        sent = broker.send_message(sid, sender, recipient, "Cancel me")
-        task_id = sent["task"]["id"]
-
-        result = broker.cancel_task(sender, task_id)
-        assert isinstance(result, dict)
-        assert "task" in result
-
-    def test_transitions_to_canceled(self):
-        sid, sender, recipient = _setup_two_agents()
-        sent = broker.send_message(sid, sender, recipient, "Cancel me")
-        task_id = sent["task"]["id"]
-
-        result = broker.cancel_task(sender, task_id)
-        assert result["task"]["status"]["state"] == "canceled"
-
-    def test_updates_timestamp(self):
-        sid, sender, recipient = _setup_two_agents()
-        sent = broker.send_message(sid, sender, recipient, "Cancel me")
-        task_id = sent["task"]["id"]
-        original_ts = sent["task"]["status"]["timestamp"]
-
-        result = broker.cancel_task(sender, task_id)
-        assert result["task"]["status"]["timestamp"] >= original_ts
-
-    def test_verifies_from_agent_id_matches(self):
-        """Only the sender (metadata.fromAgentId) can cancel."""
-        sid, sender, recipient = _setup_two_agents()
-        sent = broker.send_message(sid, sender, recipient, "Cancel me")
-        task_id = sent["task"]["id"]
-
-        # Recipient should not be able to cancel
-        with pytest.raises(PermissionError):
-            broker.cancel_task(recipient, task_id)
-
-    def test_verifies_state_is_input_required(self):
-        """Cannot cancel a task that is already completed."""
-        sid, sender, recipient = _setup_two_agents()
-        sent = broker.send_message(sid, sender, recipient, "Ack then cancel")
-        task_id = sent["task"]["id"]
-
+    broker.cancel_task(sender, task_id)
+    with pytest.raises(ValueError, match="Cannot ACK"):
         broker.ack_task(recipient, task_id)
-        with pytest.raises(ValueError, match="Cannot cancel"):
-            broker.cancel_task(sender, task_id)
 
-    def test_cannot_cancel_already_canceled(self):
-        """Cannot cancel a task that is already canceled."""
-        sid, sender, recipient = _setup_two_agents()
-        sent = broker.send_message(sid, sender, recipient, "Cancel me twice")
-        task_id = sent["task"]["id"]
 
+def test_ack_task__ack_persists_state():
+    """After ACK, polling shows the task as completed."""
+    sid, sender, recipient = _setup_two_agents()
+    sent = broker.send_message(sid, sender, recipient, "Ack me")
+    task_id = sent["task"]["id"]
+
+    broker.ack_task(recipient, task_id)
+
+    tasks = broker.poll_tasks(recipient)
+    acked = [t for t in tasks if t["id"] == task_id]
+    assert len(acked) == 1
+    assert acked[0]["status"]["state"] == "completed"
+
+
+# --- cancel_task: broker.cancel_task(agent_id, task_id) → {"task": <updated dict>} ---
+
+
+def test_cancel_task__returns_dict_with_task_key():
+    sid, sender, recipient = _setup_two_agents()
+    sent = broker.send_message(sid, sender, recipient, "Cancel me")
+    task_id = sent["task"]["id"]
+
+    result = broker.cancel_task(sender, task_id)
+    assert isinstance(result, dict)
+    assert "task" in result
+
+
+def test_cancel_task__transitions_to_canceled():
+    sid, sender, recipient = _setup_two_agents()
+    sent = broker.send_message(sid, sender, recipient, "Cancel me")
+    task_id = sent["task"]["id"]
+
+    result = broker.cancel_task(sender, task_id)
+    assert result["task"]["status"]["state"] == "canceled"
+
+
+def test_cancel_task__updates_timestamp():
+    sid, sender, recipient = _setup_two_agents()
+    sent = broker.send_message(sid, sender, recipient, "Cancel me")
+    task_id = sent["task"]["id"]
+    original_ts = sent["task"]["status"]["timestamp"]
+
+    result = broker.cancel_task(sender, task_id)
+    assert result["task"]["status"]["timestamp"] >= original_ts
+
+
+def test_cancel_task__verifies_from_agent_id_matches():
+    """Only the sender (metadata.fromAgentId) can cancel."""
+    sid, sender, recipient = _setup_two_agents()
+    sent = broker.send_message(sid, sender, recipient, "Cancel me")
+    task_id = sent["task"]["id"]
+
+    # Recipient should not be able to cancel
+    with pytest.raises(PermissionError):
+        broker.cancel_task(recipient, task_id)
+
+
+def test_cancel_task__verifies_state_is_input_required():
+    """Cannot cancel a task that is already completed."""
+    sid, sender, recipient = _setup_two_agents()
+    sent = broker.send_message(sid, sender, recipient, "Ack then cancel")
+    task_id = sent["task"]["id"]
+
+    broker.ack_task(recipient, task_id)
+    with pytest.raises(ValueError, match="Cannot cancel"):
         broker.cancel_task(sender, task_id)
-        with pytest.raises(ValueError, match="Cannot cancel"):
-            broker.cancel_task(sender, task_id)
 
-    def test_cancel_persists_state(self):
-        """After cancel, polling shows the task as canceled."""
-        sid, sender, recipient = _setup_two_agents()
-        sent = broker.send_message(sid, sender, recipient, "Cancel me")
-        task_id = sent["task"]["id"]
 
+def test_cancel_task__cannot_cancel_already_canceled():
+    """Cannot cancel a task that is already canceled."""
+    sid, sender, recipient = _setup_two_agents()
+    sent = broker.send_message(sid, sender, recipient, "Cancel me twice")
+    task_id = sent["task"]["id"]
+
+    broker.cancel_task(sender, task_id)
+    with pytest.raises(ValueError, match="Cannot cancel"):
         broker.cancel_task(sender, task_id)
 
-        tasks = broker.poll_tasks(recipient)
-        canceled = [t for t in tasks if t["id"] == task_id]
-        assert len(canceled) == 1
-        assert canceled[0]["status"]["state"] == "canceled"
+
+def test_cancel_task__cancel_persists_state():
+    """After cancel, polling shows the task as canceled."""
+    sid, sender, recipient = _setup_two_agents()
+    sent = broker.send_message(sid, sender, recipient, "Cancel me")
+    task_id = sent["task"]["id"]
+
+    broker.cancel_task(sender, task_id)
+
+    tasks = broker.poll_tasks(recipient)
+    canceled = [t for t in tasks if t["id"] == task_id]
+    assert len(canceled) == 1
+    assert canceled[0]["status"]["state"] == "canceled"
 
 
-class TestGetTask:
-    """broker.get_task(session_id, task_id) → {"task": <dict>}."""
+# --- get_task: broker.get_task(session_id, task_id) → {"task": <dict>} ---
 
-    def test_returns_dict_with_task_key(self):
-        sid, sender, recipient = _setup_two_agents()
-        sent = broker.send_message(sid, sender, recipient, "Get me")
-        task_id = sent["task"]["id"]
 
-        result = broker.get_task(sid, task_id)
-        assert isinstance(result, dict)
-        assert "task" in result
+def test_get_task__returns_dict_with_task_key():
+    sid, sender, recipient = _setup_two_agents()
+    sent = broker.send_message(sid, sender, recipient, "Get me")
+    task_id = sent["task"]["id"]
 
-    def test_returns_correct_task(self):
-        sid, sender, recipient = _setup_two_agents()
-        sent = broker.send_message(sid, sender, recipient, "Specific task")
-        task_id = sent["task"]["id"]
+    result = broker.get_task(sid, task_id)
+    assert isinstance(result, dict)
+    assert "task" in result
 
-        result = broker.get_task(sid, task_id)
-        assert result["task"]["id"] == task_id
 
-    def test_task_has_full_structure(self):
-        sid, sender, recipient = _setup_two_agents()
-        sent = broker.send_message(sid, sender, recipient, "Full structure")
-        task_id = sent["task"]["id"]
+def test_get_task__returns_correct_task():
+    sid, sender, recipient = _setup_two_agents()
+    sent = broker.send_message(sid, sender, recipient, "Specific task")
+    task_id = sent["task"]["id"]
 
-        result = broker.get_task(sid, task_id)
-        task = result["task"]
-        assert "id" in task
-        assert "contextId" in task
-        assert "status" in task
-        assert "artifacts" in task
-        assert "metadata" in task
+    result = broker.get_task(sid, task_id)
+    assert result["task"]["id"] == task_id
 
-    def test_verifies_agent_belongs_to_session(self):
-        """get_task verifies fromAgentId or toAgentId belongs to the given session."""
-        session_a = _create_session()
-        session_b = _create_session()
-        sid_a = session_a["session_id"]
-        sid_b = session_b["session_id"]
 
-        sender = _register_agent(sid_a, name="sender")
-        recipient = _register_agent(sid_a, name="recipient")
+def test_get_task__task_has_full_structure():
+    sid, sender, recipient = _setup_two_agents()
+    sent = broker.send_message(sid, sender, recipient, "Full structure")
+    task_id = sent["task"]["id"]
 
-        sent = broker.send_message(
-            sid_a, sender["agent_id"], recipient["agent_id"], "Hi"
-        )
-        task_id = sent["task"]["id"]
+    result = broker.get_task(sid, task_id)
+    task = result["task"]
+    assert "id" in task
+    assert "contextId" in task
+    assert "status" in task
+    assert "artifacts" in task
+    assert "metadata" in task
 
-        # Should succeed with the correct session
-        result = broker.get_task(sid_a, task_id)
-        assert result["task"]["id"] == task_id
 
-        # Should fail with a different session
-        with pytest.raises(ValueError, match="not found"):
-            broker.get_task(sid_b, task_id)
+def test_get_task__verifies_agent_belongs_to_session():
+    """get_task verifies fromAgentId or toAgentId belongs to the given session."""
+    session_a = _create_session()
+    session_b = _create_session()
+    sid_a = session_a["session_id"]
+    sid_b = session_b["session_id"]
 
-    def test_nonexistent_task_raises(self):
-        session = _create_session()
-        with pytest.raises(ValueError, match="not found"):
-            broker.get_task(session["session_id"], str(uuid.uuid4()))
+    sender = _register_agent(sid_a, name="sender")
+    recipient = _register_agent(sid_a, name="recipient")
 
-    def test_sender_can_get_task(self):
-        """Sender (fromAgentId) can retrieve the task."""
-        sid, sender, recipient = _setup_two_agents()
-        sent = broker.send_message(sid, sender, recipient, "sender gets")
-        task_id = sent["task"]["id"]
+    sent = broker.send_message(
+        sid_a, sender["agent_id"], recipient["agent_id"], "Hi"
+    )
+    task_id = sent["task"]["id"]
 
-        result = broker.get_task(sid, task_id)
-        assert result["task"]["id"] == task_id
+    # Should succeed with the correct session
+    result = broker.get_task(sid_a, task_id)
+    assert result["task"]["id"] == task_id
 
-    def test_recipient_can_get_task(self):
-        """Recipient (toAgentId/contextId) can retrieve the task."""
-        sid, sender, recipient = _setup_two_agents()
-        sent = broker.send_message(sid, sender, recipient, "recipient gets")
-        task_id = sent["task"]["id"]
+    # Should fail with a different session
+    with pytest.raises(ValueError, match="not found"):
+        broker.get_task(sid_b, task_id)
 
-        result = broker.get_task(sid, task_id)
-        assert result["task"]["id"] == task_id
+
+def test_get_task__nonexistent_task_raises():
+    session = _create_session()
+    with pytest.raises(ValueError, match="not found"):
+        broker.get_task(session["session_id"], str(uuid.uuid4()))
+
+
+def test_get_task__sender_can_get_task():
+    """Sender (fromAgentId) can retrieve the task."""
+    sid, sender, recipient = _setup_two_agents()
+    sent = broker.send_message(sid, sender, recipient, "sender gets")
+    task_id = sent["task"]["id"]
+
+    result = broker.get_task(sid, task_id)
+    assert result["task"]["id"] == task_id
+
+
+def test_get_task__recipient_can_get_task():
+    """Recipient (toAgentId/contextId) can retrieve the task."""
+    sid, sender, recipient = _setup_two_agents()
+    sent = broker.send_message(sid, sender, recipient, "recipient gets")
+    task_id = sent["task"]["id"]
+
+    result = broker.get_task(sid, task_id)
+    assert result["task"]["id"] == task_id

--- a/cafleet/tests/test_broker_messaging.py
+++ b/cafleet/tests/test_broker_messaging.py
@@ -694,9 +694,7 @@ def test_get_task__verifies_agent_belongs_to_session():
     sender = _register_agent(sid_a, name="sender")
     recipient = _register_agent(sid_a, name="recipient")
 
-    sent = broker.send_message(
-        sid_a, sender["agent_id"], recipient["agent_id"], "Hi"
-    )
+    sent = broker.send_message(sid_a, sender["agent_id"], recipient["agent_id"], "Hi")
     task_id = sent["task"]["id"]
 
     # Should succeed with the correct session

--- a/cafleet/tests/test_broker_registry.py
+++ b/cafleet/tests/test_broker_registry.py
@@ -56,217 +56,231 @@ def _register_agent(
     )
 
 
-class TestCreateSession:
-    """broker.create_session(label=None) → dict with session_id, label, created_at."""
-
-    def test_returns_dict_with_required_keys(self):
-        result = _create_session()
-        assert isinstance(result, dict)
-        assert "session_id" in result
-        assert "label" in result
-        assert "created_at" in result
-
-    def test_session_id_is_valid_uuid(self):
-        result = _create_session()
-        uuid.UUID(result["session_id"])  # raises ValueError if invalid
-
-    def test_label_is_none_when_omitted(self):
-        result = _create_session()
-        assert result["label"] is None
-
-    def test_label_is_stored_when_provided(self):
-        result = _create_session(label="PR-42 review")
-        assert result["label"] == "PR-42 review"
-
-    def test_created_at_is_iso8601(self):
-        result = _create_session()
-        # Should be a non-empty ISO 8601 string
-        assert isinstance(result["created_at"], str)
-        assert len(result["created_at"]) > 0
-        assert "T" in result["created_at"]
-
-    def test_each_call_mints_unique_id(self):
-        r1 = _create_session()
-        r2 = _create_session()
-        assert r1["session_id"] != r2["session_id"]
+# --- create_session: broker.create_session(label=None) → dict with session_id, label, created_at ---
 
 
-class TestCreateSessionAdministratorSeed:
-    """broker.create_session auto-seeds a built-in Administrator agent.
+def test_create_session__returns_dict_with_required_keys():
+    result = _create_session()
+    assert isinstance(result, dict)
+    assert "session_id" in result
+    assert "label" in result
+    assert "created_at" in result
 
-    Design doc 0000025 §B: create_session inserts the session row AND an
-    Administrator agent in the same transaction, and returns the new
-    ``administrator_agent_id`` in the result dict.
+
+def test_create_session__session_id_is_valid_uuid():
+    result = _create_session()
+    uuid.UUID(result["session_id"])  # raises ValueError if invalid
+
+
+def test_create_session__label_is_none_when_omitted():
+    result = _create_session()
+    assert result["label"] is None
+
+
+def test_create_session__label_is_stored_when_provided():
+    result = _create_session(label="PR-42 review")
+    assert result["label"] == "PR-42 review"
+
+
+def test_create_session__created_at_is_iso8601():
+    result = _create_session()
+    # Should be a non-empty ISO 8601 string
+    assert isinstance(result["created_at"], str)
+    assert len(result["created_at"]) > 0
+    assert "T" in result["created_at"]
+
+
+def test_create_session__each_call_mints_unique_id():
+    r1 = _create_session()
+    r2 = _create_session()
+    assert r1["session_id"] != r2["session_id"]
+
+
+# --- create_session_administrator_seed: broker.create_session auto-seeds a built-in
+# Administrator agent. Design doc 0000025 §B: create_session inserts the session row
+# AND an Administrator agent in the same transaction, and returns the new
+# ``administrator_agent_id`` in the result dict. ---
+
+
+def test_create_session_administrator_seed__result_includes_administrator_agent_id():
+    result = _create_session()
+    assert "administrator_agent_id" in result
+    assert result["administrator_agent_id"] is not None
+
+
+def test_create_session_administrator_seed__administrator_agent_id_is_valid_uuid():
+    result = _create_session()
+    uuid.UUID(result["administrator_agent_id"])
+
+
+def test_create_session_administrator_seed__administrator_row_exists_in_db_and_is_active(broker_session):
+    """After create_session, exactly one active Administrator agent exists
+    for that session in the agents table.
+
+    Design 0000026 also bootstraps a root Director (name='Director') in
+    the same transaction, so two active agents exist — we pick the
+    Administrator out by ``name == 'Administrator'``.
     """
+    result = _create_session()
+    sid = result["session_id"]
+    admin_id = result["administrator_agent_id"]
 
-    def test_result_includes_administrator_agent_id(self):
-        result = _create_session()
-        assert "administrator_agent_id" in result
-        assert result["administrator_agent_id"] is not None
+    with broker_session() as s:
+        rows = (
+            s.query(Agent)
+            .filter(Agent.session_id == sid, Agent.status == "active")
+            .all()
+        )
 
-    def test_administrator_agent_id_is_valid_uuid(self):
-        result = _create_session()
-        uuid.UUID(result["administrator_agent_id"])
-
-    def test_administrator_row_exists_in_db_and_is_active(self, broker_session):
-        """After create_session, exactly one active Administrator agent exists
-        for that session in the agents table.
-
-        Design 0000026 also bootstraps a root Director (name='Director') in
-        the same transaction, so two active agents exist — we pick the
-        Administrator out by ``name == 'Administrator'``.
-        """
-        result = _create_session()
-        sid = result["session_id"]
-        admin_id = result["administrator_agent_id"]
-
-        with broker_session() as s:
-            rows = (
-                s.query(Agent)
-                .filter(Agent.session_id == sid, Agent.status == "active")
-                .all()
-            )
-
-        # Two active agents: the root Director and the Administrator.
-        assert len(rows) == 2
-        admins = [r for r in rows if r.name == "Administrator"]
-        assert len(admins) == 1
-        row = admins[0]
-        assert row.agent_id == admin_id
-        card = json.loads(row.agent_card_json)
-        assert card["cafleet"]["kind"] == ADMINISTRATOR_KIND
-
-    def test_administrator_registered_at_equals_session_created_at(
-        self, broker_session
-    ):
-        """Per design §A: Administrator.registered_at == sessions.created_at."""
-        result = _create_session()
-        sid = result["session_id"]
-        admin_id = result["administrator_agent_id"]
-
-        with broker_session() as s:
-            session_row = (
-                s.query(SessionModel).filter(SessionModel.session_id == sid).one()
-            )
-            agent_row = s.query(Agent).filter(Agent.agent_id == admin_id).one()
-
-        assert agent_row.registered_at == session_row.created_at
-
-    def test_list_session_agents_marks_administrator_kind(self):
-        """broker.list_session_agents exposes ``kind`` per agent; the
-        auto-seeded Administrator has ``kind == 'builtin-administrator'``
-        and is the only such entry. The root Director is ``kind == 'user'``.
-        """
-        result = _create_session()
-        sid = result["session_id"]
-
-        # Register a regular user agent alongside to verify the kind split.
-        _register_agent(sid, name="user-agent")
-
-        entries = broker.list_session_agents(sid)
-        # Three entries: root Director + Administrator + user-agent (design 0000026).
-        assert len(entries) == 3
-
-        admin_entries = [e for e in entries if e["kind"] == ADMINISTRATOR_KIND]
-        user_entries = [e for e in entries if e["kind"] == "user"]
-        # Exactly one Administrator, two user-kind (director + user-agent).
-        assert len(admin_entries) == 1
-        assert len(user_entries) == 2
-        assert admin_entries[0]["name"] == "Administrator"
-        assert admin_entries[0]["agent_id"] == result["administrator_agent_id"]
-        user_names = {e["name"] for e in user_entries}
-        assert "Director" in user_names
-        assert "user-agent" in user_names
-
-    def test_each_session_gets_its_own_administrator(self):
-        """Two calls to create_session produce two distinct Administrators."""
-        r1 = _create_session()
-        r2 = _create_session()
-        assert r1["administrator_agent_id"] != r2["administrator_agent_id"]
+    # Two active agents: the root Director and the Administrator.
+    assert len(rows) == 2
+    admins = [r for r in rows if r.name == "Administrator"]
+    assert len(admins) == 1
+    row = admins[0]
+    assert row.agent_id == admin_id
+    card = json.loads(row.agent_card_json)
+    assert card["cafleet"]["kind"] == ADMINISTRATOR_KIND
 
 
-class TestListSessions:
-    """broker.list_sessions() → list of dicts with agent_count."""
+def test_create_session_administrator_seed__administrator_registered_at_equals_session_created_at(
+    broker_session,
+):
+    """Per design §A: Administrator.registered_at == sessions.created_at."""
+    result = _create_session()
+    sid = result["session_id"]
+    admin_id = result["administrator_agent_id"]
 
-    def test_empty_returns_empty_list(self):
-        result = broker.list_sessions()
-        assert result == []
+    with broker_session() as s:
+        session_row = (
+            s.query(SessionModel).filter(SessionModel.session_id == sid).one()
+        )
+        agent_row = s.query(Agent).filter(Agent.agent_id == admin_id).one()
 
-    def test_returns_created_sessions(self):
-        _create_session(label="session-a")
-        _create_session(label="session-b")
-
-        result = broker.list_sessions()
-        assert len(result) == 2
-        labels = {s["label"] for s in result}
-        assert "session-a" in labels
-        assert "session-b" in labels
-
-    def test_includes_agent_count(self):
-        """Count includes the root Director, auto-seeded Administrator, and user agents."""
-        session = _create_session()
-        sid = session["session_id"]
-
-        _register_agent(sid, name="agent-1")
-        _register_agent(sid, name="agent-2")
-
-        result = broker.list_sessions()
-        assert len(result) == 1
-        # 2 user agents + 1 root Director + 1 Administrator (design 0000026).
-        assert result[0]["agent_count"] == 4
-
-    def test_agent_count_excludes_deregistered(self):
-        """Deregistered user agents are excluded.
-
-        Root Director and Administrator remain active after bootstrap
-        (design 0000026), so the count floors at 2 for a session with
-        no live user agents.
-        """
-        session = _create_session()
-        sid = session["session_id"]
-
-        _register_agent(sid, name="active-agent")
-        agent2 = _register_agent(sid, name="dead-agent")
-        broker.deregister_agent(agent2["agent_id"])
-
-        result = broker.list_sessions()
-        # 1 active user agent + 1 root Director + 1 Administrator.
-        assert result[0]["agent_count"] == 3
-
-    def test_session_with_only_bootstrap_agents_has_count_two(self):
-        """A freshly-bootstrapped session has exactly the Director + Administrator."""
-        _create_session()
-
-        result = broker.list_sessions()
-        # Root Director + Administrator seeded by create_session (design 0000026).
-        assert result[0]["agent_count"] == 2
-
-    def test_result_contains_required_keys(self):
-        _create_session(label="test")
-
-        result = broker.list_sessions()
-        entry = result[0]
-        assert "session_id" in entry
-        assert "label" in entry
-        assert "created_at" in entry
-        assert "agent_count" in entry
+    assert agent_row.registered_at == session_row.created_at
 
 
-class TestGetSession:
-    """broker.get_session(session_id) → dict or None."""
+def test_create_session_administrator_seed__list_session_agents_marks_administrator_kind():
+    """broker.list_session_agents exposes ``kind`` per agent; the
+    auto-seeded Administrator has ``kind == 'builtin-administrator'``
+    and is the only such entry. The root Director is ``kind == 'user'``.
+    """
+    result = _create_session()
+    sid = result["session_id"]
 
-    def test_returns_dict_for_existing_session(self):
-        created = _create_session(label="find-me")
-        result = broker.get_session(created["session_id"])
+    # Register a regular user agent alongside to verify the kind split.
+    _register_agent(sid, name="user-agent")
 
-        assert result is not None
-        assert result["session_id"] == created["session_id"]
-        assert result["label"] == "find-me"
-        assert "created_at" in result
+    entries = broker.list_session_agents(sid)
+    # Three entries: root Director + Administrator + user-agent (design 0000026).
+    assert len(entries) == 3
 
-    def test_returns_none_for_nonexistent_session(self):
-        result = broker.get_session(str(uuid.uuid4()))
-        assert result is None
+    admin_entries = [e for e in entries if e["kind"] == ADMINISTRATOR_KIND]
+    user_entries = [e for e in entries if e["kind"] == "user"]
+    # Exactly one Administrator, two user-kind (director + user-agent).
+    assert len(admin_entries) == 1
+    assert len(user_entries) == 2
+    assert admin_entries[0]["name"] == "Administrator"
+    assert admin_entries[0]["agent_id"] == result["administrator_agent_id"]
+    user_names = {e["name"] for e in user_entries}
+    assert "Director" in user_names
+    assert "user-agent" in user_names
+
+
+def test_create_session_administrator_seed__each_session_gets_its_own_administrator():
+    """Two calls to create_session produce two distinct Administrators."""
+    r1 = _create_session()
+    r2 = _create_session()
+    assert r1["administrator_agent_id"] != r2["administrator_agent_id"]
+
+
+# --- list_sessions: broker.list_sessions() → list of dicts with agent_count ---
+
+
+def test_list_sessions__empty_returns_empty_list():
+    result = broker.list_sessions()
+    assert result == []
+
+
+def test_list_sessions__returns_created_sessions():
+    _create_session(label="session-a")
+    _create_session(label="session-b")
+
+    result = broker.list_sessions()
+    assert len(result) == 2
+    labels = {s["label"] for s in result}
+    assert "session-a" in labels
+    assert "session-b" in labels
+
+
+def test_list_sessions__includes_agent_count():
+    """Count includes the root Director, auto-seeded Administrator, and user agents."""
+    session = _create_session()
+    sid = session["session_id"]
+
+    _register_agent(sid, name="agent-1")
+    _register_agent(sid, name="agent-2")
+
+    result = broker.list_sessions()
+    assert len(result) == 1
+    # 2 user agents + 1 root Director + 1 Administrator (design 0000026).
+    assert result[0]["agent_count"] == 4
+
+
+def test_list_sessions__agent_count_excludes_deregistered():
+    """Deregistered user agents are excluded.
+
+    Root Director and Administrator remain active after bootstrap
+    (design 0000026), so the count floors at 2 for a session with
+    no live user agents.
+    """
+    session = _create_session()
+    sid = session["session_id"]
+
+    _register_agent(sid, name="active-agent")
+    agent2 = _register_agent(sid, name="dead-agent")
+    broker.deregister_agent(agent2["agent_id"])
+
+    result = broker.list_sessions()
+    # 1 active user agent + 1 root Director + 1 Administrator.
+    assert result[0]["agent_count"] == 3
+
+
+def test_list_sessions__session_with_only_bootstrap_agents_has_count_two():
+    """A freshly-bootstrapped session has exactly the Director + Administrator."""
+    _create_session()
+
+    result = broker.list_sessions()
+    # Root Director + Administrator seeded by create_session (design 0000026).
+    assert result[0]["agent_count"] == 2
+
+
+def test_list_sessions__result_contains_required_keys():
+    _create_session(label="test")
+
+    result = broker.list_sessions()
+    entry = result[0]
+    assert "session_id" in entry
+    assert "label" in entry
+    assert "created_at" in entry
+    assert "agent_count" in entry
+
+
+# --- get_session: broker.get_session(session_id) → dict or None ---
+
+
+def test_get_session__returns_dict_for_existing_session():
+    created = _create_session(label="find-me")
+    result = broker.get_session(created["session_id"])
+
+    assert result is not None
+    assert result["session_id"] == created["session_id"]
+    assert result["label"] == "find-me"
+    assert "created_at" in result
+
+
+def test_get_session__returns_none_for_nonexistent_session():
+    result = broker.get_session(str(uuid.uuid4()))
+    assert result is None
 
 
 # NOTE: The former ``TestDeleteSession`` class is removed in this file.
@@ -282,496 +296,525 @@ class TestGetSession:
 # ``tests/test_session_bootstrap.py::TestDeleteSessionCascade``.
 
 
-class TestRegisterAgent:
-    """broker.register_agent() → dict with agent_id, name, registered_at."""
-
-    def test_returns_dict_with_required_keys(self):
-        session = _create_session()
-        result = _register_agent(session["session_id"])
-
-        assert isinstance(result, dict)
-        assert "agent_id" in result
-        assert "name" in result
-        assert "registered_at" in result
-
-    def test_agent_id_is_valid_uuid(self):
-        session = _create_session()
-        result = _register_agent(session["session_id"])
-        uuid.UUID(result["agent_id"])
-
-    def test_name_is_stored(self):
-        session = _create_session()
-        result = _register_agent(session["session_id"], name="my-agent")
-        assert result["name"] == "my-agent"
-
-    def test_validates_session_exists(self):
-        """Registering with a non-existent session_id should raise an error."""
-        fake_sid = str(uuid.uuid4())
-        with pytest.raises(click.UsageError, match="not found"):
-            broker.register_agent(
-                session_id=fake_sid,
-                name="orphan",
-                description="no session",
-            )
-
-    def test_each_call_mints_unique_agent_id(self):
-        session = _create_session()
-        r1 = _register_agent(session["session_id"], name="a1")
-        r2 = _register_agent(session["session_id"], name="a2")
-        assert r1["agent_id"] != r2["agent_id"]
-
-    def test_register_with_placement(self):
-        """When placement is provided, validates director and stores placement."""
-        session = _create_session()
-        sid = session["session_id"]
-
-        # Register a director first
-        director = _register_agent(sid, name="director")
-
-        # Register member with placement
-        placement = {
-            "director_agent_id": director["agent_id"],
-            "tmux_session": "main",
-            "tmux_window_id": "@1",
-            "tmux_pane_id": None,
-            "coding_agent": "claude",
-        }
-        member = _register_agent(sid, name="member", placement=placement)
-
-        # Verify placement was stored by fetching the agent
-        agent = broker.get_agent(member["agent_id"], sid)
-        assert agent is not None
-        assert agent["placement"] is not None
-        assert agent["placement"]["director_agent_id"] == director["agent_id"]
-        assert agent["placement"]["tmux_session"] == "main"
-        assert agent["placement"]["tmux_window_id"] == "@1"
-
-    def test_placement_validates_director_exists(self):
-        """Placement with non-existent director should raise an error."""
-        session = _create_session()
-        sid = session["session_id"]
-
-        placement = {
-            "director_agent_id": str(uuid.uuid4()),  # non-existent
-            "tmux_session": "main",
-            "tmux_window_id": "@1",
-            "tmux_pane_id": None,
-            "coding_agent": "claude",
-        }
-        with pytest.raises(click.UsageError, match="Director agent"):
-            _register_agent(sid, name="orphan-member", placement=placement)
-
-    def test_placement_validates_director_active_in_same_session(self):
-        """Director must be active and in the same session."""
-
-        session1 = _create_session()
-        session2 = _create_session()
-
-        director = _register_agent(session1["session_id"], name="director")
-
-        # Try to place member in session2 referencing director in session1
-        placement = {
-            "director_agent_id": director["agent_id"],
-            "tmux_session": "main",
-            "tmux_window_id": "@1",
-            "tmux_pane_id": None,
-            "coding_agent": "claude",
-        }
-        with pytest.raises(click.UsageError, match="Director agent"):
-            _register_agent(
-                session2["session_id"], name="cross-session-member", placement=placement
-            )
-
-    def test_placement_validates_director_is_active(self):
-        """Deregistered director should not accept new placements."""
-        session = _create_session()
-        sid = session["session_id"]
-
-        director = _register_agent(sid, name="director")
-        broker.deregister_agent(director["agent_id"])
-
-        placement = {
-            "director_agent_id": director["agent_id"],
-            "tmux_session": "main",
-            "tmux_window_id": "@1",
-            "tmux_pane_id": None,
-            "coding_agent": "claude",
-        }
-        with pytest.raises(click.UsageError, match="not active"):
-            _register_agent(sid, name="late-member", placement=placement)
-
-    def test_register_without_placement(self):
-        """Agent without placement has no placement row."""
-        session = _create_session()
-        sid = session["session_id"]
-
-        agent = _register_agent(sid, name="standalone")
-        fetched = broker.get_agent(agent["agent_id"], sid)
-        assert fetched is not None
-        assert fetched["placement"] is None
+# --- register_agent: broker.register_agent() → dict with agent_id, name, registered_at ---
 
 
-class TestGetAgent:
-    """broker.get_agent(agent_id, session_id) → dict or None."""
+def test_register_agent__returns_dict_with_required_keys():
+    session = _create_session()
+    result = _register_agent(session["session_id"])
 
-    def test_returns_agent_dict(self):
-        session = _create_session()
-        sid = session["session_id"]
-        agent = _register_agent(sid, name="visible", description="test desc")
-
-        result = broker.get_agent(agent["agent_id"], sid)
-        assert result is not None
-        assert result["agent_id"] == agent["agent_id"]
-        assert result["name"] == "visible"
-        assert result["description"] == "test desc"
-        assert result["status"] == "active"
-        assert "registered_at" in result
-
-    def test_includes_placement_when_present(self):
-        session = _create_session()
-        sid = session["session_id"]
-        director = _register_agent(sid, name="director")
-        placement = {
-            "director_agent_id": director["agent_id"],
-            "tmux_session": "main",
-            "tmux_window_id": "@1",
-            "tmux_pane_id": None,
-            "coding_agent": "claude",
-        }
-        member = _register_agent(sid, name="member", placement=placement)
-
-        result = broker.get_agent(member["agent_id"], sid)
-        assert result is not None
-        assert result["placement"] is not None
-        assert result["placement"]["director_agent_id"] == director["agent_id"]
-
-    def test_returns_none_for_nonexistent_agent(self):
-        session = _create_session()
-        result = broker.get_agent(str(uuid.uuid4()), session["session_id"])
-        assert result is None
-
-    def test_excludes_deregistered_agents(self):
-        session = _create_session()
-        sid = session["session_id"]
-        agent = _register_agent(sid, name="temp")
-        broker.deregister_agent(agent["agent_id"])
-
-        result = broker.get_agent(agent["agent_id"], sid)
-        assert result is None
-
-    def test_filters_by_session(self):
-        """Agent in session A is not visible when querying session B."""
-        session_a = _create_session()
-        session_b = _create_session()
-        agent = _register_agent(session_a["session_id"], name="scoped")
-
-        result = broker.get_agent(agent["agent_id"], session_b["session_id"])
-        assert result is None
+    assert isinstance(result, dict)
+    assert "agent_id" in result
+    assert "name" in result
+    assert "registered_at" in result
 
 
-class TestListAgents:
-    """broker.list_agents(session_id) → list of active agents."""
-
-    def test_returns_active_agents_only(self):
-        """list_agents returns all active agents including the bootstrap pair."""
-        session = _create_session()
-        sid = session["session_id"]
-
-        _register_agent(sid, name="active-1")
-        _register_agent(sid, name="active-2")
-        dead = _register_agent(sid, name="dead-agent")
-        broker.deregister_agent(dead["agent_id"])
-
-        result = broker.list_agents(sid)
-        # 2 active user agents + root Director + Administrator (design 0000026).
-        assert len(result) == 4
-        names = {a["name"] for a in result}
-        assert "active-1" in names
-        assert "active-2" in names
-        assert "Director" in names
-        assert "Administrator" in names
-        assert "dead-agent" not in names
-
-    def test_newly_created_session_lists_bootstrap_agents(self):
-        """A freshly created session has exactly the root Director + Administrator."""
-        session = _create_session()
-        result = broker.list_agents(session["session_id"])
-        assert len(result) == 2
-        names = {a["name"] for a in result}
-        assert names == {"Director", "Administrator"}
-
-    def test_agents_scoped_to_session(self):
-        """Agents from other sessions are not included. Each session has its own
-        bootstrap pair (root Director + Administrator).
-        """
-        session_a = _create_session()
-        session_b = _create_session()
-
-        _register_agent(session_a["session_id"], name="agent-a")
-        _register_agent(session_b["session_id"], name="agent-b")
-
-        result_a = broker.list_agents(session_a["session_id"])
-        # Director (A) + Administrator (A) + agent-a.
-        assert len(result_a) == 3
-        names_a = {a["name"] for a in result_a}
-        assert "agent-a" in names_a
-        assert "Director" in names_a
-        assert "Administrator" in names_a
-        assert "agent-b" not in names_a
-
-    def test_result_contains_required_keys(self):
-        session = _create_session()
-        _register_agent(session["session_id"], name="keyed")
-
-        result = broker.list_agents(session["session_id"])
-        agent = result[0]
-        assert "agent_id" in agent
-        assert "name" in agent
-        assert "description" in agent
-        assert agent["status"] == "active"
-        assert "registered_at" in agent
+def test_register_agent__agent_id_is_valid_uuid():
+    session = _create_session()
+    result = _register_agent(session["session_id"])
+    uuid.UUID(result["agent_id"])
 
 
-class TestVerifyAgentSession:
-    """broker.verify_agent_session(agent_id, session_id) → bool."""
+def test_register_agent__name_is_stored():
+    session = _create_session()
+    result = _register_agent(session["session_id"], name="my-agent")
+    assert result["name"] == "my-agent"
 
-    def test_returns_true_for_agent_in_session(self):
-        session = _create_session()
-        sid = session["session_id"]
-        agent = _register_agent(sid, name="here")
 
-        assert broker.verify_agent_session(agent["agent_id"], sid) is True
-
-    def test_returns_false_for_agent_in_different_session(self):
-        session_a = _create_session()
-        session_b = _create_session()
-        agent = _register_agent(session_a["session_id"], name="there")
-
-        assert (
-            broker.verify_agent_session(agent["agent_id"], session_b["session_id"])
-            is False
-        )
-
-    def test_returns_false_for_nonexistent_agent(self):
-        session = _create_session()
-        assert (
-            broker.verify_agent_session(str(uuid.uuid4()), session["session_id"])
-            is False
+def test_register_agent__validates_session_exists():
+    """Registering with a non-existent session_id should raise an error."""
+    fake_sid = str(uuid.uuid4())
+    with pytest.raises(click.UsageError, match="not found"):
+        broker.register_agent(
+            session_id=fake_sid,
+            name="orphan",
+            description="no session",
         )
 
 
-class TestDeregisterAgent:
-    """broker.deregister_agent(agent_id) → bool."""
-
-    def test_returns_true_and_deregisters_active_agent(self):
-        """Deregistering a user agent leaves the bootstrap pair intact."""
-        session = _create_session()
-        sid = session["session_id"]
-        agent = _register_agent(sid, name="retiring")
-
-        result = broker.deregister_agent(agent["agent_id"])
-        assert result is True
-
-        # The retiring user agent is gone; the bootstrap Director and
-        # Administrator remain (design 0000026).
-        names = {a["name"] for a in broker.list_agents(sid)}
-        assert names == {"Director", "Administrator"}
-
-    def test_sets_deregistered_status_and_timestamp(self):
-        """After deregistering, status is 'deregistered' and deregistered_at is set."""
-        session = _create_session()
-        sid = session["session_id"]
-        agent = _register_agent(sid, name="retiring")
-
-        broker.deregister_agent(agent["agent_id"])
-
-        # get_agent excludes deregistered, so verify via list_agents or DB.
-        # Use verify_agent_session to confirm the agent still belongs to session
-        # (it's deregistered, not deleted)
-        assert broker.verify_agent_session(agent["agent_id"], sid) is True
-
-    def test_deletes_placement_on_deregister(self):
-        session = _create_session()
-        sid = session["session_id"]
-        director = _register_agent(sid, name="director")
-        placement = {
-            "director_agent_id": director["agent_id"],
-            "tmux_session": "main",
-            "tmux_window_id": "@1",
-            "tmux_pane_id": None,
-            "coding_agent": "claude",
-        }
-        member = _register_agent(sid, name="member", placement=placement)
-
-        broker.deregister_agent(member["agent_id"])
-
-        # Placement should be gone — update_placement_pane_id should return None
-        result = broker.update_placement_pane_id(member["agent_id"], "%99")
-        assert result is None
-
-    def test_returns_false_for_already_deregistered(self):
-        session = _create_session()
-        agent = _register_agent(session["session_id"], name="double-dereg")
-
-        broker.deregister_agent(agent["agent_id"])
-        result = broker.deregister_agent(agent["agent_id"])
-        assert result is False
-
-    def test_returns_false_for_nonexistent_agent(self):
-        result = broker.deregister_agent(str(uuid.uuid4()))
-        assert result is False
+def test_register_agent__each_call_mints_unique_agent_id():
+    session = _create_session()
+    r1 = _register_agent(session["session_id"], name="a1")
+    r2 = _register_agent(session["session_id"], name="a2")
+    assert r1["agent_id"] != r2["agent_id"]
 
 
-class TestUpdatePlacementPaneId:
-    """broker.update_placement_pane_id(agent_id, pane_id) → dict or None."""
+def test_register_agent__register_with_placement():
+    """When placement is provided, validates director and stores placement."""
+    session = _create_session()
+    sid = session["session_id"]
 
-    def test_updates_pane_id_returns_placement(self):
-        session = _create_session()
-        sid = session["session_id"]
-        director = _register_agent(sid, name="director")
-        placement = {
-            "director_agent_id": director["agent_id"],
-            "tmux_session": "main",
-            "tmux_window_id": "@1",
-            "tmux_pane_id": None,
-            "coding_agent": "claude",
-        }
-        member = _register_agent(sid, name="member", placement=placement)
+    # Register a director first
+    director = _register_agent(sid, name="director")
 
-        result = broker.update_placement_pane_id(member["agent_id"], "%42")
-        assert result is not None
-        assert result["tmux_pane_id"] == "%42"
+    # Register member with placement
+    placement = {
+        "director_agent_id": director["agent_id"],
+        "tmux_session": "main",
+        "tmux_window_id": "@1",
+        "tmux_pane_id": None,
+        "coding_agent": "claude",
+    }
+    member = _register_agent(sid, name="member", placement=placement)
 
-    def test_returns_none_when_no_placement(self):
-        session = _create_session()
-        agent = _register_agent(session["session_id"], name="no-placement")
-
-        result = broker.update_placement_pane_id(agent["agent_id"], "%99")
-        assert result is None
-
-    def test_returns_none_for_nonexistent_agent(self):
-        result = broker.update_placement_pane_id(str(uuid.uuid4()), "%1")
-        assert result is None
-
-    def test_pane_id_persists_after_update(self):
-        """After updating pane_id, get_agent should reflect it."""
-        session = _create_session()
-        sid = session["session_id"]
-        director = _register_agent(sid, name="director")
-        placement = {
-            "director_agent_id": director["agent_id"],
-            "tmux_session": "main",
-            "tmux_window_id": "@1",
-            "tmux_pane_id": None,
-            "coding_agent": "claude",
-        }
-        member = _register_agent(sid, name="member", placement=placement)
-
-        broker.update_placement_pane_id(member["agent_id"], "%77")
-
-        fetched = broker.get_agent(member["agent_id"], sid)
-        assert fetched is not None
-        assert fetched["placement"]["tmux_pane_id"] == "%77"
+    # Verify placement was stored by fetching the agent
+    agent = broker.get_agent(member["agent_id"], sid)
+    assert agent is not None
+    assert agent["placement"] is not None
+    assert agent["placement"]["director_agent_id"] == director["agent_id"]
+    assert agent["placement"]["tmux_session"] == "main"
+    assert agent["placement"]["tmux_window_id"] == "@1"
 
 
-class TestListMembers:
-    """broker.list_members(session_id, director_agent_id) → list with placement."""
+def test_register_agent__placement_validates_director_exists():
+    """Placement with non-existent director should raise an error."""
+    session = _create_session()
+    sid = session["session_id"]
 
-    def test_returns_members_for_director(self):
-        session = _create_session()
-        sid = session["session_id"]
-        director = _register_agent(sid, name="director")
-        did = director["agent_id"]
+    placement = {
+        "director_agent_id": str(uuid.uuid4()),  # non-existent
+        "tmux_session": "main",
+        "tmux_window_id": "@1",
+        "tmux_pane_id": None,
+        "coding_agent": "claude",
+    }
+    with pytest.raises(click.UsageError, match="Director agent"):
+        _register_agent(sid, name="orphan-member", placement=placement)
 
-        placement = {
-            "director_agent_id": did,
-            "tmux_session": "main",
-            "tmux_window_id": "@1",
-            "tmux_pane_id": None,
-            "coding_agent": "claude",
-        }
-        _register_agent(sid, name="member-1", placement=placement)
-        _register_agent(sid, name="member-2", placement=placement)
 
-        result = broker.list_members(sid, did)
-        assert len(result) == 2
-        names = {m["name"] for m in result}
-        assert "member-1" in names
-        assert "member-2" in names
+def test_register_agent__placement_validates_director_active_in_same_session():
+    """Director must be active and in the same session."""
 
-    def test_includes_placement_info(self):
-        session = _create_session()
-        sid = session["session_id"]
-        director = _register_agent(sid, name="director")
-        did = director["agent_id"]
+    session1 = _create_session()
+    session2 = _create_session()
 
-        placement = {
-            "director_agent_id": did,
-            "tmux_session": "main",
-            "tmux_window_id": "@1",
-            "tmux_pane_id": None,
-            "coding_agent": "claude",
-        }
-        _register_agent(sid, name="member", placement=placement)
+    director = _register_agent(session1["session_id"], name="director")
 
-        result = broker.list_members(sid, did)
-        assert len(result) == 1
-        member = result[0]
-        assert "placement" in member
-        assert member["placement"] is not None
-        assert member["placement"]["tmux_session"] == "main"
-        assert member["placement"]["tmux_window_id"] == "@1"
-        assert member["placement"]["director_agent_id"] == did
+    # Try to place member in session2 referencing director in session1
+    placement = {
+        "director_agent_id": director["agent_id"],
+        "tmux_session": "main",
+        "tmux_window_id": "@1",
+        "tmux_pane_id": None,
+        "coding_agent": "claude",
+    }
+    with pytest.raises(click.UsageError, match="Director agent"):
+        _register_agent(
+            session2["session_id"], name="cross-session-member", placement=placement
+        )
 
-    def test_returns_empty_list_when_no_members(self):
-        session = _create_session()
-        sid = session["session_id"]
-        director = _register_agent(sid, name="lonely-director")
 
-        result = broker.list_members(sid, director["agent_id"])
-        assert result == []
+def test_register_agent__placement_validates_director_is_active():
+    """Deregistered director should not accept new placements."""
+    session = _create_session()
+    sid = session["session_id"]
 
-    def test_excludes_members_of_other_directors(self):
-        session = _create_session()
-        sid = session["session_id"]
-        dir1 = _register_agent(sid, name="director-1")
-        dir2 = _register_agent(sid, name="director-2")
+    director = _register_agent(sid, name="director")
+    broker.deregister_agent(director["agent_id"])
 
-        placement1 = {
-            "director_agent_id": dir1["agent_id"],
-            "tmux_session": "main",
-            "tmux_window_id": "@1",
-            "tmux_pane_id": None,
-            "coding_agent": "claude",
-        }
-        placement2 = {
-            "director_agent_id": dir2["agent_id"],
-            "tmux_session": "main",
-            "tmux_window_id": "@2",
-            "tmux_pane_id": None,
-            "coding_agent": "claude",
-        }
-        _register_agent(sid, name="m1-of-d1", placement=placement1)
-        _register_agent(sid, name="m2-of-d2", placement=placement2)
+    placement = {
+        "director_agent_id": director["agent_id"],
+        "tmux_session": "main",
+        "tmux_window_id": "@1",
+        "tmux_pane_id": None,
+        "coding_agent": "claude",
+    }
+    with pytest.raises(click.UsageError, match="not active"):
+        _register_agent(sid, name="late-member", placement=placement)
 
-        result = broker.list_members(sid, dir1["agent_id"])
-        assert len(result) == 1
-        assert result[0]["name"] == "m1-of-d1"
 
-    def test_includes_agent_status(self):
-        session = _create_session()
-        sid = session["session_id"]
-        director = _register_agent(sid, name="director")
-        did = director["agent_id"]
+def test_register_agent__register_without_placement():
+    """Agent without placement has no placement row."""
+    session = _create_session()
+    sid = session["session_id"]
 
-        placement = {
-            "director_agent_id": did,
-            "tmux_session": "main",
-            "tmux_window_id": "@1",
-            "tmux_pane_id": None,
-            "coding_agent": "claude",
-        }
-        _register_agent(sid, name="member", placement=placement)
+    agent = _register_agent(sid, name="standalone")
+    fetched = broker.get_agent(agent["agent_id"], sid)
+    assert fetched is not None
+    assert fetched["placement"] is None
 
-        result = broker.list_members(sid, did)
-        assert result[0]["status"] == "active"
+
+# --- get_agent: broker.get_agent(agent_id, session_id) → dict or None ---
+
+
+def test_get_agent__returns_agent_dict():
+    session = _create_session()
+    sid = session["session_id"]
+    agent = _register_agent(sid, name="visible", description="test desc")
+
+    result = broker.get_agent(agent["agent_id"], sid)
+    assert result is not None
+    assert result["agent_id"] == agent["agent_id"]
+    assert result["name"] == "visible"
+    assert result["description"] == "test desc"
+    assert result["status"] == "active"
+    assert "registered_at" in result
+
+
+def test_get_agent__includes_placement_when_present():
+    session = _create_session()
+    sid = session["session_id"]
+    director = _register_agent(sid, name="director")
+    placement = {
+        "director_agent_id": director["agent_id"],
+        "tmux_session": "main",
+        "tmux_window_id": "@1",
+        "tmux_pane_id": None,
+        "coding_agent": "claude",
+    }
+    member = _register_agent(sid, name="member", placement=placement)
+
+    result = broker.get_agent(member["agent_id"], sid)
+    assert result is not None
+    assert result["placement"] is not None
+    assert result["placement"]["director_agent_id"] == director["agent_id"]
+
+
+def test_get_agent__returns_none_for_nonexistent_agent():
+    session = _create_session()
+    result = broker.get_agent(str(uuid.uuid4()), session["session_id"])
+    assert result is None
+
+
+def test_get_agent__excludes_deregistered_agents():
+    session = _create_session()
+    sid = session["session_id"]
+    agent = _register_agent(sid, name="temp")
+    broker.deregister_agent(agent["agent_id"])
+
+    result = broker.get_agent(agent["agent_id"], sid)
+    assert result is None
+
+
+def test_get_agent__filters_by_session():
+    """Agent in session A is not visible when querying session B."""
+    session_a = _create_session()
+    session_b = _create_session()
+    agent = _register_agent(session_a["session_id"], name="scoped")
+
+    result = broker.get_agent(agent["agent_id"], session_b["session_id"])
+    assert result is None
+
+
+# --- list_agents: broker.list_agents(session_id) → list of active agents ---
+
+
+def test_list_agents__returns_active_agents_only():
+    """list_agents returns all active agents including the bootstrap pair."""
+    session = _create_session()
+    sid = session["session_id"]
+
+    _register_agent(sid, name="active-1")
+    _register_agent(sid, name="active-2")
+    dead = _register_agent(sid, name="dead-agent")
+    broker.deregister_agent(dead["agent_id"])
+
+    result = broker.list_agents(sid)
+    # 2 active user agents + root Director + Administrator (design 0000026).
+    assert len(result) == 4
+    names = {a["name"] for a in result}
+    assert "active-1" in names
+    assert "active-2" in names
+    assert "Director" in names
+    assert "Administrator" in names
+    assert "dead-agent" not in names
+
+
+def test_list_agents__newly_created_session_lists_bootstrap_agents():
+    """A freshly created session has exactly the root Director + Administrator."""
+    session = _create_session()
+    result = broker.list_agents(session["session_id"])
+    assert len(result) == 2
+    names = {a["name"] for a in result}
+    assert names == {"Director", "Administrator"}
+
+
+def test_list_agents__agents_scoped_to_session():
+    """Agents from other sessions are not included. Each session has its own
+    bootstrap pair (root Director + Administrator).
+    """
+    session_a = _create_session()
+    session_b = _create_session()
+
+    _register_agent(session_a["session_id"], name="agent-a")
+    _register_agent(session_b["session_id"], name="agent-b")
+
+    result_a = broker.list_agents(session_a["session_id"])
+    # Director (A) + Administrator (A) + agent-a.
+    assert len(result_a) == 3
+    names_a = {a["name"] for a in result_a}
+    assert "agent-a" in names_a
+    assert "Director" in names_a
+    assert "Administrator" in names_a
+    assert "agent-b" not in names_a
+
+
+def test_list_agents__result_contains_required_keys():
+    session = _create_session()
+    _register_agent(session["session_id"], name="keyed")
+
+    result = broker.list_agents(session["session_id"])
+    agent = result[0]
+    assert "agent_id" in agent
+    assert "name" in agent
+    assert "description" in agent
+    assert agent["status"] == "active"
+    assert "registered_at" in agent
+
+
+# --- verify_agent_session: broker.verify_agent_session(agent_id, session_id) → bool ---
+
+
+def test_verify_agent_session__returns_true_for_agent_in_session():
+    session = _create_session()
+    sid = session["session_id"]
+    agent = _register_agent(sid, name="here")
+
+    assert broker.verify_agent_session(agent["agent_id"], sid) is True
+
+
+def test_verify_agent_session__returns_false_for_agent_in_different_session():
+    session_a = _create_session()
+    session_b = _create_session()
+    agent = _register_agent(session_a["session_id"], name="there")
+
+    assert (
+        broker.verify_agent_session(agent["agent_id"], session_b["session_id"])
+        is False
+    )
+
+
+def test_verify_agent_session__returns_false_for_nonexistent_agent():
+    session = _create_session()
+    assert (
+        broker.verify_agent_session(str(uuid.uuid4()), session["session_id"])
+        is False
+    )
+
+
+# --- deregister_agent: broker.deregister_agent(agent_id) → bool ---
+
+
+def test_deregister_agent__returns_true_and_deregisters_active_agent():
+    """Deregistering a user agent leaves the bootstrap pair intact."""
+    session = _create_session()
+    sid = session["session_id"]
+    agent = _register_agent(sid, name="retiring")
+
+    result = broker.deregister_agent(agent["agent_id"])
+    assert result is True
+
+    # The retiring user agent is gone; the bootstrap Director and
+    # Administrator remain (design 0000026).
+    names = {a["name"] for a in broker.list_agents(sid)}
+    assert names == {"Director", "Administrator"}
+
+
+def test_deregister_agent__sets_deregistered_status_and_timestamp():
+    """After deregistering, status is 'deregistered' and deregistered_at is set."""
+    session = _create_session()
+    sid = session["session_id"]
+    agent = _register_agent(sid, name="retiring")
+
+    broker.deregister_agent(agent["agent_id"])
+
+    # get_agent excludes deregistered, so verify via list_agents or DB.
+    # Use verify_agent_session to confirm the agent still belongs to session
+    # (it's deregistered, not deleted)
+    assert broker.verify_agent_session(agent["agent_id"], sid) is True
+
+
+def test_deregister_agent__deletes_placement_on_deregister():
+    session = _create_session()
+    sid = session["session_id"]
+    director = _register_agent(sid, name="director")
+    placement = {
+        "director_agent_id": director["agent_id"],
+        "tmux_session": "main",
+        "tmux_window_id": "@1",
+        "tmux_pane_id": None,
+        "coding_agent": "claude",
+    }
+    member = _register_agent(sid, name="member", placement=placement)
+
+    broker.deregister_agent(member["agent_id"])
+
+    # Placement should be gone — update_placement_pane_id should return None
+    result = broker.update_placement_pane_id(member["agent_id"], "%99")
+    assert result is None
+
+
+def test_deregister_agent__returns_false_for_already_deregistered():
+    session = _create_session()
+    agent = _register_agent(session["session_id"], name="double-dereg")
+
+    broker.deregister_agent(agent["agent_id"])
+    result = broker.deregister_agent(agent["agent_id"])
+    assert result is False
+
+
+def test_deregister_agent__returns_false_for_nonexistent_agent():
+    result = broker.deregister_agent(str(uuid.uuid4()))
+    assert result is False
+
+
+# --- update_placement_pane_id: broker.update_placement_pane_id(agent_id, pane_id) → dict or None ---
+
+
+def test_update_placement_pane_id__updates_pane_id_returns_placement():
+    session = _create_session()
+    sid = session["session_id"]
+    director = _register_agent(sid, name="director")
+    placement = {
+        "director_agent_id": director["agent_id"],
+        "tmux_session": "main",
+        "tmux_window_id": "@1",
+        "tmux_pane_id": None,
+        "coding_agent": "claude",
+    }
+    member = _register_agent(sid, name="member", placement=placement)
+
+    result = broker.update_placement_pane_id(member["agent_id"], "%42")
+    assert result is not None
+    assert result["tmux_pane_id"] == "%42"
+
+
+def test_update_placement_pane_id__returns_none_when_no_placement():
+    session = _create_session()
+    agent = _register_agent(session["session_id"], name="no-placement")
+
+    result = broker.update_placement_pane_id(agent["agent_id"], "%99")
+    assert result is None
+
+
+def test_update_placement_pane_id__returns_none_for_nonexistent_agent():
+    result = broker.update_placement_pane_id(str(uuid.uuid4()), "%1")
+    assert result is None
+
+
+def test_update_placement_pane_id__pane_id_persists_after_update():
+    """After updating pane_id, get_agent should reflect it."""
+    session = _create_session()
+    sid = session["session_id"]
+    director = _register_agent(sid, name="director")
+    placement = {
+        "director_agent_id": director["agent_id"],
+        "tmux_session": "main",
+        "tmux_window_id": "@1",
+        "tmux_pane_id": None,
+        "coding_agent": "claude",
+    }
+    member = _register_agent(sid, name="member", placement=placement)
+
+    broker.update_placement_pane_id(member["agent_id"], "%77")
+
+    fetched = broker.get_agent(member["agent_id"], sid)
+    assert fetched is not None
+    assert fetched["placement"]["tmux_pane_id"] == "%77"
+
+
+# --- list_members: broker.list_members(session_id, director_agent_id) → list with placement ---
+
+
+def test_list_members__returns_members_for_director():
+    session = _create_session()
+    sid = session["session_id"]
+    director = _register_agent(sid, name="director")
+    did = director["agent_id"]
+
+    placement = {
+        "director_agent_id": did,
+        "tmux_session": "main",
+        "tmux_window_id": "@1",
+        "tmux_pane_id": None,
+        "coding_agent": "claude",
+    }
+    _register_agent(sid, name="member-1", placement=placement)
+    _register_agent(sid, name="member-2", placement=placement)
+
+    result = broker.list_members(sid, did)
+    assert len(result) == 2
+    names = {m["name"] for m in result}
+    assert "member-1" in names
+    assert "member-2" in names
+
+
+def test_list_members__includes_placement_info():
+    session = _create_session()
+    sid = session["session_id"]
+    director = _register_agent(sid, name="director")
+    did = director["agent_id"]
+
+    placement = {
+        "director_agent_id": did,
+        "tmux_session": "main",
+        "tmux_window_id": "@1",
+        "tmux_pane_id": None,
+        "coding_agent": "claude",
+    }
+    _register_agent(sid, name="member", placement=placement)
+
+    result = broker.list_members(sid, did)
+    assert len(result) == 1
+    member = result[0]
+    assert "placement" in member
+    assert member["placement"] is not None
+    assert member["placement"]["tmux_session"] == "main"
+    assert member["placement"]["tmux_window_id"] == "@1"
+    assert member["placement"]["director_agent_id"] == did
+
+
+def test_list_members__returns_empty_list_when_no_members():
+    session = _create_session()
+    sid = session["session_id"]
+    director = _register_agent(sid, name="lonely-director")
+
+    result = broker.list_members(sid, director["agent_id"])
+    assert result == []
+
+
+def test_list_members__excludes_members_of_other_directors():
+    session = _create_session()
+    sid = session["session_id"]
+    dir1 = _register_agent(sid, name="director-1")
+    dir2 = _register_agent(sid, name="director-2")
+
+    placement1 = {
+        "director_agent_id": dir1["agent_id"],
+        "tmux_session": "main",
+        "tmux_window_id": "@1",
+        "tmux_pane_id": None,
+        "coding_agent": "claude",
+    }
+    placement2 = {
+        "director_agent_id": dir2["agent_id"],
+        "tmux_session": "main",
+        "tmux_window_id": "@2",
+        "tmux_pane_id": None,
+        "coding_agent": "claude",
+    }
+    _register_agent(sid, name="m1-of-d1", placement=placement1)
+    _register_agent(sid, name="m2-of-d2", placement=placement2)
+
+    result = broker.list_members(sid, dir1["agent_id"])
+    assert len(result) == 1
+    assert result[0]["name"] == "m1-of-d1"
+
+
+def test_list_members__includes_agent_status():
+    session = _create_session()
+    sid = session["session_id"]
+    director = _register_agent(sid, name="director")
+    did = director["agent_id"]
+
+    placement = {
+        "director_agent_id": did,
+        "tmux_session": "main",
+        "tmux_window_id": "@1",
+        "tmux_pane_id": None,
+        "coding_agent": "claude",
+    }
+    _register_agent(sid, name="member", placement=placement)
+
+    result = broker.list_members(sid, did)
+    assert result[0]["status"] == "active"

--- a/cafleet/tests/test_broker_registry.py
+++ b/cafleet/tests/test_broker_registry.py
@@ -113,7 +113,9 @@ def test_create_session_administrator_seed__administrator_agent_id_is_valid_uuid
     uuid.UUID(result["administrator_agent_id"])
 
 
-def test_create_session_administrator_seed__administrator_row_exists_in_db_and_is_active(broker_session):
+def test_create_session_administrator_seed__administrator_row_exists_in_db_and_is_active(
+    broker_session,
+):
     """After create_session, exactly one active Administrator agent exists
     for that session in the agents table.
 
@@ -151,9 +153,7 @@ def test_create_session_administrator_seed__administrator_registered_at_equals_s
     admin_id = result["administrator_agent_id"]
 
     with broker_session() as s:
-        session_row = (
-            s.query(SessionModel).filter(SessionModel.session_id == sid).one()
-        )
+        session_row = s.query(SessionModel).filter(SessionModel.session_id == sid).one()
         agent_row = s.query(Agent).filter(Agent.agent_id == admin_id).one()
 
     assert agent_row.registered_at == session_row.created_at
@@ -579,16 +579,14 @@ def test_verify_agent_session__returns_false_for_agent_in_different_session():
     agent = _register_agent(session_a["session_id"], name="there")
 
     assert (
-        broker.verify_agent_session(agent["agent_id"], session_b["session_id"])
-        is False
+        broker.verify_agent_session(agent["agent_id"], session_b["session_id"]) is False
     )
 
 
 def test_verify_agent_session__returns_false_for_nonexistent_agent():
     session = _create_session()
     assert (
-        broker.verify_agent_session(str(uuid.uuid4()), session["session_id"])
-        is False
+        broker.verify_agent_session(str(uuid.uuid4()), session["session_id"]) is False
     )
 
 

--- a/cafleet/tests/test_broker_webui.py
+++ b/cafleet/tests/test_broker_webui.py
@@ -66,421 +66,447 @@ def _setup_three_agents() -> tuple[str, str, str, str]:
     return sid, a["agent_id"], b["agent_id"], c["agent_id"]
 
 
-class TestListSessionAgents:
-    def test_returns_active_agents(self):
-        session = _create_session()
-        sid = session["session_id"]
-        _register_agent(sid, name="active-1")
-        _register_agent(sid, name="active-2")
-
-        result = broker.list_session_agents(sid)
-        assert len(result) == 4
-        names = {a["name"] for a in result}
-        assert "active-1" in names
-        assert "active-2" in names
-        assert "Director" in names
-        assert "Administrator" in names
-
-    def test_active_agents_have_active_status(self):
-        session = _create_session()
-        sid = session["session_id"]
-        _register_agent(sid, name="agent")
-
-        result = broker.list_session_agents(sid)
-        assert result[0]["status"] == "active"
-
-    def test_includes_deregistered_agents_with_tasks(self):
-        sid, sender, recipient = _setup_two_agents()
-
-        broker.send_message(sid, sender, recipient, "keep me visible")
-        broker.deregister_agent(recipient)
-
-        result = broker.list_session_agents(sid)
-        agent_ids = {a["agent_id"] for a in result}
-        assert recipient in agent_ids
-
-        deregistered = [a for a in result if a["agent_id"] == recipient]
-        assert deregistered[0]["status"] == "deregistered"
-
-    def test_excludes_deregistered_agents_without_tasks(self):
-        session = _create_session()
-        sid = session["session_id"]
-        agent = _register_agent(sid, name="ghost")
-        broker.deregister_agent(agent["agent_id"])
-
-        result = broker.list_session_agents(sid)
-        agent_ids = {a["agent_id"] for a in result}
-        assert agent["agent_id"] not in agent_ids
-
-    def test_newly_created_session_returns_bootstrap_pair(self):
-        session = _create_session()
-        result = broker.list_session_agents(session["session_id"])
-        assert len(result) == 2
-        names = {a["name"] for a in result}
-        assert names == {"Director", "Administrator"}
-
-    def test_result_contains_required_keys(self):
-        session = _create_session()
-        sid = session["session_id"]
-        _register_agent(sid, name="keyed")
-
-        result = broker.list_session_agents(sid)
-        agent = result[0]
-        assert "agent_id" in agent
-        assert "name" in agent
-        assert "description" in agent
-        assert "status" in agent
-        assert "registered_at" in agent
-
-    def test_scoped_to_session(self):
-        session_a = _create_session()
-        session_b = _create_session()
-        _register_agent(session_a["session_id"], name="in-a")
-        _register_agent(session_b["session_id"], name="in-b")
-
-        result = broker.list_session_agents(session_a["session_id"])
-        assert len(result) == 3
-        names = {a["name"] for a in result}
-        assert "in-a" in names
-        assert "Director" in names
-        assert "Administrator" in names
-        assert "in-b" not in names
-
-
-class TestListSessionAgentsKind:
-    """Testing at the broker layer covers the public HTTP surface because
-    webui_api.py is a thin passthrough around broker.list_session_agents.
-    """
-
-    def test_entries_include_kind_field(self):
-        session = _create_session()
-        sid = session["session_id"]
-        _register_agent(sid, name="user-a")
-        _register_agent(sid, name="user-b")
-
-        result = broker.list_session_agents(sid)
-        for entry in result:
-            assert "kind" in entry
-
-    def test_administrator_marked_as_builtin_administrator(self):
-        session = _create_session()
-        sid = session["session_id"]
-        _register_agent(sid, name="user-a")
-        _register_agent(sid, name="user-b")
-
-        result = broker.list_session_agents(sid)
-        admins = [e for e in result if e["kind"] == ADMINISTRATOR_KIND]
-        users = [e for e in result if e["kind"] == "user"]
-
-        assert len(admins) == 1
-        assert admins[0]["name"] == "Administrator"
-        assert admins[0]["agent_id"] == session["administrator_agent_id"]
-
-        assert len(users) == 3
-        user_names = {e["name"] for e in users}
-        assert user_names == {"Director", "user-a", "user-b"}
-
-    def test_kind_values_are_restricted_to_known_set(self):
-        session = _create_session()
-        sid = session["session_id"]
-        _register_agent(sid, name="user-a")
-
-        result = broker.list_session_agents(sid)
-        valid_kinds = {ADMINISTRATOR_KIND, "user"}
-        for entry in result:
-            assert entry["kind"] in valid_kinds
-
-
-class TestGetAgentKind:
-    def test_get_agent_for_administrator_returns_builtin_administrator(self):
-        session = _create_session()
-        sid = session["session_id"]
-        admin_id = session["administrator_agent_id"]
-
-        result = broker.get_agent(admin_id, sid)
-        assert result is not None
-        assert "kind" in result
-        assert result["kind"] == ADMINISTRATOR_KIND
-
-    def test_get_agent_for_user_returns_user_kind(self):
-        session = _create_session()
-        sid = session["session_id"]
-        user = _register_agent(sid, name="regular")
-
-        result = broker.get_agent(user["agent_id"], sid)
-        assert result is not None
-        assert "kind" in result
-        assert result["kind"] == "user"
-
-
-class TestListInbox:
-    def test_returns_inbox_tasks(self):
-        sid, sender, recipient = _setup_two_agents()
-        broker.send_message(sid, sender, recipient, "msg1")
-        broker.send_message(sid, sender, recipient, "msg2")
-
-        result = broker.list_inbox(recipient)
-        assert len(result) == 2
-
-    def test_returns_empty_when_no_tasks(self):
-        session = _create_session()
-        agent = _register_agent(session["session_id"], name="idle")
-        result = broker.list_inbox(agent["agent_id"])
-        assert result == []
-
-    def test_ordered_by_status_timestamp_desc(self):
-        sid, sender, recipient = _setup_two_agents()
-        broker.send_message(sid, sender, recipient, "first")
-        broker.send_message(sid, sender, recipient, "second")
-
-        result = broker.list_inbox(recipient)
-        assert len(result) == 2
-        ts0 = result[0]["status_timestamp"]
-        ts1 = result[1]["status_timestamp"]
-        assert ts0 >= ts1
-
-    def test_filters_out_broadcast_summary(self):
-        sid, sender, _b_id, _ = _setup_three_agents()
-        broker.broadcast_message(sid, sender, "broadcast")
-
-        sender_inbox = broker.list_inbox(sender)
-        summaries = [t for t in sender_inbox if t["type"] == "broadcast_summary"]
-        assert len(summaries) == 0
-
-    def test_only_returns_tasks_where_context_id_matches(self):
-        sid, sender, recipient = _setup_two_agents()
-        broker.send_message(sid, sender, recipient, "for-recipient")
-
-        sender_inbox = broker.list_inbox(sender)
-        assert len(sender_inbox) == 0
-
-    def test_returns_raw_dicts(self):
-        sid, sender, recipient = _setup_two_agents()
-        broker.send_message(sid, sender, recipient, "raw")
-
-        result = broker.list_inbox(recipient)
-        assert len(result) == 1
-        entry = result[0]
-        assert isinstance(entry, dict)
-        assert "task_id" in entry or "task_json" in entry
-
-
-class TestListSent:
-    def test_returns_sent_tasks(self):
-        sid, sender, recipient = _setup_two_agents()
-        broker.send_message(sid, sender, recipient, "sent1")
-        broker.send_message(sid, sender, recipient, "sent2")
-
-        result = broker.list_sent(sender)
-        assert len(result) == 2
-
-    def test_returns_empty_when_no_sent_tasks(self):
-        session = _create_session()
-        agent = _register_agent(session["session_id"], name="quiet")
-        result = broker.list_sent(agent["agent_id"])
-        assert result == []
-
-    def test_ordered_by_status_timestamp_desc(self):
-        sid, sender, recipient = _setup_two_agents()
-        broker.send_message(sid, sender, recipient, "first")
-        broker.send_message(sid, sender, recipient, "second")
-
-        result = broker.list_sent(sender)
-        assert len(result) == 2
-        ts0 = result[0]["status_timestamp"]
-        ts1 = result[1]["status_timestamp"]
-        assert ts0 >= ts1
-
-    def test_filters_out_broadcast_summary(self):
-        sid, sender, _b_id, _ = _setup_three_agents()
-        broker.broadcast_message(sid, sender, "broadcast")
-
-        sent = broker.list_sent(sender)
-        summaries = [t for t in sent if t["type"] == "broadcast_summary"]
-        assert len(summaries) == 0
-
-    def test_only_returns_tasks_from_agent(self):
-        sid, sender, recipient = _setup_two_agents()
-        broker.send_message(sid, sender, recipient, "from-sender")
-
-        recipient_sent = broker.list_sent(recipient)
-        assert len(recipient_sent) == 0
-
-    def test_returns_raw_dicts(self):
-        sid, sender, recipient = _setup_two_agents()
-        broker.send_message(sid, sender, recipient, "raw")
-
-        result = broker.list_sent(sender)
-        assert len(result) == 1
-        entry = result[0]
-        assert isinstance(entry, dict)
-        assert "task_id" in entry or "task_json" in entry
-
-
-class TestListTimeline:
-    def test_returns_timeline_entries(self):
-        sid, sender, recipient = _setup_two_agents()
-        broker.send_message(sid, sender, recipient, "timeline entry")
-
-        result = broker.list_timeline(sid)
-        assert len(result) == 1
-
-    def test_returns_empty_for_no_tasks(self):
-        session = _create_session()
-        result = broker.list_timeline(session["session_id"])
-        assert result == []
-
-    def test_entry_has_required_keys(self):
-        sid, sender, recipient = _setup_two_agents()
-        broker.send_message(sid, sender, recipient, "structured")
-
-        result = broker.list_timeline(sid)
-        assert len(result) == 1
-        entry = result[0]
-        assert "task" in entry
-        assert "origin_task_id" in entry or "created_at" in entry
-
-    def test_ordered_by_status_timestamp_desc(self):
-        sid, sender, recipient = _setup_two_agents()
-        broker.send_message(sid, sender, recipient, "first")
-        broker.send_message(sid, sender, recipient, "second")
-
-        result = broker.list_timeline(sid)
-        assert len(result) == 2
-        assert result[0]["created_at"] >= result[1]["created_at"]
-
-    def test_filters_broadcast_summary(self):
-        sid, sender, _b_id, _c_id = _setup_three_agents()
-        broker.broadcast_message(sid, sender, "broadcast")
-
-        result = broker.list_timeline(sid)
-        for entry in result:
-            assert entry["task"]["metadata"]["type"] != "broadcast_summary"
-
-    def test_scoped_to_session(self):
-        session_a = _create_session()
-        session_b = _create_session()
-        sid_a = session_a["session_id"]
-        sid_b = session_b["session_id"]
-
-        a1 = _register_agent(sid_a, name="a1")
-        a2 = _register_agent(sid_a, name="a2")
-        b1 = _register_agent(sid_b, name="b1")
-        b2 = _register_agent(sid_b, name="b2")
-
-        broker.send_message(sid_a, a1["agent_id"], a2["agent_id"], "session-a msg")
-        broker.send_message(sid_b, b1["agent_id"], b2["agent_id"], "session-b msg")
-
-        result_a = broker.list_timeline(sid_a)
-        result_b = broker.list_timeline(sid_b)
-        assert len(result_a) == 1
-        assert len(result_b) == 1
-
-    def test_limit_parameter(self):
-        sid, sender, recipient = _setup_two_agents()
-        broker.send_message(sid, sender, recipient, "msg1")
-        broker.send_message(sid, sender, recipient, "msg2")
-        broker.send_message(sid, sender, recipient, "msg3")
-
-        result = broker.list_timeline(sid, limit=2)
-        assert len(result) == 2
-
-    def test_includes_broadcast_delivery_tasks(self):
-        sid, sender, _b_id, _c_id = _setup_three_agents()
-        broker.broadcast_message(sid, sender, "Hello all")
-
-        result = broker.list_timeline(sid)
-        assert len(result) >= 2
-
-
-class TestGetAgentNames:
-    def test_returns_name_mapping(self):
-        session = _create_session()
-        sid = session["session_id"]
-        a1 = _register_agent(sid, name="alpha")
-        a2 = _register_agent(sid, name="beta")
-
-        result = broker.get_agent_names([a1["agent_id"], a2["agent_id"]])
-        assert isinstance(result, dict)
-        assert result[a1["agent_id"]] == "alpha"
-        assert result[a2["agent_id"]] == "beta"
-
-    def test_empty_input_returns_empty_dict(self):
-        result = broker.get_agent_names([])
-        assert result == {}
-
-    def test_nonexistent_agent_id_absent_from_result(self):
-        session = _create_session()
-        agent = _register_agent(session["session_id"], name="real")
-        fake_id = str(uuid.uuid4())
-
-        result = broker.get_agent_names([agent["agent_id"], fake_id])
-        assert agent["agent_id"] in result
-        assert fake_id not in result
-
-    def test_includes_deregistered_agents(self):
-        session = _create_session()
-        sid = session["session_id"]
-        agent = _register_agent(sid, name="departed")
-        broker.deregister_agent(agent["agent_id"])
-
-        result = broker.get_agent_names([agent["agent_id"]])
-        assert result[agent["agent_id"]] == "departed"
-
-    def test_single_agent(self):
-        session = _create_session()
-        agent = _register_agent(session["session_id"], name="solo")
-
-        result = broker.get_agent_names([agent["agent_id"]])
-        assert len(result) == 1
-        assert result[agent["agent_id"]] == "solo"
-
-
-class TestGetTaskCreatedAts:
-    def test_returns_created_at_mapping(self):
-        sid, sender, recipient = _setup_two_agents()
-        sent1 = broker.send_message(sid, sender, recipient, "first")
-        sent2 = broker.send_message(sid, sender, recipient, "second")
-        tid1 = sent1["task"]["id"]
-        tid2 = sent2["task"]["id"]
-
-        result = broker.get_task_created_ats([tid1, tid2])
-        assert isinstance(result, dict)
-        assert tid1 in result
-        assert tid2 in result
-        assert isinstance(result[tid1], str)
-        assert len(result[tid1]) > 0
-        assert isinstance(result[tid2], str)
-        assert len(result[tid2]) > 0
-
-    def test_empty_input_returns_empty_dict(self):
-        result = broker.get_task_created_ats([])
-        assert result == {}
-
-    def test_nonexistent_task_id_absent_from_result(self):
-        sid, sender, recipient = _setup_two_agents()
-        sent = broker.send_message(sid, sender, recipient, "real")
-        tid = sent["task"]["id"]
-        fake_id = str(uuid.uuid4())
-
-        result = broker.get_task_created_ats([tid, fake_id])
-        assert tid in result
-        assert fake_id not in result
-
-    def test_single_task(self):
-        sid, sender, recipient = _setup_two_agents()
-        sent = broker.send_message(sid, sender, recipient, "one")
-        tid = sent["task"]["id"]
-
-        result = broker.get_task_created_ats([tid])
-        assert len(result) == 1
-        assert tid in result
-
-    def test_created_at_is_iso8601(self):
-        sid, sender, recipient = _setup_two_agents()
-        sent = broker.send_message(sid, sender, recipient, "timestamped")
-        tid = sent["task"]["id"]
-
-        result = broker.get_task_created_ats([tid])
-        created_at = result[tid]
-        assert "T" in created_at
+def test_list_session_agents__returns_active_agents():
+    session = _create_session()
+    sid = session["session_id"]
+    _register_agent(sid, name="active-1")
+    _register_agent(sid, name="active-2")
+
+    result = broker.list_session_agents(sid)
+    assert len(result) == 4
+    names = {a["name"] for a in result}
+    assert "active-1" in names
+    assert "active-2" in names
+    assert "Director" in names
+    assert "Administrator" in names
+
+
+def test_list_session_agents__active_agents_have_active_status():
+    session = _create_session()
+    sid = session["session_id"]
+    _register_agent(sid, name="agent")
+
+    result = broker.list_session_agents(sid)
+    assert result[0]["status"] == "active"
+
+
+def test_list_session_agents__includes_deregistered_agents_with_tasks():
+    sid, sender, recipient = _setup_two_agents()
+
+    broker.send_message(sid, sender, recipient, "keep me visible")
+    broker.deregister_agent(recipient)
+
+    result = broker.list_session_agents(sid)
+    agent_ids = {a["agent_id"] for a in result}
+    assert recipient in agent_ids
+
+    deregistered = [a for a in result if a["agent_id"] == recipient]
+    assert deregistered[0]["status"] == "deregistered"
+
+
+def test_list_session_agents__excludes_deregistered_agents_without_tasks():
+    session = _create_session()
+    sid = session["session_id"]
+    agent = _register_agent(sid, name="ghost")
+    broker.deregister_agent(agent["agent_id"])
+
+    result = broker.list_session_agents(sid)
+    agent_ids = {a["agent_id"] for a in result}
+    assert agent["agent_id"] not in agent_ids
+
+
+def test_list_session_agents__newly_created_session_returns_bootstrap_pair():
+    session = _create_session()
+    result = broker.list_session_agents(session["session_id"])
+    assert len(result) == 2
+    names = {a["name"] for a in result}
+    assert names == {"Director", "Administrator"}
+
+
+def test_list_session_agents__result_contains_required_keys():
+    session = _create_session()
+    sid = session["session_id"]
+    _register_agent(sid, name="keyed")
+
+    result = broker.list_session_agents(sid)
+    agent = result[0]
+    assert "agent_id" in agent
+    assert "name" in agent
+    assert "description" in agent
+    assert "status" in agent
+    assert "registered_at" in agent
+
+
+def test_list_session_agents__scoped_to_session():
+    session_a = _create_session()
+    session_b = _create_session()
+    _register_agent(session_a["session_id"], name="in-a")
+    _register_agent(session_b["session_id"], name="in-b")
+
+    result = broker.list_session_agents(session_a["session_id"])
+    assert len(result) == 3
+    names = {a["name"] for a in result}
+    assert "in-a" in names
+    assert "Director" in names
+    assert "Administrator" in names
+    assert "in-b" not in names
+
+
+# --- list_session_agents_kind: testing at the broker layer covers the public HTTP
+# surface because webui_api.py is a thin passthrough around broker.list_session_agents. ---
+
+
+def test_list_session_agents_kind__entries_include_kind_field():
+    session = _create_session()
+    sid = session["session_id"]
+    _register_agent(sid, name="user-a")
+    _register_agent(sid, name="user-b")
+
+    result = broker.list_session_agents(sid)
+    for entry in result:
+        assert "kind" in entry
+
+
+def test_list_session_agents_kind__administrator_marked_as_builtin_administrator():
+    session = _create_session()
+    sid = session["session_id"]
+    _register_agent(sid, name="user-a")
+    _register_agent(sid, name="user-b")
+
+    result = broker.list_session_agents(sid)
+    admins = [e for e in result if e["kind"] == ADMINISTRATOR_KIND]
+    users = [e for e in result if e["kind"] == "user"]
+
+    assert len(admins) == 1
+    assert admins[0]["name"] == "Administrator"
+    assert admins[0]["agent_id"] == session["administrator_agent_id"]
+
+    assert len(users) == 3
+    user_names = {e["name"] for e in users}
+    assert user_names == {"Director", "user-a", "user-b"}
+
+
+def test_list_session_agents_kind__kind_values_are_restricted_to_known_set():
+    session = _create_session()
+    sid = session["session_id"]
+    _register_agent(sid, name="user-a")
+
+    result = broker.list_session_agents(sid)
+    valid_kinds = {ADMINISTRATOR_KIND, "user"}
+    for entry in result:
+        assert entry["kind"] in valid_kinds
+
+
+def test_get_agent_kind__get_agent_for_administrator_returns_builtin_administrator():
+    session = _create_session()
+    sid = session["session_id"]
+    admin_id = session["administrator_agent_id"]
+
+    result = broker.get_agent(admin_id, sid)
+    assert result is not None
+    assert "kind" in result
+    assert result["kind"] == ADMINISTRATOR_KIND
+
+
+def test_get_agent_kind__get_agent_for_user_returns_user_kind():
+    session = _create_session()
+    sid = session["session_id"]
+    user = _register_agent(sid, name="regular")
+
+    result = broker.get_agent(user["agent_id"], sid)
+    assert result is not None
+    assert "kind" in result
+    assert result["kind"] == "user"
+
+
+def test_list_inbox__returns_inbox_tasks():
+    sid, sender, recipient = _setup_two_agents()
+    broker.send_message(sid, sender, recipient, "msg1")
+    broker.send_message(sid, sender, recipient, "msg2")
+
+    result = broker.list_inbox(recipient)
+    assert len(result) == 2
+
+
+def test_list_inbox__returns_empty_when_no_tasks():
+    session = _create_session()
+    agent = _register_agent(session["session_id"], name="idle")
+    result = broker.list_inbox(agent["agent_id"])
+    assert result == []
+
+
+def test_list_inbox__ordered_by_status_timestamp_desc():
+    sid, sender, recipient = _setup_two_agents()
+    broker.send_message(sid, sender, recipient, "first")
+    broker.send_message(sid, sender, recipient, "second")
+
+    result = broker.list_inbox(recipient)
+    assert len(result) == 2
+    ts0 = result[0]["status_timestamp"]
+    ts1 = result[1]["status_timestamp"]
+    assert ts0 >= ts1
+
+
+def test_list_inbox__filters_out_broadcast_summary():
+    sid, sender, _b_id, _ = _setup_three_agents()
+    broker.broadcast_message(sid, sender, "broadcast")
+
+    sender_inbox = broker.list_inbox(sender)
+    summaries = [t for t in sender_inbox if t["type"] == "broadcast_summary"]
+    assert len(summaries) == 0
+
+
+def test_list_inbox__only_returns_tasks_where_context_id_matches():
+    sid, sender, recipient = _setup_two_agents()
+    broker.send_message(sid, sender, recipient, "for-recipient")
+
+    sender_inbox = broker.list_inbox(sender)
+    assert len(sender_inbox) == 0
+
+
+def test_list_inbox__returns_raw_dicts():
+    sid, sender, recipient = _setup_two_agents()
+    broker.send_message(sid, sender, recipient, "raw")
+
+    result = broker.list_inbox(recipient)
+    assert len(result) == 1
+    entry = result[0]
+    assert isinstance(entry, dict)
+    assert "task_id" in entry or "task_json" in entry
+
+
+def test_list_sent__returns_sent_tasks():
+    sid, sender, recipient = _setup_two_agents()
+    broker.send_message(sid, sender, recipient, "sent1")
+    broker.send_message(sid, sender, recipient, "sent2")
+
+    result = broker.list_sent(sender)
+    assert len(result) == 2
+
+
+def test_list_sent__returns_empty_when_no_sent_tasks():
+    session = _create_session()
+    agent = _register_agent(session["session_id"], name="quiet")
+    result = broker.list_sent(agent["agent_id"])
+    assert result == []
+
+
+def test_list_sent__ordered_by_status_timestamp_desc():
+    sid, sender, recipient = _setup_two_agents()
+    broker.send_message(sid, sender, recipient, "first")
+    broker.send_message(sid, sender, recipient, "second")
+
+    result = broker.list_sent(sender)
+    assert len(result) == 2
+    ts0 = result[0]["status_timestamp"]
+    ts1 = result[1]["status_timestamp"]
+    assert ts0 >= ts1
+
+
+def test_list_sent__filters_out_broadcast_summary():
+    sid, sender, _b_id, _ = _setup_three_agents()
+    broker.broadcast_message(sid, sender, "broadcast")
+
+    sent = broker.list_sent(sender)
+    summaries = [t for t in sent if t["type"] == "broadcast_summary"]
+    assert len(summaries) == 0
+
+
+def test_list_sent__only_returns_tasks_from_agent():
+    sid, sender, recipient = _setup_two_agents()
+    broker.send_message(sid, sender, recipient, "from-sender")
+
+    recipient_sent = broker.list_sent(recipient)
+    assert len(recipient_sent) == 0
+
+
+def test_list_sent__returns_raw_dicts():
+    sid, sender, recipient = _setup_two_agents()
+    broker.send_message(sid, sender, recipient, "raw")
+
+    result = broker.list_sent(sender)
+    assert len(result) == 1
+    entry = result[0]
+    assert isinstance(entry, dict)
+    assert "task_id" in entry or "task_json" in entry
+
+
+def test_list_timeline__returns_timeline_entries():
+    sid, sender, recipient = _setup_two_agents()
+    broker.send_message(sid, sender, recipient, "timeline entry")
+
+    result = broker.list_timeline(sid)
+    assert len(result) == 1
+
+
+def test_list_timeline__returns_empty_for_no_tasks():
+    session = _create_session()
+    result = broker.list_timeline(session["session_id"])
+    assert result == []
+
+
+def test_list_timeline__entry_has_required_keys():
+    sid, sender, recipient = _setup_two_agents()
+    broker.send_message(sid, sender, recipient, "structured")
+
+    result = broker.list_timeline(sid)
+    assert len(result) == 1
+    entry = result[0]
+    assert "task" in entry
+    assert "origin_task_id" in entry or "created_at" in entry
+
+
+def test_list_timeline__ordered_by_status_timestamp_desc():
+    sid, sender, recipient = _setup_two_agents()
+    broker.send_message(sid, sender, recipient, "first")
+    broker.send_message(sid, sender, recipient, "second")
+
+    result = broker.list_timeline(sid)
+    assert len(result) == 2
+    assert result[0]["created_at"] >= result[1]["created_at"]
+
+
+def test_list_timeline__filters_broadcast_summary():
+    sid, sender, _b_id, _c_id = _setup_three_agents()
+    broker.broadcast_message(sid, sender, "broadcast")
+
+    result = broker.list_timeline(sid)
+    for entry in result:
+        assert entry["task"]["metadata"]["type"] != "broadcast_summary"
+
+
+def test_list_timeline__scoped_to_session():
+    session_a = _create_session()
+    session_b = _create_session()
+    sid_a = session_a["session_id"]
+    sid_b = session_b["session_id"]
+
+    a1 = _register_agent(sid_a, name="a1")
+    a2 = _register_agent(sid_a, name="a2")
+    b1 = _register_agent(sid_b, name="b1")
+    b2 = _register_agent(sid_b, name="b2")
+
+    broker.send_message(sid_a, a1["agent_id"], a2["agent_id"], "session-a msg")
+    broker.send_message(sid_b, b1["agent_id"], b2["agent_id"], "session-b msg")
+
+    result_a = broker.list_timeline(sid_a)
+    result_b = broker.list_timeline(sid_b)
+    assert len(result_a) == 1
+    assert len(result_b) == 1
+
+
+def test_list_timeline__limit_parameter():
+    sid, sender, recipient = _setup_two_agents()
+    broker.send_message(sid, sender, recipient, "msg1")
+    broker.send_message(sid, sender, recipient, "msg2")
+    broker.send_message(sid, sender, recipient, "msg3")
+
+    result = broker.list_timeline(sid, limit=2)
+    assert len(result) == 2
+
+
+def test_list_timeline__includes_broadcast_delivery_tasks():
+    sid, sender, _b_id, _c_id = _setup_three_agents()
+    broker.broadcast_message(sid, sender, "Hello all")
+
+    result = broker.list_timeline(sid)
+    assert len(result) >= 2
+
+
+def test_get_agent_names__returns_name_mapping():
+    session = _create_session()
+    sid = session["session_id"]
+    a1 = _register_agent(sid, name="alpha")
+    a2 = _register_agent(sid, name="beta")
+
+    result = broker.get_agent_names([a1["agent_id"], a2["agent_id"]])
+    assert isinstance(result, dict)
+    assert result[a1["agent_id"]] == "alpha"
+    assert result[a2["agent_id"]] == "beta"
+
+
+def test_get_agent_names__empty_input_returns_empty_dict():
+    result = broker.get_agent_names([])
+    assert result == {}
+
+
+def test_get_agent_names__nonexistent_agent_id_absent_from_result():
+    session = _create_session()
+    agent = _register_agent(session["session_id"], name="real")
+    fake_id = str(uuid.uuid4())
+
+    result = broker.get_agent_names([agent["agent_id"], fake_id])
+    assert agent["agent_id"] in result
+    assert fake_id not in result
+
+
+def test_get_agent_names__includes_deregistered_agents():
+    session = _create_session()
+    sid = session["session_id"]
+    agent = _register_agent(sid, name="departed")
+    broker.deregister_agent(agent["agent_id"])
+
+    result = broker.get_agent_names([agent["agent_id"]])
+    assert result[agent["agent_id"]] == "departed"
+
+
+def test_get_agent_names__single_agent():
+    session = _create_session()
+    agent = _register_agent(session["session_id"], name="solo")
+
+    result = broker.get_agent_names([agent["agent_id"]])
+    assert len(result) == 1
+    assert result[agent["agent_id"]] == "solo"
+
+
+def test_get_task_created_ats__returns_created_at_mapping():
+    sid, sender, recipient = _setup_two_agents()
+    sent1 = broker.send_message(sid, sender, recipient, "first")
+    sent2 = broker.send_message(sid, sender, recipient, "second")
+    tid1 = sent1["task"]["id"]
+    tid2 = sent2["task"]["id"]
+
+    result = broker.get_task_created_ats([tid1, tid2])
+    assert isinstance(result, dict)
+    assert tid1 in result
+    assert tid2 in result
+    assert isinstance(result[tid1], str)
+    assert len(result[tid1]) > 0
+    assert isinstance(result[tid2], str)
+    assert len(result[tid2]) > 0
+
+
+def test_get_task_created_ats__empty_input_returns_empty_dict():
+    result = broker.get_task_created_ats([])
+    assert result == {}
+
+
+def test_get_task_created_ats__nonexistent_task_id_absent_from_result():
+    sid, sender, recipient = _setup_two_agents()
+    sent = broker.send_message(sid, sender, recipient, "real")
+    tid = sent["task"]["id"]
+    fake_id = str(uuid.uuid4())
+
+    result = broker.get_task_created_ats([tid, fake_id])
+    assert tid in result
+    assert fake_id not in result
+
+
+def test_get_task_created_ats__single_task():
+    sid, sender, recipient = _setup_two_agents()
+    sent = broker.send_message(sid, sender, recipient, "one")
+    tid = sent["task"]["id"]
+
+    result = broker.get_task_created_ats([tid])
+    assert len(result) == 1
+    assert tid in result
+
+
+def test_get_task_created_ats__created_at_is_iso8601():
+    sid, sender, recipient = _setup_two_agents()
+    sent = broker.send_message(sid, sender, recipient, "timestamped")
+    tid = sent["task"]["id"]
+
+    result = broker.get_task_created_ats([tid])
+    created_at = result[tid]
+    assert "T" in created_at

--- a/cafleet/tests/test_cli_agent.py
+++ b/cafleet/tests/test_cli_agent.py
@@ -31,74 +31,75 @@ def runner():
     return CliRunner()
 
 
-class TestAgentDeregisterAuthCheck:
-    """``agent deregister`` must call ``broker.verify_agent_session`` BEFORE
-    ``broker.deregister_agent``. Without the gate, a caller can deregister
-    any agent in the database by supplying an unrelated ``--session-id``.
-    """
+# --- agent_deregister_auth_check: ``agent deregister`` must call
+# ``broker.verify_agent_session`` BEFORE ``broker.deregister_agent``. Without
+# the gate, a caller can deregister any agent in the database by supplying an
+# unrelated ``--session-id``. ---
 
-    def test_rejects_unknown_agent(self, runner, session_id, agent_id, monkeypatch):
-        deregister_calls: list[tuple] = []
 
-        def fake_verify(aid, sid):
-            assert aid == agent_id
-            assert sid == session_id
-            return False
+def test_agent_deregister_auth_check__rejects_unknown_agent(runner, session_id, agent_id, monkeypatch):
+    deregister_calls: list[tuple] = []
 
-        def fake_deregister(*args, **kwargs):
-            deregister_calls.append((args, kwargs))
-            return True
+    def fake_verify(aid, sid):
+        assert aid == agent_id
+        assert sid == session_id
+        return False
 
-        monkeypatch.setattr(broker, "verify_agent_session", fake_verify)
-        monkeypatch.setattr(broker, "deregister_agent", fake_deregister)
+    def fake_deregister(*args, **kwargs):
+        deregister_calls.append((args, kwargs))
+        return True
 
-        result = runner.invoke(
-            cli,
-            [
-                "--session-id",
-                session_id,
-                "agent",
-                "deregister",
-                "--agent-id",
-                agent_id,
-            ],
-        )
-        assert result.exit_code == 1, result.output
-        out = result.output or ""
-        assert agent_id in out
-        assert "not a member of session" in out
-        assert session_id in out
-        assert deregister_calls == [], (
-            "broker.deregister_agent must not be invoked when "
-            "verify_agent_session fails"
-        )
+    monkeypatch.setattr(broker, "verify_agent_session", fake_verify)
+    monkeypatch.setattr(broker, "deregister_agent", fake_deregister)
 
-    def test_accepts_valid_agent(self, runner, session_id, agent_id, monkeypatch):
-        verify_calls: list[tuple] = []
-        deregister_calls: list[tuple] = []
+    result = runner.invoke(
+        cli,
+        [
+            "--session-id",
+            session_id,
+            "agent",
+            "deregister",
+            "--agent-id",
+            agent_id,
+        ],
+    )
+    assert result.exit_code == 1, result.output
+    out = result.output or ""
+    assert agent_id in out
+    assert "not a member of session" in out
+    assert session_id in out
+    assert deregister_calls == [], (
+        "broker.deregister_agent must not be invoked when "
+        "verify_agent_session fails"
+    )
 
-        def fake_verify(aid, sid):
-            verify_calls.append((aid, sid))
-            return True
 
-        def fake_deregister(aid):
-            deregister_calls.append(aid)
-            return True
+def test_agent_deregister_auth_check__accepts_valid_agent(runner, session_id, agent_id, monkeypatch):
+    verify_calls: list[tuple] = []
+    deregister_calls: list[tuple] = []
 
-        monkeypatch.setattr(broker, "verify_agent_session", fake_verify)
-        monkeypatch.setattr(broker, "deregister_agent", fake_deregister)
+    def fake_verify(aid, sid):
+        verify_calls.append((aid, sid))
+        return True
 
-        result = runner.invoke(
-            cli,
-            [
-                "--session-id",
-                session_id,
-                "agent",
-                "deregister",
-                "--agent-id",
-                agent_id,
-            ],
-        )
-        assert result.exit_code == 0, result.output
-        assert verify_calls == [(agent_id, session_id)]
-        assert deregister_calls == [agent_id]
+    def fake_deregister(aid):
+        deregister_calls.append(aid)
+        return True
+
+    monkeypatch.setattr(broker, "verify_agent_session", fake_verify)
+    monkeypatch.setattr(broker, "deregister_agent", fake_deregister)
+
+    result = runner.invoke(
+        cli,
+        [
+            "--session-id",
+            session_id,
+            "agent",
+            "deregister",
+            "--agent-id",
+            agent_id,
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert verify_calls == [(agent_id, session_id)]
+    assert deregister_calls == [agent_id]

--- a/cafleet/tests/test_cli_agent.py
+++ b/cafleet/tests/test_cli_agent.py
@@ -37,7 +37,9 @@ def runner():
 # unrelated ``--session-id``. ---
 
 
-def test_agent_deregister_auth_check__rejects_unknown_agent(runner, session_id, agent_id, monkeypatch):
+def test_agent_deregister_auth_check__rejects_unknown_agent(
+    runner, session_id, agent_id, monkeypatch
+):
     deregister_calls: list[tuple] = []
 
     def fake_verify(aid, sid):
@@ -69,12 +71,13 @@ def test_agent_deregister_auth_check__rejects_unknown_agent(runner, session_id, 
     assert "not a member of session" in out
     assert session_id in out
     assert deregister_calls == [], (
-        "broker.deregister_agent must not be invoked when "
-        "verify_agent_session fails"
+        "broker.deregister_agent must not be invoked when verify_agent_session fails"
     )
 
 
-def test_agent_deregister_auth_check__accepts_valid_agent(runner, session_id, agent_id, monkeypatch):
+def test_agent_deregister_auth_check__accepts_valid_agent(
+    runner, session_id, agent_id, monkeypatch
+):
     verify_calls: list[tuple] = []
     deregister_calls: list[tuple] = []
 

--- a/cafleet/tests/test_cli_claude_helpers.py
+++ b/cafleet/tests/test_cli_claude_helpers.py
@@ -19,69 +19,71 @@ from cafleet.cli import (
 )
 
 
-class TestBuildClaudeCommand:
-    def test_argv_shape(self):
-        assert _build_claude_command("PROMPT_TEXT", display_name="Bob") == [
-            "claude",
-            "--permission-mode",
-            "dontAsk",
-            "--name",
-            "Bob",
-            "PROMPT_TEXT",
-        ]
-
-    def test_preserves_prompt_with_special_chars(self):
-        prompt = (
-            "Review PR #42.\n"
-            "Use --agent-id 7ba91234-5678-90ab-cdef-112233445566.\n"
-            'Quote: "hello" and {literal_braces}.'
-        )
-        result = _build_claude_command(prompt, display_name="Drafter")
-        assert result[-1] == prompt
-        assert result[0] == "claude"
-
-    def test_preserves_display_name_with_spaces(self):
-        result = _build_claude_command("p", display_name="Code Reviewer")
-        assert result == [
-            "claude",
-            "--permission-mode",
-            "dontAsk",
-            "--name",
-            "Code Reviewer",
-            "p",
-        ]
+def test_build_claude_command__argv_shape():
+    assert _build_claude_command("PROMPT_TEXT", display_name="Bob") == [
+        "claude",
+        "--permission-mode",
+        "dontAsk",
+        "--name",
+        "Bob",
+        "PROMPT_TEXT",
+    ]
 
 
-class TestEnsureClaudeAvailable:
-    def test_raises_when_missing(self, monkeypatch):
-        monkeypatch.setattr("cafleet.cli.shutil.which", lambda _: None)
-        with pytest.raises(RuntimeError, match="claude"):
-            _ensure_claude_available()
+def test_build_claude_command__preserves_prompt_with_special_chars():
+    prompt = (
+        "Review PR #42.\n"
+        "Use --agent-id 7ba91234-5678-90ab-cdef-112233445566.\n"
+        'Quote: "hello" and {literal_braces}.'
+    )
+    result = _build_claude_command(prompt, display_name="Drafter")
+    assert result[-1] == prompt
+    assert result[0] == "claude"
 
-    def test_silent_when_found(self, monkeypatch):
-        monkeypatch.setattr("cafleet.cli.shutil.which", lambda _: "/usr/bin/claude")
-        assert _ensure_claude_available() is None
+
+def test_build_claude_command__preserves_display_name_with_spaces():
+    result = _build_claude_command("p", display_name="Code Reviewer")
+    assert result == [
+        "claude",
+        "--permission-mode",
+        "dontAsk",
+        "--name",
+        "Code Reviewer",
+        "p",
+    ]
 
 
-class TestClaudePromptTemplate:
-    _STANDARD_KWARGS = {
-        "session_id": "550e8400-e29b-41d4-a716-446655440000",
-        "agent_id": "7ba91234-5678-90ab-cdef-112233445566",
-        "director_name": "Alice",
-        "director_agent_id": "dir-001",
-    }
+def test_ensure_claude_available__raises_when_missing(monkeypatch):
+    monkeypatch.setattr("cafleet.cli.shutil.which", lambda _: None)
+    with pytest.raises(RuntimeError, match="claude"):
+        _ensure_claude_available()
 
-    def test_has_required_placeholders_and_markers(self):
-        assert "{session_id}" in _CLAUDE_PROMPT_TEMPLATE
-        assert "{agent_id}" in _CLAUDE_PROMPT_TEMPLATE
-        assert "{director_name}" in _CLAUDE_PROMPT_TEMPLATE
-        assert "{director_agent_id}" in _CLAUDE_PROMPT_TEMPLATE
-        assert "Load Skill(cafleet)" in _CLAUDE_PROMPT_TEMPLATE
-        assert "dontAsk" in _CLAUDE_PROMPT_TEMPLATE
 
-    def test_format_succeeds_with_standard_kwargs(self):
-        result = _CLAUDE_PROMPT_TEMPLATE.format(**self._STANDARD_KWARGS)
-        assert "550e8400-e29b-41d4-a716-446655440000" in result
-        assert "7ba91234-5678-90ab-cdef-112233445566" in result
-        assert "Alice" in result
-        assert "dir-001" in result
+def test_ensure_claude_available__silent_when_found(monkeypatch):
+    monkeypatch.setattr("cafleet.cli.shutil.which", lambda _: "/usr/bin/claude")
+    assert _ensure_claude_available() is None
+
+
+_STANDARD_KWARGS = {
+    "session_id": "550e8400-e29b-41d4-a716-446655440000",
+    "agent_id": "7ba91234-5678-90ab-cdef-112233445566",
+    "director_name": "Alice",
+    "director_agent_id": "dir-001",
+}
+
+
+def test_claude_prompt_template__has_required_placeholders_and_markers():
+    assert "{session_id}" in _CLAUDE_PROMPT_TEMPLATE
+    assert "{agent_id}" in _CLAUDE_PROMPT_TEMPLATE
+    assert "{director_name}" in _CLAUDE_PROMPT_TEMPLATE
+    assert "{director_agent_id}" in _CLAUDE_PROMPT_TEMPLATE
+    assert "Load Skill(cafleet)" in _CLAUDE_PROMPT_TEMPLATE
+    assert "dontAsk" in _CLAUDE_PROMPT_TEMPLATE
+
+
+def test_claude_prompt_template__format_succeeds_with_standard_kwargs():
+    result = _CLAUDE_PROMPT_TEMPLATE.format(**_STANDARD_KWARGS)
+    assert "550e8400-e29b-41d4-a716-446655440000" in result
+    assert "7ba91234-5678-90ab-cdef-112233445566" in result
+    assert "Alice" in result
+    assert "dir-001" in result

--- a/cafleet/tests/test_cli_client_command.py
+++ b/cafleet/tests/test_cli_client_command.py
@@ -82,7 +82,9 @@ def test_requires_agent_session__false_does_not_call_verify(runner, monkeypatch)
     assert verify_calls == []
 
 
-def test_requires_agent_session__true_calls_verify_and_raises_on_false(runner, monkeypatch):
+def test_requires_agent_session__true_calls_verify_and_raises_on_false(
+    runner, monkeypatch
+):
     verify_calls = []
 
     def fake_verify(aid, sid):
@@ -106,7 +108,9 @@ def test_requires_agent_session__true_calls_verify_and_raises_on_false(runner, m
     assert verify_calls == [("agent-1", "session-1")]
 
 
-def test_requires_agent_session__true_proceeds_when_verify_returns_true(runner, monkeypatch):
+def test_requires_agent_session__true_proceeds_when_verify_returns_true(
+    runner, monkeypatch
+):
     monkeypatch.setattr(broker, "verify_agent_session", lambda _a, _s: True)
 
     result = runner.invoke(

--- a/cafleet/tests/test_cli_client_command.py
+++ b/cafleet/tests/test_cli_client_command.py
@@ -59,97 +59,96 @@ def runner():
     return CliRunner()
 
 
-class TestSessionIdGuard:
-    def test_missing_session_id_raises_click_exception(self, runner):
-        result = runner.invoke(_test_cli, ["simple"])
-        assert result.exit_code != 0
-        assert "session-id" in result.output.lower() or "is required" in result.output
+def test_session_id_guard__missing_session_id_raises_click_exception(runner):
+    result = runner.invoke(_test_cli, ["simple"])
+    assert result.exit_code != 0
+    assert "session-id" in result.output.lower() or "is required" in result.output
 
 
-class TestRequiresAgentSession:
-    def test_false_does_not_call_verify(self, runner, monkeypatch):
-        verify_calls = []
+def test_requires_agent_session__false_does_not_call_verify(runner, monkeypatch):
+    verify_calls = []
 
-        def fake_verify(aid, sid):
-            verify_calls.append((aid, sid))
-            return True
+    def fake_verify(aid, sid):
+        verify_calls.append((aid, sid))
+        return True
 
-        monkeypatch.setattr(broker, "verify_agent_session", fake_verify)
+    monkeypatch.setattr(broker, "verify_agent_session", fake_verify)
 
-        result = runner.invoke(
-            _test_cli,
-            ["--session-id", "session-1", "simple"],
-        )
-        assert result.exit_code == 0, result.output
-        assert verify_calls == []
-
-    def test_true_calls_verify_and_raises_on_false(self, runner, monkeypatch):
-        verify_calls = []
-
-        def fake_verify(aid, sid):
-            verify_calls.append((aid, sid))
-            return False
-
-        monkeypatch.setattr(broker, "verify_agent_session", fake_verify)
-
-        result = runner.invoke(
-            _test_cli,
-            [
-                "--session-id",
-                "session-1",
-                "agent-bound",
-                "--agent-id",
-                "agent-1",
-            ],
-        )
-        assert result.exit_code != 0
-        assert "not a member of session" in result.output
-        assert verify_calls == [("agent-1", "session-1")]
-
-    def test_true_proceeds_when_verify_returns_true(self, runner, monkeypatch):
-        monkeypatch.setattr(broker, "verify_agent_session", lambda _a, _s: True)
-
-        result = runner.invoke(
-            _test_cli,
-            [
-                "--session-id",
-                "session-1",
-                "agent-bound",
-                "--agent-id",
-                "agent-1",
-            ],
-        )
-        assert result.exit_code == 0, result.output
-        assert "TEXT:" in result.output
-        assert "agent-1" in result.output
+    result = runner.invoke(
+        _test_cli,
+        ["--session-id", "session-1", "simple"],
+    )
+    assert result.exit_code == 0, result.output
+    assert verify_calls == []
 
 
-class TestBrokerErrorWrapping:
-    def test_runtime_error_wrapped_as_click_exception(self, runner):
-        result = runner.invoke(
-            _test_cli,
-            ["--session-id", "session-1", "raises"],
-        )
-        assert result.exit_code == 1, result.output
-        assert "boom!" in result.output
+def test_requires_agent_session__true_calls_verify_and_raises_on_false(runner, monkeypatch):
+    verify_calls = []
+
+    def fake_verify(aid, sid):
+        verify_calls.append((aid, sid))
+        return False
+
+    monkeypatch.setattr(broker, "verify_agent_session", fake_verify)
+
+    result = runner.invoke(
+        _test_cli,
+        [
+            "--session-id",
+            "session-1",
+            "agent-bound",
+            "--agent-id",
+            "agent-1",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "not a member of session" in result.output
+    assert verify_calls == [("agent-1", "session-1")]
 
 
-class TestOutputBranching:
-    def test_json_output_branch_uses_format_json(self, runner):
-        result = runner.invoke(
-            _test_cli,
-            ["--json", "--session-id", "session-1", "simple"],
-        )
-        assert result.exit_code == 0, result.output
-        parsed = json.loads(result.output)
-        assert parsed == {"hello": "world"}
+def test_requires_agent_session__true_proceeds_when_verify_returns_true(runner, monkeypatch):
+    monkeypatch.setattr(broker, "verify_agent_session", lambda _a, _s: True)
 
-    def test_text_output_branch_uses_text_formatter(self, runner):
-        result = runner.invoke(
-            _test_cli,
-            ["--session-id", "session-1", "simple"],
-        )
-        assert result.exit_code == 0, result.output
-        assert result.output.startswith("TEXT:")
-        assert "hello" in result.output
-        assert "world" in result.output
+    result = runner.invoke(
+        _test_cli,
+        [
+            "--session-id",
+            "session-1",
+            "agent-bound",
+            "--agent-id",
+            "agent-1",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert "TEXT:" in result.output
+    assert "agent-1" in result.output
+
+
+def test_broker_error_wrapping__runtime_error_wrapped_as_click_exception(runner):
+    result = runner.invoke(
+        _test_cli,
+        ["--session-id", "session-1", "raises"],
+    )
+    assert result.exit_code == 1, result.output
+    assert "boom!" in result.output
+
+
+def test_output_branching__json_output_branch_uses_format_json(runner):
+    result = runner.invoke(
+        _test_cli,
+        ["--json", "--session-id", "session-1", "simple"],
+    )
+    assert result.exit_code == 0, result.output
+    parsed = json.loads(result.output)
+    assert parsed == {"hello": "world"}
+
+
+def test_output_branching__text_output_branch_uses_text_formatter(runner):
+    result = runner.invoke(
+        _test_cli,
+        ["--session-id", "session-1", "simple"],
+    )
+    assert result.exit_code == 0, result.output
+    assert result.output.startswith("TEXT:")
+    assert "hello" in result.output
+    assert "world" in result.output

--- a/cafleet/tests/test_cli_doctor.py
+++ b/cafleet/tests/test_cli_doctor.py
@@ -67,7 +67,9 @@ def test_doctor_outside_tmux__outside_tmux_exits_one(runner, monkeypatch):
     assert "cafleet member commands must be run inside a tmux session" in combined
 
 
-def test_doctor_session_id_silently_ignored__session_id_flag_silently_ignored(runner, mock_tmux_ok):
+def test_doctor_session_id_silently_ignored__session_id_flag_silently_ignored(
+    runner, mock_tmux_ok
+):
     result = runner.invoke(
         cli,
         [

--- a/cafleet/tests/test_cli_doctor.py
+++ b/cafleet/tests/test_cli_doctor.py
@@ -26,69 +26,65 @@ def mock_tmux_ok(monkeypatch):
     monkeypatch.setattr(tmux, "director_context", lambda: _FAKE_DIRECTOR_CTX)
 
 
-class TestDoctorTextOutput:
-    def test_text_output_has_all_four_fields(self, runner, mock_tmux_ok):
-        result = runner.invoke(cli, ["doctor"])
-        assert result.exit_code == 0, result.output
-        out = result.output
-        assert "session_name:" in out
-        assert "main" in out
-        assert "window_id:" in out
-        assert "@3" in out
-        assert "pane_id:" in out
-        assert "%0" in out
-        assert "TMUX_PANE:" in out
-        assert _TMUX_PANE_VALUE in out
+def test_doctor_text_output__text_output_has_all_four_fields(runner, mock_tmux_ok):
+    result = runner.invoke(cli, ["doctor"])
+    assert result.exit_code == 0, result.output
+    out = result.output
+    assert "session_name:" in out
+    assert "main" in out
+    assert "window_id:" in out
+    assert "@3" in out
+    assert "pane_id:" in out
+    assert "%0" in out
+    assert "TMUX_PANE:" in out
+    assert _TMUX_PANE_VALUE in out
 
 
-class TestDoctorJsonOutput:
-    def test_json_output_shape(self, runner, mock_tmux_ok):
-        result = runner.invoke(cli, ["--json", "doctor"])
-        assert result.exit_code == 0, result.output
-        data = json.loads(result.output)
-        assert data == {
-            "tmux": {
-                "session_name": "main",
-                "window_id": "@3",
-                "pane_id": "%0",
-                "tmux_pane_env": _TMUX_PANE_VALUE,
-            }
+def test_doctor_json_output__json_output_shape(runner, mock_tmux_ok):
+    result = runner.invoke(cli, ["--json", "doctor"])
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    assert data == {
+        "tmux": {
+            "session_name": "main",
+            "window_id": "@3",
+            "pane_id": "%0",
+            "tmux_pane_env": _TMUX_PANE_VALUE,
         }
+    }
 
 
-class TestDoctorOutsideTmux:
-    def test_outside_tmux_exits_one(self, runner, monkeypatch):
-        monkeypatch.delenv("TMUX", raising=False)
+def test_doctor_outside_tmux__outside_tmux_exits_one(runner, monkeypatch):
+    monkeypatch.delenv("TMUX", raising=False)
 
-        def _raise():
-            raise TmuxError("cafleet member commands must be run inside a tmux session")
+    def _raise():
+        raise TmuxError("cafleet member commands must be run inside a tmux session")
 
-        monkeypatch.setattr(tmux, "ensure_tmux_available", _raise)
-        result = runner.invoke(cli, ["doctor"])
-        assert result.exit_code == 1, result.output
-        combined = (result.output or "") + (result.stderr or "")
-        assert "cafleet member commands must be run inside a tmux session" in combined
+    monkeypatch.setattr(tmux, "ensure_tmux_available", _raise)
+    result = runner.invoke(cli, ["doctor"])
+    assert result.exit_code == 1, result.output
+    combined = (result.output or "") + (result.stderr or "")
+    assert "cafleet member commands must be run inside a tmux session" in combined
 
 
-class TestDoctorSessionIdSilentlyIgnored:
-    def test_session_id_flag_silently_ignored(self, runner, mock_tmux_ok):
-        result = runner.invoke(
-            cli,
-            [
-                "--session-id",
-                "00000000-0000-0000-0000-000000000000",
-                "doctor",
-            ],
-        )
-        assert result.exit_code == 0, result.output
-        out = result.output
-        assert "session_name:" in out
-        assert "main" in out
-        assert "window_id:" in out
-        assert "@3" in out
-        assert "pane_id:" in out
-        assert "%0" in out
-        assert "TMUX_PANE:" in out
-        assert _TMUX_PANE_VALUE in out
-        assert "--session-id" not in out
-        assert "is required for this subcommand" not in out
+def test_doctor_session_id_silently_ignored__session_id_flag_silently_ignored(runner, mock_tmux_ok):
+    result = runner.invoke(
+        cli,
+        [
+            "--session-id",
+            "00000000-0000-0000-0000-000000000000",
+            "doctor",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    out = result.output
+    assert "session_name:" in out
+    assert "main" in out
+    assert "window_id:" in out
+    assert "@3" in out
+    assert "pane_id:" in out
+    assert "%0" in out
+    assert "TMUX_PANE:" in out
+    assert _TMUX_PANE_VALUE in out
+    assert "--session-id" not in out
+    assert "is required for this subcommand" not in out

--- a/cafleet/tests/test_cli_member.py
+++ b/cafleet/tests/test_cli_member.py
@@ -54,159 +54,147 @@ def mock_get_agent(monkeypatch):
     return fake_get_agent
 
 
-class TestDefaultPromptSubstitution:
-    def test_default_path_substitutes_all_placeholders(
-        self,
+def test_default_prompt_substitution__default_path_substitutes_all_placeholders(
+    ctx,
+    director_agent_id,
+    new_agent_id,
+    mock_get_agent,
+    session_id,
+):
+    result = _resolve_prompt(
         ctx,
-        director_agent_id,
-        new_agent_id,
-        mock_get_agent,
-        session_id,
-    ):
-        result = _resolve_prompt(
+        director_agent_id=director_agent_id,
+        new_agent_id=new_agent_id,
+        prompt_argv=(),
+    )
+    assert session_id in result
+    assert new_agent_id in result
+    assert director_agent_id in result
+    assert "Director-X" in result
+    assert "{session_id}" not in result
+    assert "{agent_id}" not in result
+    assert "{director_name}" not in result
+    assert "{director_agent_id}" not in result
+
+
+def test_custom_prompt_placeholder_substitution__custom_prompt_with_agent_id_placeholder_substitutes(
+    ctx,
+    director_agent_id,
+    new_agent_id,
+    mock_get_agent,
+):
+    result = _resolve_prompt(
+        ctx,
+        director_agent_id=director_agent_id,
+        new_agent_id=new_agent_id,
+        prompt_argv=("message", "for", "{agent_id}"),
+    )
+    assert result == f"message for {new_agent_id}"
+
+
+def test_custom_prompt_no_placeholder_pass_through__custom_prompt_without_placeholders_unchanged(
+    ctx,
+    director_agent_id,
+    new_agent_id,
+    mock_get_agent,
+):
+    result = _resolve_prompt(
+        ctx,
+        director_agent_id=director_agent_id,
+        new_agent_id=new_agent_id,
+        prompt_argv=("no", "placeholders", "here"),
+    )
+    assert result == "no placeholders here"
+
+
+# --- custom_prompt_doubled_brace_escape: design doc 2.2(d): ``{{...}}``
+# collapses to ``{...}`` without substitution. Callers embedding literal JSON
+# snippets must double their braces, and ``.format`` then collapses each pair
+# to a single literal brace. No placeholder substitution is attempted on the
+# inner tokens. Against pre-fix code this test FAILS because the custom path
+# never calls ``.format`` and returns the raw doubled-brace string. ---
+
+
+def test_custom_prompt_doubled_brace_escape__custom_prompt_with_doubled_braces_collapses_to_single(
+    ctx,
+    director_agent_id,
+    new_agent_id,
+    mock_get_agent,
+):
+    result = _resolve_prompt(
+        ctx,
+        director_agent_id=director_agent_id,
+        new_agent_id=new_agent_id,
+        prompt_argv=("data", "is", "{{not", "a", "placeholder}}", "closed"),
+    )
+    assert result == "data is {not a placeholder} closed"
+    assert new_agent_id not in result
+    assert director_agent_id not in result
+
+
+# --- custom_prompt_malformed_raises_usage_error: ``str.format`` errors must
+# convert to ``click.UsageError``. ``member_create``'s rollback path only
+# catches ``UsageError``, so a raw ``KeyError`` / ``ValueError`` would orphan
+# the just-registered agent. ---
+
+
+def test_custom_prompt_malformed_raises_usage_error__unknown_placeholder_raises_usage_error(
+    ctx,
+    director_agent_id,
+    new_agent_id,
+    mock_get_agent,
+):
+    with pytest.raises(click.UsageError) as exc_info:
+        _resolve_prompt(
             ctx,
             director_agent_id=director_agent_id,
             new_agent_id=new_agent_id,
-            prompt_argv=(),
+            prompt_argv=("hello", "{foo}"),
         )
-        assert session_id in result
-        assert new_agent_id in result
-        assert director_agent_id in result
-        assert "Director-X" in result
-        assert "{session_id}" not in result
-        assert "{agent_id}" not in result
-        assert "{director_name}" not in result
-        assert "{director_agent_id}" not in result
+    message = str(exc_info.value)
+    assert "foo" in message
+    assert "{session_id}" in message
+    assert "{agent_id}" in message
 
 
-class TestCustomPromptPlaceholderSubstitution:
-    def test_custom_prompt_with_agent_id_placeholder_substitutes(
-        self,
-        ctx,
-        director_agent_id,
-        new_agent_id,
-        mock_get_agent,
-    ):
-        result = _resolve_prompt(
+def test_custom_prompt_malformed_raises_usage_error__unmatched_brace_raises_usage_error(
+    ctx,
+    director_agent_id,
+    new_agent_id,
+    mock_get_agent,
+):
+    with pytest.raises(click.UsageError) as exc_info:
+        _resolve_prompt(
             ctx,
             director_agent_id=director_agent_id,
             new_agent_id=new_agent_id,
-            prompt_argv=("message", "for", "{agent_id}"),
+            prompt_argv=("hello", "{unclosed"),
         )
-        assert result == f"message for {new_agent_id}"
+    message = str(exc_info.value)
+    assert "{{" in message
+    assert "}}" in message
 
 
-class TestCustomPromptNoPlaceholderPassThrough:
-    def test_custom_prompt_without_placeholders_unchanged(
-        self,
-        ctx,
-        director_agent_id,
-        new_agent_id,
-        mock_get_agent,
-    ):
-        result = _resolve_prompt(
+def test_custom_prompt_malformed_raises_usage_error__attribute_access_raises_usage_error(
+    ctx,
+    director_agent_id,
+    new_agent_id,
+    mock_get_agent,
+):
+    # PR #25 3rd review: ``{agent_id.foo}`` triggers str.format attribute
+    # access on the substituted string; ``str`` has no ``.foo`` so Python
+    # raises ``AttributeError``. Must be caught and converted to
+    # ``UsageError`` so the rollback path in ``member_create`` still runs.
+    with pytest.raises(click.UsageError) as exc_info:
+        _resolve_prompt(
             ctx,
             director_agent_id=director_agent_id,
             new_agent_id=new_agent_id,
-            prompt_argv=("no", "placeholders", "here"),
+            prompt_argv=("hello", "{agent_id.foo}"),
         )
-        assert result == "no placeholders here"
-
-
-class TestCustomPromptDoubledBraceEscape:
-    """Design doc 2.2(d): ``{{...}}`` collapses to ``{...}`` without substitution.
-
-    Callers embedding literal JSON snippets must double their braces, and
-    ``.format`` then collapses each pair to a single literal brace.
-    No placeholder substitution is attempted on the inner tokens.
-
-    Against pre-fix code this test FAILS because the custom path never
-    calls ``.format`` and returns the raw doubled-brace string.
-    """
-
-    def test_custom_prompt_with_doubled_braces_collapses_to_single(
-        self,
-        ctx,
-        director_agent_id,
-        new_agent_id,
-        mock_get_agent,
-    ):
-        result = _resolve_prompt(
-            ctx,
-            director_agent_id=director_agent_id,
-            new_agent_id=new_agent_id,
-            prompt_argv=("data", "is", "{{not", "a", "placeholder}}", "closed"),
-        )
-        assert result == "data is {not a placeholder} closed"
-        assert new_agent_id not in result
-        assert director_agent_id not in result
-
-
-class TestCustomPromptMalformedRaisesUsageError:
-    """``str.format`` errors must convert to ``click.UsageError``.
-
-    ``member_create``'s rollback path only catches ``UsageError``, so a raw
-    ``KeyError`` / ``ValueError`` would orphan the just-registered agent.
-    """
-
-    def test_unknown_placeholder_raises_usage_error(
-        self,
-        ctx,
-        director_agent_id,
-        new_agent_id,
-        mock_get_agent,
-    ):
-        with pytest.raises(click.UsageError) as exc_info:
-            _resolve_prompt(
-                ctx,
-                director_agent_id=director_agent_id,
-                new_agent_id=new_agent_id,
-                prompt_argv=("hello", "{foo}"),
-            )
-        message = str(exc_info.value)
-        assert "foo" in message
-        assert "{session_id}" in message
-        assert "{agent_id}" in message
-
-    def test_unmatched_brace_raises_usage_error(
-        self,
-        ctx,
-        director_agent_id,
-        new_agent_id,
-        mock_get_agent,
-    ):
-        with pytest.raises(click.UsageError) as exc_info:
-            _resolve_prompt(
-                ctx,
-                director_agent_id=director_agent_id,
-                new_agent_id=new_agent_id,
-                prompt_argv=("hello", "{unclosed"),
-            )
-        message = str(exc_info.value)
-        assert "{{" in message
-        assert "}}" in message
-
-    def test_attribute_access_raises_usage_error(
-        self,
-        ctx,
-        director_agent_id,
-        new_agent_id,
-        mock_get_agent,
-    ):
-        # PR #25 3rd review: ``{agent_id.foo}`` triggers str.format attribute
-        # access on the substituted string; ``str`` has no ``.foo`` so Python
-        # raises ``AttributeError``. Must be caught and converted to
-        # ``UsageError`` so the rollback path in ``member_create`` still runs.
-        with pytest.raises(click.UsageError) as exc_info:
-            _resolve_prompt(
-                ctx,
-                director_agent_id=director_agent_id,
-                new_agent_id=new_agent_id,
-                prompt_argv=("hello", "{agent_id.foo}"),
-            )
-        message = str(exc_info.value)
-        assert "{{" in message
-        assert "}}" in message
+    message = str(exc_info.value)
+    assert "{{" in message
+    assert "}}" in message
 
 
 _CLI_FAKE_DIRECTOR_CTX = DirectorContext(session="main", window_id="@3", pane_id="%0")
@@ -276,88 +264,83 @@ def stub_coding_agent_binaries(monkeypatch):
     monkeypatch.setattr("cafleet.cli.shutil.which", lambda _: "/usr/bin/stub")
 
 
-class TestMemberCreatePassesDisplayName:
-    """``cli.py`` threads ``--name`` as ``display_name`` into
-    ``_build_claude_command()``, which means the ``command`` kwarg handed
-    to ``tmux.split_window`` contains ``"--name"`` + the member name.
-    """
-
-    def test_member_create_passes_member_name_as_display_name(
-        self,
-        bootstrapped_session,
-        split_window_recorder,
-        stub_coding_agent_binaries,
-    ):
-        session_id, director_id, runner = bootstrapped_session
-        result = runner.invoke(
-            cli,
-            [
-                "--session-id",
-                session_id,
-                "member",
-                "create",
-                "--agent-id",
-                director_id,
-                "--name",
-                "Drafter",
-                "--description",
-                "Drafter for PR #42",
-                "--",
-                "hello",
-            ],
-        )
-        assert result.exit_code == 0, result.output
-        assert len(split_window_recorder) == 1
-        command = split_window_recorder[0]["command"]
-        assert isinstance(command, list)
-        assert "--name" in command
-        name_index = command.index("--name")
-        assert command[name_index + 1] == "Drafter"
-        assert command[name_index + 2] == "hello"
-        assert command[0] == "claude"
+# --- member_create_passes_display_name: ``cli.py`` threads ``--name`` as
+# ``display_name`` into ``_build_claude_command()``, which means the ``command``
+# kwarg handed to ``tmux.split_window`` contains ``"--name"`` + the member name. ---
 
 
-class TestPermissionMode:
-    """Spawn argv carries ``--permission-mode dontAsk``.
+def test_member_create_passes_display_name__member_create_passes_member_name_as_display_name(
+    bootstrapped_session,
+    split_window_recorder,
+    stub_coding_agent_binaries,
+):
+    session_id, director_id, runner = bootstrapped_session
+    result = runner.invoke(
+        cli,
+        [
+            "--session-id",
+            session_id,
+            "member",
+            "create",
+            "--agent-id",
+            director_id,
+            "--name",
+            "Drafter",
+            "--description",
+            "Drafter for PR #42",
+            "--",
+            "hello",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert len(split_window_recorder) == 1
+    command = split_window_recorder[0]["command"]
+    assert isinstance(command, list)
+    assert "--name" in command
+    name_index = command.index("--name")
+    assert command[name_index + 1] == "Drafter"
+    assert command[name_index + 2] == "hello"
+    assert command[0] == "claude"
 
-    Members spawn with the Bash tool enabled and permission prompts auto-resolve.
-    """
 
-    def test_claude_default_injects_dontask_permission_mode(
-        self,
-        bootstrapped_session,
-        split_window_recorder,
-        stub_coding_agent_binaries,
-    ):
-        session_id, director_id, runner = bootstrapped_session
-        result = runner.invoke(
-            cli,
-            [
-                "--session-id",
-                session_id,
-                "member",
-                "create",
-                "--agent-id",
-                director_id,
-                "--name",
-                "Drafter",
-                "--description",
-                "Drafter for PR #42",
-                "--",
-                "hello",
-            ],
-        )
-        assert result.exit_code == 0, result.output
-        assert len(split_window_recorder) == 1
-        command = split_window_recorder[0]["command"]
-        assert "--permission-mode" in command
-        perm_index = command.index("--permission-mode")
-        assert command[perm_index + 1] == "dontAsk"
-        assert command[0] == "claude"
-        assert "--disallowedTools" not in command
-        assert "Bash" not in command
-        # Pinned argv ordering: permission tokens before name args.
-        name_index = command.index("--name")
-        assert perm_index < name_index, (
-            f"--permission-mode must precede --name; got {command!r}"
-        )
+# --- permission_mode: spawn argv carries ``--permission-mode dontAsk``.
+# Members spawn with the Bash tool enabled and permission prompts auto-resolve. ---
+
+
+def test_permission_mode__claude_default_injects_dontask_permission_mode(
+    bootstrapped_session,
+    split_window_recorder,
+    stub_coding_agent_binaries,
+):
+    session_id, director_id, runner = bootstrapped_session
+    result = runner.invoke(
+        cli,
+        [
+            "--session-id",
+            session_id,
+            "member",
+            "create",
+            "--agent-id",
+            director_id,
+            "--name",
+            "Drafter",
+            "--description",
+            "Drafter for PR #42",
+            "--",
+            "hello",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert len(split_window_recorder) == 1
+    command = split_window_recorder[0]["command"]
+    assert "--permission-mode" in command
+    perm_index = command.index("--permission-mode")
+    assert command[perm_index + 1] == "dontAsk"
+    assert command[0] == "claude"
+    assert "--disallowedTools" not in command
+    assert "Bash" not in command
+    # Pinned argv ordering: permission tokens before name args.
+    name_index = command.index("--name")
+    assert perm_index < name_index, (
+        f"--permission-mode must precede --name; got {command!r}"
+    )

--- a/cafleet/tests/test_cli_member_delete.py
+++ b/cafleet/tests/test_cli_member_delete.py
@@ -227,9 +227,7 @@ def test_happy_path__call_ordering_send_exit_then_wait_then_deregister_then_layo
         "select_layout",
     ]
 
-    assert send_exit_recorder == [
-        {"target_pane_id": PANE_ID, "ignore_missing": True}
-    ]
+    assert send_exit_recorder == [{"target_pane_id": PANE_ID, "ignore_missing": True}]
     assert deregister_recorder == [MEMBER_ID]
 
     out = result.output
@@ -400,9 +398,7 @@ def test_force__force_kills_pane_then_deregisters(
     assert send_exit_recorder == []
     assert wait_for_pane_gone_recorder.calls == []
 
-    assert kill_pane_recorder == [
-        {"target_pane_id": PANE_ID, "ignore_missing": True}
-    ]
+    assert kill_pane_recorder == [{"target_pane_id": PANE_ID, "ignore_missing": True}]
     assert deregister_recorder == [MEMBER_ID]
 
     names = [name for (name, *_) in call_log]
@@ -430,9 +426,7 @@ def test_force__force_short_flag_works(
     result = _invoke(runner, session_id, "-f")
     assert result.exit_code == 0, result.output
     assert send_exit_recorder == []
-    assert kill_pane_recorder == [
-        {"target_pane_id": PANE_ID, "ignore_missing": True}
-    ]
+    assert kill_pane_recorder == [{"target_pane_id": PANE_ID, "ignore_missing": True}]
 
 
 def test_force__force_json_output_pane_status_killed(
@@ -516,9 +510,7 @@ def test_authorization_boundary__fetch_db_error_surfaces_failed_to_fetch_wording
 def test_authorization_boundary__placement_none_exits_one_with_deregister_hint(
     runner, session_id, monkeypatch, deregister_recorder
 ):
-    monkeypatch.setattr(
-        broker, "get_agent", lambda *_a, **_kw: _agent(placement=None)
-    )
+    monkeypatch.setattr(broker, "get_agent", lambda *_a, **_kw: _agent(placement=None))
     result = _invoke(runner, session_id)
     assert result.exit_code == 1, result.output
     out = result.output or ""

--- a/cafleet/tests/test_cli_member_delete.py
+++ b/cafleet/tests/test_cli_member_delete.py
@@ -203,403 +203,393 @@ def _invoke_json(runner, session_id, *extra_args):
     )
 
 
-class TestHappyPath:
-    def test_call_ordering_send_exit_then_wait_then_deregister_then_layout(
-        self,
-        runner,
-        session_id,
-        monkeypatch,
-        call_log,
-        deregister_recorder,
-        send_exit_recorder,
-        select_layout_recorder,
-        wait_for_pane_gone_recorder,
-    ):
-        monkeypatch.setattr(broker, "get_agent", lambda *_a, **_kw: _agent())
-        wait_for_pane_gone_recorder.state["return_value"] = True
+def test_happy_path__call_ordering_send_exit_then_wait_then_deregister_then_layout(
+    runner,
+    session_id,
+    monkeypatch,
+    call_log,
+    deregister_recorder,
+    send_exit_recorder,
+    select_layout_recorder,
+    wait_for_pane_gone_recorder,
+):
+    monkeypatch.setattr(broker, "get_agent", lambda *_a, **_kw: _agent())
+    wait_for_pane_gone_recorder.state["return_value"] = True
 
-        result = _invoke(runner, session_id)
-        assert result.exit_code == 0, result.output
+    result = _invoke(runner, session_id)
+    assert result.exit_code == 0, result.output
 
-        names = [name for (name, *_) in call_log]
-        assert names == [
-            "send_exit",
-            "wait_for_pane_gone",
-            "deregister_agent",
-            "select_layout",
-        ]
+    names = [name for (name, *_) in call_log]
+    assert names == [
+        "send_exit",
+        "wait_for_pane_gone",
+        "deregister_agent",
+        "select_layout",
+    ]
 
-        assert send_exit_recorder == [
-            {"target_pane_id": PANE_ID, "ignore_missing": True}
-        ]
-        assert deregister_recorder == [MEMBER_ID]
+    assert send_exit_recorder == [
+        {"target_pane_id": PANE_ID, "ignore_missing": True}
+    ]
+    assert deregister_recorder == [MEMBER_ID]
 
-        out = result.output
-        assert "Member deleted." in out
-        assert MEMBER_ID in out
-        assert f"{PANE_ID} (closed)" in out
-
-    def test_json_output_returns_agent_id_and_pane_status(
-        self,
-        runner,
-        session_id,
-        monkeypatch,
-        deregister_recorder,
-        wait_for_pane_gone_recorder,
-    ):
-        monkeypatch.setattr(broker, "get_agent", lambda *_a, **_kw: _agent())
-        wait_for_pane_gone_recorder.state["return_value"] = True
-
-        result = _invoke_json(runner, session_id)
-        assert result.exit_code == 0, result.output
-        data = json.loads(result.stdout)
-        assert data == {
-            "agent_id": MEMBER_ID,
-            "pane_status": f"{PANE_ID} (closed)",
-        }
+    out = result.output
+    assert "Member deleted." in out
+    assert MEMBER_ID in out
+    assert f"{PANE_ID} (closed)" in out
 
 
-class TestPaneAlreadyGone:
-    def test_pane_already_gone_first_poll_yields_happy_path(
-        self,
-        runner,
-        session_id,
-        monkeypatch,
-        call_log,
-        deregister_recorder,
-        send_exit_recorder,
-        select_layout_recorder,
-        wait_for_pane_gone_recorder,
-        capture_pane_recorder,
-    ):
-        monkeypatch.setattr(broker, "get_agent", lambda *_a, **_kw: _agent())
-        wait_for_pane_gone_recorder.state["return_value"] = True
+def test_happy_path__json_output_returns_agent_id_and_pane_status(
+    runner,
+    session_id,
+    monkeypatch,
+    deregister_recorder,
+    wait_for_pane_gone_recorder,
+):
+    monkeypatch.setattr(broker, "get_agent", lambda *_a, **_kw: _agent())
+    wait_for_pane_gone_recorder.state["return_value"] = True
 
-        result = _invoke(runner, session_id)
-        assert result.exit_code == 0, result.output
-
-        assert capture_pane_recorder.calls == []
-
-        names = [name for (name, *_) in call_log]
-        assert "capture_pane" not in names
-        assert names == [
-            "send_exit",
-            "wait_for_pane_gone",
-            "deregister_agent",
-            "select_layout",
-        ]
-
-        assert deregister_recorder == [MEMBER_ID]
-
-        out = result.output
-        assert "Member deleted." in out
-        assert "already gone" not in out
-        assert f"{PANE_ID} (closed)" in out
+    result = _invoke_json(runner, session_id)
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.stdout)
+    assert data == {
+        "agent_id": MEMBER_ID,
+        "pane_status": f"{PANE_ID} (closed)",
+    }
 
 
-class TestTimeout:
-    def test_timeout_exits_two_with_tail_and_recovery_hint(
-        self,
-        runner,
-        session_id,
-        monkeypatch,
-        call_log,
-        deregister_recorder,
-        send_exit_recorder,
-        select_layout_recorder,
-        wait_for_pane_gone_recorder,
-        capture_pane_recorder,
-    ):
-        monkeypatch.setattr(broker, "get_agent", lambda *_a, **_kw: _agent())
-        wait_for_pane_gone_recorder.state["return_value"] = False
-        capture_pane_recorder.state["return_value"] = "STUCK_BUFFER_TAIL"
+def test_pane_already_gone__pane_already_gone_first_poll_yields_happy_path(
+    runner,
+    session_id,
+    monkeypatch,
+    call_log,
+    deregister_recorder,
+    send_exit_recorder,
+    select_layout_recorder,
+    wait_for_pane_gone_recorder,
+    capture_pane_recorder,
+):
+    monkeypatch.setattr(broker, "get_agent", lambda *_a, **_kw: _agent())
+    wait_for_pane_gone_recorder.state["return_value"] = True
 
-        result = _invoke(runner, session_id)
-        assert result.exit_code == 2, (result.output, getattr(result, "stderr", ""))
+    result = _invoke(runner, session_id)
+    assert result.exit_code == 0, result.output
 
-        combined = (result.output or "") + (getattr(result, "stderr", "") or "")
-        assert f"pane {PANE_ID} did not close within 15.0s" in combined
-        assert "STUCK_BUFFER_TAIL" in combined
-        assert "cafleet member capture" in combined
-        assert "cafleet member send-input" in combined
-        assert "--force" in combined
+    assert capture_pane_recorder.calls == []
 
-        assert deregister_recorder == []
-        assert select_layout_recorder == []
+    names = [name for (name, *_) in call_log]
+    assert "capture_pane" not in names
+    assert names == [
+        "send_exit",
+        "wait_for_pane_gone",
+        "deregister_agent",
+        "select_layout",
+    ]
 
-        names = [name for (name, *_) in call_log]
-        assert "deregister_agent" not in names
-        assert "select_layout" not in names
-        assert names == [
-            "send_exit",
-            "wait_for_pane_gone",
-            "capture_pane",
-        ]
+    assert deregister_recorder == [MEMBER_ID]
 
-    def test_timeout_json_output_pane_status(
-        self,
-        runner,
-        session_id,
-        monkeypatch,
-        deregister_recorder,
-        wait_for_pane_gone_recorder,
-        capture_pane_recorder,
-    ):
-        monkeypatch.setattr(broker, "get_agent", lambda *_a, **_kw: _agent())
-        wait_for_pane_gone_recorder.state["return_value"] = False
-        capture_pane_recorder.state["return_value"] = "STUCK_BUFFER_TAIL"
-
-        result = _invoke_json(runner, session_id)
-        assert result.exit_code == 2, result.output
-        data = json.loads(result.stdout)
-        assert data == {
-            "agent_id": MEMBER_ID,
-            "pane_status": f"{PANE_ID} (timeout)",
-        }
-
-    def test_capture_failure_still_exits_two(
-        self,
-        runner,
-        session_id,
-        monkeypatch,
-        deregister_recorder,
-        send_exit_recorder,
-        wait_for_pane_gone_recorder,
-        capture_pane_recorder,
-    ):
-        monkeypatch.setattr(broker, "get_agent", lambda *_a, **_kw: _agent())
-        wait_for_pane_gone_recorder.state["return_value"] = False
-        capture_pane_recorder.state["side_effect"] = TmuxError(
-            "capture-pane failed: pane is dead"
-        )
-
-        result = _invoke(runner, session_id)
-        assert result.exit_code == 2, (result.output, getattr(result, "stderr", ""))
-
-        combined = (result.output or "") + (getattr(result, "stderr", "") or "")
-        assert "Warning: capture_pane failed during timeout handling" in combined
-        assert "timeout error and recovery hint still print" in combined
-        assert f"pane {PANE_ID} did not close within 15.0s" in combined
-        assert "cafleet member capture" in combined
-        assert "cafleet member send-input" in combined
-        assert "--force" in combined
-
-        assert deregister_recorder == []
+    out = result.output
+    assert "Member deleted." in out
+    assert "already gone" not in out
+    assert f"{PANE_ID} (closed)" in out
 
 
-class TestForce:
-    def test_force_kills_pane_then_deregisters(
-        self,
-        runner,
-        session_id,
-        monkeypatch,
-        call_log,
-        deregister_recorder,
-        send_exit_recorder,
-        select_layout_recorder,
-        kill_pane_recorder,
-        wait_for_pane_gone_recorder,
-    ):
-        monkeypatch.setattr(broker, "get_agent", lambda *_a, **_kw: _agent())
+def test_timeout__timeout_exits_two_with_tail_and_recovery_hint(
+    runner,
+    session_id,
+    monkeypatch,
+    call_log,
+    deregister_recorder,
+    send_exit_recorder,
+    select_layout_recorder,
+    wait_for_pane_gone_recorder,
+    capture_pane_recorder,
+):
+    monkeypatch.setattr(broker, "get_agent", lambda *_a, **_kw: _agent())
+    wait_for_pane_gone_recorder.state["return_value"] = False
+    capture_pane_recorder.state["return_value"] = "STUCK_BUFFER_TAIL"
 
-        result = _invoke(runner, session_id, "--force")
-        assert result.exit_code == 0, result.output
+    result = _invoke(runner, session_id)
+    assert result.exit_code == 2, (result.output, getattr(result, "stderr", ""))
 
-        assert send_exit_recorder == []
-        assert wait_for_pane_gone_recorder.calls == []
+    combined = (result.output or "") + (getattr(result, "stderr", "") or "")
+    assert f"pane {PANE_ID} did not close within 15.0s" in combined
+    assert "STUCK_BUFFER_TAIL" in combined
+    assert "cafleet member capture" in combined
+    assert "cafleet member send-input" in combined
+    assert "--force" in combined
 
-        assert kill_pane_recorder == [
-            {"target_pane_id": PANE_ID, "ignore_missing": True}
-        ]
-        assert deregister_recorder == [MEMBER_ID]
+    assert deregister_recorder == []
+    assert select_layout_recorder == []
 
-        names = [name for (name, *_) in call_log]
-        assert names == [
-            "kill_pane",
-            "deregister_agent",
-            "select_layout",
-        ]
-
-        out = result.output
-        assert "Member deleted (--force)." in out
-        assert f"{PANE_ID} (killed)" in out
-
-    def test_force_short_flag_works(
-        self,
-        runner,
-        session_id,
-        monkeypatch,
-        deregister_recorder,
-        send_exit_recorder,
-        kill_pane_recorder,
-    ):
-        monkeypatch.setattr(broker, "get_agent", lambda *_a, **_kw: _agent())
-
-        result = _invoke(runner, session_id, "-f")
-        assert result.exit_code == 0, result.output
-        assert send_exit_recorder == []
-        assert kill_pane_recorder == [
-            {"target_pane_id": PANE_ID, "ignore_missing": True}
-        ]
-
-    def test_force_json_output_pane_status_killed(
-        self,
-        runner,
-        session_id,
-        monkeypatch,
-        deregister_recorder,
-        kill_pane_recorder,
-    ):
-        monkeypatch.setattr(broker, "get_agent", lambda *_a, **_kw: _agent())
-
-        result = _invoke_json(runner, session_id, "--force")
-        assert result.exit_code == 0, result.output
-        data = json.loads(result.stdout)
-        assert data == {
-            "agent_id": MEMBER_ID,
-            "pane_status": f"{PANE_ID} (killed)",
-        }
+    names = [name for (name, *_) in call_log]
+    assert "deregister_agent" not in names
+    assert "select_layout" not in names
+    assert names == [
+        "send_exit",
+        "wait_for_pane_gone",
+        "capture_pane",
+    ]
 
 
-class TestPendingPlacementForce:
-    def test_force_with_pending_placement_skips_all_tmux(
-        self,
-        runner,
-        session_id,
-        monkeypatch,
-        call_log,
-        deregister_recorder,
-        send_exit_recorder,
-        select_layout_recorder,
-        kill_pane_recorder,
-        wait_for_pane_gone_recorder,
-    ):
-        monkeypatch.setattr(
-            broker,
-            "get_agent",
-            lambda *_a, **_kw: _agent(placement=_placement(tmux_pane_id=None)),
-        )
+def test_timeout__timeout_json_output_pane_status(
+    runner,
+    session_id,
+    monkeypatch,
+    deregister_recorder,
+    wait_for_pane_gone_recorder,
+    capture_pane_recorder,
+):
+    monkeypatch.setattr(broker, "get_agent", lambda *_a, **_kw: _agent())
+    wait_for_pane_gone_recorder.state["return_value"] = False
+    capture_pane_recorder.state["return_value"] = "STUCK_BUFFER_TAIL"
 
-        result = _invoke(runner, session_id, "--force")
-        assert result.exit_code == 0, result.output
-
-        assert deregister_recorder == [MEMBER_ID]
-        assert send_exit_recorder == []
-        assert kill_pane_recorder == []
-        assert select_layout_recorder == []
-        assert wait_for_pane_gone_recorder.calls == []
-
-        names = [name for (name, *_) in call_log]
-        assert names == ["deregister_agent"]
+    result = _invoke_json(runner, session_id)
+    assert result.exit_code == 2, result.output
+    data = json.loads(result.stdout)
+    assert data == {
+        "agent_id": MEMBER_ID,
+        "pane_status": f"{PANE_ID} (timeout)",
+    }
 
 
-class TestAuthorizationBoundary:
-    def test_missing_agent_exits_one(
-        self, runner, session_id, monkeypatch, deregister_recorder
-    ):
-        monkeypatch.setattr(broker, "get_agent", lambda *_a, **_kw: None)
-        result = _invoke(runner, session_id)
-        assert result.exit_code == 1, result.output
-        out = result.output or ""
-        assert MEMBER_ID in out
-        assert "failed to fetch member" not in out
-        assert f"Error: Agent {MEMBER_ID} not found" in out
-        assert deregister_recorder == []
+def test_timeout__capture_failure_still_exits_two(
+    runner,
+    session_id,
+    monkeypatch,
+    deregister_recorder,
+    send_exit_recorder,
+    wait_for_pane_gone_recorder,
+    capture_pane_recorder,
+):
+    monkeypatch.setattr(broker, "get_agent", lambda *_a, **_kw: _agent())
+    wait_for_pane_gone_recorder.state["return_value"] = False
+    capture_pane_recorder.state["side_effect"] = TmuxError(
+        "capture-pane failed: pane is dead"
+    )
 
-    def test_fetch_db_error_surfaces_failed_to_fetch_wording(
-        self, runner, session_id, monkeypatch, deregister_recorder
-    ):
-        """Symmetric guard: real ``get_agent`` failures keep the wrapper wording."""
+    result = _invoke(runner, session_id)
+    assert result.exit_code == 2, (result.output, getattr(result, "stderr", ""))
 
-        def boom(*_a, **_kw):
-            raise RuntimeError("db connection lost")
+    combined = (result.output or "") + (getattr(result, "stderr", "") or "")
+    assert "Warning: capture_pane failed during timeout handling" in combined
+    assert "timeout error and recovery hint still print" in combined
+    assert f"pane {PANE_ID} did not close within 15.0s" in combined
+    assert "cafleet member capture" in combined
+    assert "cafleet member send-input" in combined
+    assert "--force" in combined
 
-        monkeypatch.setattr(broker, "get_agent", boom)
-        result = _invoke(runner, session_id)
-        assert result.exit_code == 1
-        out = result.output or ""
-        assert "failed to fetch member" in out
-        assert "db connection lost" in out
-        assert deregister_recorder == []
-
-    def test_placement_none_exits_one_with_deregister_hint(
-        self, runner, session_id, monkeypatch, deregister_recorder
-    ):
-        monkeypatch.setattr(
-            broker, "get_agent", lambda *_a, **_kw: _agent(placement=None)
-        )
-        result = _invoke(runner, session_id)
-        assert result.exit_code == 1, result.output
-        out = result.output or ""
-        assert f"agent {MEMBER_ID}" in out
-        assert "has no placement" in out
-        assert "cafleet agent deregister" in out
-        assert deregister_recorder == []
-
-    def test_cross_director_same_session_is_rejected(
-        self, runner, session_id, monkeypatch, deregister_recorder, send_exit_recorder
-    ):
-        """Regression guard for the cross-Director auth gap in ``member_delete``."""
-        monkeypatch.setattr(
-            broker,
-            "get_agent",
-            lambda *_a, **_kw: _agent(
-                placement=_placement(director_agent_id=OTHER_DIRECTOR_ID)
-            ),
-        )
-        result = _invoke(runner, session_id)
-        assert result.exit_code == 1, result.output
-        out = result.output or ""
-        assert f"agent {MEMBER_ID}" in out
-        assert "is not a member of your team" in out
-        assert OTHER_DIRECTOR_ID in out
-        assert deregister_recorder == []
-        assert send_exit_recorder == []
+    assert deregister_recorder == []
 
 
-class TestPendingPlacement:
-    def test_pending_pane_id_skips_send_exit(
-        self, runner, session_id, monkeypatch, deregister_recorder, send_exit_recorder
-    ):
-        """Pending placements still deregister but skip the pane ``/exit``."""
-        monkeypatch.setattr(
-            broker,
-            "get_agent",
-            lambda *_a, **_kw: _agent(placement=_placement(tmux_pane_id=None)),
-        )
-        result = _invoke(runner, session_id)
-        assert result.exit_code == 0, result.output
-        assert deregister_recorder == [MEMBER_ID]
-        assert send_exit_recorder == []
-        out = result.output
-        assert "(pending" in out
-        assert "no pane" in out
+def test_force__force_kills_pane_then_deregisters(
+    runner,
+    session_id,
+    monkeypatch,
+    call_log,
+    deregister_recorder,
+    send_exit_recorder,
+    select_layout_recorder,
+    kill_pane_recorder,
+    wait_for_pane_gone_recorder,
+):
+    monkeypatch.setattr(broker, "get_agent", lambda *_a, **_kw: _agent())
+
+    result = _invoke(runner, session_id, "--force")
+    assert result.exit_code == 0, result.output
+
+    assert send_exit_recorder == []
+    assert wait_for_pane_gone_recorder.calls == []
+
+    assert kill_pane_recorder == [
+        {"target_pane_id": PANE_ID, "ignore_missing": True}
+    ]
+    assert deregister_recorder == [MEMBER_ID]
+
+    names = [name for (name, *_) in call_log]
+    assert names == [
+        "kill_pane",
+        "deregister_agent",
+        "select_layout",
+    ]
+
+    out = result.output
+    assert "Member deleted (--force)." in out
+    assert f"{PANE_ID} (killed)" in out
 
 
-class TestTmuxErrorOnSendExit:
-    def test_send_exit_failure_now_exits_one_with_recovery_wording(
-        self, runner, session_id, monkeypatch, deregister_recorder
-    ):
-        """Under design 0000032 §3, send_exit TmuxError is a hard exit-1.
+def test_force__force_short_flag_works(
+    runner,
+    session_id,
+    monkeypatch,
+    deregister_recorder,
+    send_exit_recorder,
+    kill_pane_recorder,
+):
+    monkeypatch.setattr(broker, "get_agent", lambda *_a, **_kw: _agent())
 
-        The old behavior was warning-and-continue with `tmux kill-pane -t <pane>`
-        in the warning text. The new wording points operators at `cafleet doctor`
-        and `--force` instead, with no raw tmux command exposed.
-        """
-        monkeypatch.setattr(broker, "get_agent", lambda *_a, **_kw: _agent())
+    result = _invoke(runner, session_id, "-f")
+    assert result.exit_code == 0, result.output
+    assert send_exit_recorder == []
+    assert kill_pane_recorder == [
+        {"target_pane_id": PANE_ID, "ignore_missing": True}
+    ]
 
-        def fake_send_exit(**_kw):
-            raise TmuxError("send-keys failed: pane is dead")
 
-        monkeypatch.setattr(tmux, "send_exit", fake_send_exit)
-        result = _invoke(runner, session_id)
+def test_force__force_json_output_pane_status_killed(
+    runner,
+    session_id,
+    monkeypatch,
+    deregister_recorder,
+    kill_pane_recorder,
+):
+    monkeypatch.setattr(broker, "get_agent", lambda *_a, **_kw: _agent())
 
-        assert result.exit_code == 1, (result.output, getattr(result, "stderr", ""))
-        combined = (result.output or "") + (getattr(result, "stderr", "") or "")
-        assert "send_exit failed" in combined
-        assert "tmux server may be unreachable" in combined
-        assert "cafleet doctor" in combined
-        assert "--force" in combined
-        assert "tmux kill-pane" not in combined
+    result = _invoke_json(runner, session_id, "--force")
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.stdout)
+    assert data == {
+        "agent_id": MEMBER_ID,
+        "pane_status": f"{PANE_ID} (killed)",
+    }
 
-        assert deregister_recorder == []
+
+def test_pending_placement_force__force_with_pending_placement_skips_all_tmux(
+    runner,
+    session_id,
+    monkeypatch,
+    call_log,
+    deregister_recorder,
+    send_exit_recorder,
+    select_layout_recorder,
+    kill_pane_recorder,
+    wait_for_pane_gone_recorder,
+):
+    monkeypatch.setattr(
+        broker,
+        "get_agent",
+        lambda *_a, **_kw: _agent(placement=_placement(tmux_pane_id=None)),
+    )
+
+    result = _invoke(runner, session_id, "--force")
+    assert result.exit_code == 0, result.output
+
+    assert deregister_recorder == [MEMBER_ID]
+    assert send_exit_recorder == []
+    assert kill_pane_recorder == []
+    assert select_layout_recorder == []
+    assert wait_for_pane_gone_recorder.calls == []
+
+    names = [name for (name, *_) in call_log]
+    assert names == ["deregister_agent"]
+
+
+def test_authorization_boundary__missing_agent_exits_one(
+    runner, session_id, monkeypatch, deregister_recorder
+):
+    monkeypatch.setattr(broker, "get_agent", lambda *_a, **_kw: None)
+    result = _invoke(runner, session_id)
+    assert result.exit_code == 1, result.output
+    out = result.output or ""
+    assert MEMBER_ID in out
+    assert "failed to fetch member" not in out
+    assert f"Error: Agent {MEMBER_ID} not found" in out
+    assert deregister_recorder == []
+
+
+def test_authorization_boundary__fetch_db_error_surfaces_failed_to_fetch_wording(
+    runner, session_id, monkeypatch, deregister_recorder
+):
+    """Symmetric guard: real ``get_agent`` failures keep the wrapper wording."""
+
+    def boom(*_a, **_kw):
+        raise RuntimeError("db connection lost")
+
+    monkeypatch.setattr(broker, "get_agent", boom)
+    result = _invoke(runner, session_id)
+    assert result.exit_code == 1
+    out = result.output or ""
+    assert "failed to fetch member" in out
+    assert "db connection lost" in out
+    assert deregister_recorder == []
+
+
+def test_authorization_boundary__placement_none_exits_one_with_deregister_hint(
+    runner, session_id, monkeypatch, deregister_recorder
+):
+    monkeypatch.setattr(
+        broker, "get_agent", lambda *_a, **_kw: _agent(placement=None)
+    )
+    result = _invoke(runner, session_id)
+    assert result.exit_code == 1, result.output
+    out = result.output or ""
+    assert f"agent {MEMBER_ID}" in out
+    assert "has no placement" in out
+    assert "cafleet agent deregister" in out
+    assert deregister_recorder == []
+
+
+def test_authorization_boundary__cross_director_same_session_is_rejected(
+    runner, session_id, monkeypatch, deregister_recorder, send_exit_recorder
+):
+    """Regression guard for the cross-Director auth gap in ``member_delete``."""
+    monkeypatch.setattr(
+        broker,
+        "get_agent",
+        lambda *_a, **_kw: _agent(
+            placement=_placement(director_agent_id=OTHER_DIRECTOR_ID)
+        ),
+    )
+    result = _invoke(runner, session_id)
+    assert result.exit_code == 1, result.output
+    out = result.output or ""
+    assert f"agent {MEMBER_ID}" in out
+    assert "is not a member of your team" in out
+    assert OTHER_DIRECTOR_ID in out
+    assert deregister_recorder == []
+    assert send_exit_recorder == []
+
+
+def test_pending_placement__pending_pane_id_skips_send_exit(
+    runner, session_id, monkeypatch, deregister_recorder, send_exit_recorder
+):
+    """Pending placements still deregister but skip the pane ``/exit``."""
+    monkeypatch.setattr(
+        broker,
+        "get_agent",
+        lambda *_a, **_kw: _agent(placement=_placement(tmux_pane_id=None)),
+    )
+    result = _invoke(runner, session_id)
+    assert result.exit_code == 0, result.output
+    assert deregister_recorder == [MEMBER_ID]
+    assert send_exit_recorder == []
+    out = result.output
+    assert "(pending" in out
+    assert "no pane" in out
+
+
+def test_tmux_error_on_send_exit__send_exit_failure_now_exits_one_with_recovery_wording(
+    runner, session_id, monkeypatch, deregister_recorder
+):
+    """Under design 0000032 §3, send_exit TmuxError is a hard exit-1.
+
+    The old behavior was warning-and-continue with `tmux kill-pane -t <pane>`
+    in the warning text. The new wording points operators at `cafleet doctor`
+    and `--force` instead, with no raw tmux command exposed.
+    """
+    monkeypatch.setattr(broker, "get_agent", lambda *_a, **_kw: _agent())
+
+    def fake_send_exit(**_kw):
+        raise TmuxError("send-keys failed: pane is dead")
+
+    monkeypatch.setattr(tmux, "send_exit", fake_send_exit)
+    result = _invoke(runner, session_id)
+
+    assert result.exit_code == 1, (result.output, getattr(result, "stderr", ""))
+    combined = (result.output or "") + (getattr(result, "stderr", "") or "")
+    assert "send_exit failed" in combined
+    assert "tmux server may be unreachable" in combined
+    assert "cafleet doctor" in combined
+    assert "--force" in combined
+    assert "tmux kill-pane" not in combined
+
+    assert deregister_recorder == []

--- a/cafleet/tests/test_cli_member_exec.py
+++ b/cafleet/tests/test_cli_member_exec.py
@@ -124,7 +124,9 @@ def test_exec_dispatch__positional_cmd_dispatched_with_pane_and_command(
     assert call["command"] == "git log -1 --oneline"
 
 
-def test_exec_dispatch__text_output(runner, session_id, happy_path_agent, bash_recorder):
+def test_exec_dispatch__text_output(
+    runner, session_id, happy_path_agent, bash_recorder
+):
     result = _invoke(runner, session_id, "git log -1 --oneline")
     assert result.exit_code == 0, result.output
     out = result.output or ""
@@ -161,13 +163,17 @@ def test_exec_dispatch__json_output_three_keys(
     assert data["command"] == payload
 
 
-def test_input_validation__missing_positional_exits_two(runner, session_id, happy_path_agent):
+def test_input_validation__missing_positional_exits_two(
+    runner, session_id, happy_path_agent
+):
     result = _invoke(runner, session_id)
     assert result.exit_code == 2, result.output
     assert "Missing argument" in (result.output or "")
 
 
-def test_input_validation__empty_command_exits_two(runner, session_id, happy_path_agent):
+def test_input_validation__empty_command_exits_two(
+    runner, session_id, happy_path_agent
+):
     result = _invoke(runner, session_id, "")
     assert result.exit_code == 2, result.output
     assert "command may not be empty." in (result.output or "")
@@ -199,7 +205,9 @@ def test_input_validation__command_with_newline_exits_two(
     assert "command may not contain newlines." in (result.output or "")
 
 
-def test_authorization_boundary__missing_agent_exits_one(runner, session_id, monkeypatch):
+def test_authorization_boundary__missing_agent_exits_one(
+    runner, session_id, monkeypatch
+):
     monkeypatch.setattr(broker, "get_agent", lambda *_a, **_kw: None)
     result = _invoke(runner, session_id, "git log -1")
     assert result.exit_code == 1, result.output

--- a/cafleet/tests/test_cli_member_exec.py
+++ b/cafleet/tests/test_cli_member_exec.py
@@ -113,157 +113,161 @@ def _invoke(runner, session_id, *extra_args, **invoke_kwargs):
     )
 
 
-class TestExecDispatch:
-    def test_positional_cmd_dispatched_with_pane_and_command(
-        self, runner, session_id, happy_path_agent, bash_recorder
-    ):
-        result = _invoke(runner, session_id, "git log -1 --oneline")
-        assert result.exit_code == 0, result.output
-        assert len(bash_recorder) == 1
-        call = bash_recorder[0]
-        assert call["target_pane_id"] == PANE_ID
-        assert call["command"] == "git log -1 --oneline"
-
-    def test_text_output(self, runner, session_id, happy_path_agent, bash_recorder):
-        result = _invoke(runner, session_id, "git log -1 --oneline")
-        assert result.exit_code == 0, result.output
-        out = result.output or ""
-        assert "Sent bash command" in out
-        assert "git log -1 --oneline" in out
-        assert MEMBER_NAME in out
-        assert PANE_ID in out
-
-    def test_json_output_three_keys(
-        self, runner, session_id, happy_path_agent, bash_recorder
-    ):
-        payload = "git log -1 --oneline"
-        result = runner.invoke(
-            cli,
-            [
-                "--session-id",
-                session_id,
-                "--json",
-                "member",
-                "exec",
-                "--agent-id",
-                DIRECTOR_ID,
-                "--member-id",
-                MEMBER_ID,
-                payload,
-            ],
-        )
-        assert result.exit_code == 0, result.output
-        data = json.loads(result.output)
-        assert set(data.keys()) == {"member_agent_id", "pane_id", "command"}
-        assert data["member_agent_id"] == MEMBER_ID
-        assert data["pane_id"] == PANE_ID
-        assert data["command"] == payload
+def test_exec_dispatch__positional_cmd_dispatched_with_pane_and_command(
+    runner, session_id, happy_path_agent, bash_recorder
+):
+    result = _invoke(runner, session_id, "git log -1 --oneline")
+    assert result.exit_code == 0, result.output
+    assert len(bash_recorder) == 1
+    call = bash_recorder[0]
+    assert call["target_pane_id"] == PANE_ID
+    assert call["command"] == "git log -1 --oneline"
 
 
-class TestInputValidation:
-    def test_missing_positional_exits_two(self, runner, session_id, happy_path_agent):
-        result = _invoke(runner, session_id)
-        assert result.exit_code == 2, result.output
-        assert "Missing argument" in (result.output or "")
+def test_exec_dispatch__text_output(runner, session_id, happy_path_agent, bash_recorder):
+    result = _invoke(runner, session_id, "git log -1 --oneline")
+    assert result.exit_code == 0, result.output
+    out = result.output or ""
+    assert "Sent bash command" in out
+    assert "git log -1 --oneline" in out
+    assert MEMBER_NAME in out
+    assert PANE_ID in out
 
-    def test_empty_command_exits_two(self, runner, session_id, happy_path_agent):
-        result = _invoke(runner, session_id, "")
-        assert result.exit_code == 2, result.output
-        assert "command may not be empty." in (result.output or "")
 
-    def test_whitespace_only_command_exits_two(
-        self, runner, session_id, happy_path_agent
-    ):
-        result = _invoke(runner, session_id, "   ")
-        assert result.exit_code == 2, result.output
-        assert "command may not be empty." in (result.output or "")
-
-    @pytest.mark.parametrize(
-        "bad_command",
+def test_exec_dispatch__json_output_three_keys(
+    runner, session_id, happy_path_agent, bash_recorder
+):
+    payload = "git log -1 --oneline"
+    result = runner.invoke(
+        cli,
         [
-            "\n",
-            "\r",
-            "\r\n",
-            "\nls",
-            "ls\n",
+            "--session-id",
+            session_id,
+            "--json",
+            "member",
+            "exec",
+            "--agent-id",
+            DIRECTOR_ID,
+            "--member-id",
+            MEMBER_ID,
+            payload,
         ],
     )
-    def test_command_with_newline_exits_two(
-        self, runner, session_id, happy_path_agent, bad_command
-    ):
-        result = _invoke(runner, session_id, bad_command)
-        assert result.exit_code == 2, result.output
-        assert "command may not contain newlines." in (result.output or "")
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    assert set(data.keys()) == {"member_agent_id", "pane_id", "command"}
+    assert data["member_agent_id"] == MEMBER_ID
+    assert data["pane_id"] == PANE_ID
+    assert data["command"] == payload
 
 
-class TestAuthorizationBoundary:
-    def test_missing_agent_exits_one(self, runner, session_id, monkeypatch):
-        monkeypatch.setattr(broker, "get_agent", lambda *_a, **_kw: None)
-        result = _invoke(runner, session_id, "git log -1")
-        assert result.exit_code == 1, result.output
-        assert MEMBER_ID in (result.output or "")
-        assert "not found" in (result.output or "").lower()
+def test_input_validation__missing_positional_exits_two(runner, session_id, happy_path_agent):
+    result = _invoke(runner, session_id)
+    assert result.exit_code == 2, result.output
+    assert "Missing argument" in (result.output or "")
 
-    def test_placement_none_exits_one_with_exact_message(
-        self, runner, session_id, monkeypatch
-    ):
-        monkeypatch.setattr(
-            broker,
-            "get_agent",
-            lambda *_a, **_kw: _agent(placement=None),
+
+def test_input_validation__empty_command_exits_two(runner, session_id, happy_path_agent):
+    result = _invoke(runner, session_id, "")
+    assert result.exit_code == 2, result.output
+    assert "command may not be empty." in (result.output or "")
+
+
+def test_input_validation__whitespace_only_command_exits_two(
+    runner, session_id, happy_path_agent
+):
+    result = _invoke(runner, session_id, "   ")
+    assert result.exit_code == 2, result.output
+    assert "command may not be empty." in (result.output or "")
+
+
+@pytest.mark.parametrize(
+    "bad_command",
+    [
+        "\n",
+        "\r",
+        "\r\n",
+        "\nls",
+        "ls\n",
+    ],
+)
+def test_input_validation__command_with_newline_exits_two(
+    runner, session_id, happy_path_agent, bad_command
+):
+    result = _invoke(runner, session_id, bad_command)
+    assert result.exit_code == 2, result.output
+    assert "command may not contain newlines." in (result.output or "")
+
+
+def test_authorization_boundary__missing_agent_exits_one(runner, session_id, monkeypatch):
+    monkeypatch.setattr(broker, "get_agent", lambda *_a, **_kw: None)
+    result = _invoke(runner, session_id, "git log -1")
+    assert result.exit_code == 1, result.output
+    assert MEMBER_ID in (result.output or "")
+    assert "not found" in (result.output or "").lower()
+
+
+def test_authorization_boundary__placement_none_exits_one_with_exact_message(
+    runner, session_id, monkeypatch
+):
+    monkeypatch.setattr(
+        broker,
+        "get_agent",
+        lambda *_a, **_kw: _agent(placement=None),
+    )
+    result = _invoke(runner, session_id, "git log -1")
+    assert result.exit_code == 1, result.output
+    out = result.output or ""
+    assert f"agent {MEMBER_ID}" in out
+    assert "has no placement row" in out
+    assert "cafleet member create" in out
+
+
+def test_authorization_boundary__cross_director_exits_one_with_exact_message(
+    runner, session_id, monkeypatch
+):
+    monkeypatch.setattr(
+        broker,
+        "get_agent",
+        lambda *_a, **_kw: _agent(
+            placement=_placement(director_agent_id=OTHER_DIRECTOR_ID)
+        ),
+    )
+    result = _invoke(runner, session_id, "git log -1")
+    assert result.exit_code == 1, result.output
+    out = result.output or ""
+    assert f"agent {MEMBER_ID}" in out
+    assert "is not a member of your team" in out
+    assert OTHER_DIRECTOR_ID in out
+
+
+def test_authorization_boundary__pending_pane_exits_one_with_exact_message(
+    runner, session_id, monkeypatch
+):
+    monkeypatch.setattr(
+        broker,
+        "get_agent",
+        lambda *_a, **_kw: _agent(placement=_placement(tmux_pane_id=None)),
+    )
+    result = _invoke(runner, session_id, "git log -1")
+    assert result.exit_code == 1, result.output
+    out = result.output or ""
+    assert f"member {MEMBER_ID}" in out
+    assert "has no pane yet" in out
+    assert "pending placement" in out
+
+
+def test_tmux_unavailable__tmux_not_available_exits_one(
+    runner, session_id, happy_path_agent, monkeypatch
+):
+    def raise_unavailable():
+        raise tmux.TmuxError(
+            "cafleet member commands must be run inside a tmux session"
         )
-        result = _invoke(runner, session_id, "git log -1")
-        assert result.exit_code == 1, result.output
-        out = result.output or ""
-        assert f"agent {MEMBER_ID}" in out
-        assert "has no placement row" in out
-        assert "cafleet member create" in out
 
-    def test_cross_director_exits_one_with_exact_message(
-        self, runner, session_id, monkeypatch
-    ):
-        monkeypatch.setattr(
-            broker,
-            "get_agent",
-            lambda *_a, **_kw: _agent(
-                placement=_placement(director_agent_id=OTHER_DIRECTOR_ID)
-            ),
-        )
-        result = _invoke(runner, session_id, "git log -1")
-        assert result.exit_code == 1, result.output
-        out = result.output or ""
-        assert f"agent {MEMBER_ID}" in out
-        assert "is not a member of your team" in out
-        assert OTHER_DIRECTOR_ID in out
-
-    def test_pending_pane_exits_one_with_exact_message(
-        self, runner, session_id, monkeypatch
-    ):
-        monkeypatch.setattr(
-            broker,
-            "get_agent",
-            lambda *_a, **_kw: _agent(placement=_placement(tmux_pane_id=None)),
-        )
-        result = _invoke(runner, session_id, "git log -1")
-        assert result.exit_code == 1, result.output
-        out = result.output or ""
-        assert f"member {MEMBER_ID}" in out
-        assert "has no pane yet" in out
-        assert "pending placement" in out
-
-
-class TestTmuxUnavailable:
-    def test_tmux_not_available_exits_one(
-        self, runner, session_id, happy_path_agent, monkeypatch
-    ):
-        def raise_unavailable():
-            raise tmux.TmuxError(
-                "cafleet member commands must be run inside a tmux session"
-            )
-
-        monkeypatch.setattr(tmux, "ensure_tmux_available", raise_unavailable)
-        result = _invoke(runner, session_id, "git log -1")
-        assert result.exit_code == 1, result.output
-        assert "cafleet member commands must be run inside a tmux session" in (
-            result.output or ""
-        )
+    monkeypatch.setattr(tmux, "ensure_tmux_available", raise_unavailable)
+    result = _invoke(runner, session_id, "git log -1")
+    assert result.exit_code == 1, result.output
+    assert "cafleet member commands must be run inside a tmux session" in (
+        result.output or ""
+    )

--- a/cafleet/tests/test_cli_member_ping.py
+++ b/cafleet/tests/test_cli_member_ping.py
@@ -115,203 +115,206 @@ def _invoke(runner, session_id, **invoke_kwargs):
     )
 
 
-class TestPingDispatch:
-    def test_poll_trigger_called_with_correct_kwargs(
-        self, runner, session_id, happy_path_agent, poll_recorder
-    ):
-        result = _invoke(runner, session_id)
-        assert result.exit_code == 0, result.output
-        assert len(poll_recorder) == 1
-        call = poll_recorder[0]
-        assert call["target_pane_id"] == PANE_ID
-        assert call["session_id"] == session_id
-        assert call["agent_id"] == MEMBER_ID
-
-    def test_text_output(self, runner, session_id, happy_path_agent, poll_recorder):
-        result = _invoke(runner, session_id)
-        assert result.exit_code == 0, result.output
-        out = result.output or ""
-        assert "Pinged member" in out
-        assert MEMBER_NAME in out
-        assert PANE_ID in out
-        assert "poll keystroke dispatched" in out
-
-    def test_json_output_two_keys(
-        self, runner, session_id, happy_path_agent, poll_recorder
-    ):
-        result = runner.invoke(
-            cli,
-            [
-                "--session-id",
-                session_id,
-                "--json",
-                "member",
-                "ping",
-                "--agent-id",
-                DIRECTOR_ID,
-                "--member-id",
-                MEMBER_ID,
-            ],
-        )
-        assert result.exit_code == 0, result.output
-        data = json.loads(result.output)
-        assert set(data.keys()) == {"member_agent_id", "pane_id"}
-        assert data["member_agent_id"] == MEMBER_ID
-        assert data["pane_id"] == PANE_ID
+def test_ping_dispatch__poll_trigger_called_with_correct_kwargs(
+    runner, session_id, happy_path_agent, poll_recorder
+):
+    result = _invoke(runner, session_id)
+    assert result.exit_code == 0, result.output
+    assert len(poll_recorder) == 1
+    call = poll_recorder[0]
+    assert call["target_pane_id"] == PANE_ID
+    assert call["session_id"] == session_id
+    assert call["agent_id"] == MEMBER_ID
 
 
-class TestSendFailure:
-    def test_send_poll_trigger_returns_false_exits_one(
-        self, runner, session_id, happy_path_agent, monkeypatch
-    ):
-        monkeypatch.setattr(
-            tmux, "send_poll_trigger", lambda **_kw: False, raising=False
-        )
-        result = _invoke(runner, session_id)
-        assert result.exit_code == 1, result.output
-        out = result.output or ""
-        assert "send failed" in out
-        assert "tmux send-keys did not deliver the poll-trigger keystroke" in out
-        assert PANE_ID in out
-
-    def test_send_poll_trigger_raises_tmux_error_exits_one(
-        self, runner, session_id, happy_path_agent, monkeypatch
-    ):
-        def raise_err(**_kw):
-            raise tmux.TmuxError("simulated")
-
-        monkeypatch.setattr(tmux, "send_poll_trigger", raise_err, raising=False)
-        result = _invoke(runner, session_id)
-        assert result.exit_code == 1, result.output
-        assert "send failed: simulated" in (result.output or "")
+def test_ping_dispatch__text_output(runner, session_id, happy_path_agent, poll_recorder):
+    result = _invoke(runner, session_id)
+    assert result.exit_code == 0, result.output
+    out = result.output or ""
+    assert "Pinged member" in out
+    assert MEMBER_NAME in out
+    assert PANE_ID in out
+    assert "poll keystroke dispatched" in out
 
 
-class TestAuthorizationBoundary:
-    def test_missing_agent_exits_one(self, runner, session_id, monkeypatch):
-        monkeypatch.setattr(broker, "get_agent", lambda *_a, **_kw: None)
-        result = _invoke(runner, session_id)
-        assert result.exit_code == 1, result.output
-        assert MEMBER_ID in (result.output or "")
-        assert "not found" in (result.output or "").lower()
-
-    def test_placement_none_exits_one_with_exact_message(
-        self, runner, session_id, monkeypatch
-    ):
-        monkeypatch.setattr(
-            broker,
-            "get_agent",
-            lambda *_a, **_kw: _agent(placement=None),
-        )
-        result = _invoke(runner, session_id)
-        assert result.exit_code == 1, result.output
-        out = result.output or ""
-        assert f"agent {MEMBER_ID}" in out
-        assert "has no placement row" in out
-        assert "cafleet member create" in out
-
-    def test_cross_director_exits_one_with_exact_message(
-        self, runner, session_id, monkeypatch
-    ):
-        monkeypatch.setattr(
-            broker,
-            "get_agent",
-            lambda *_a, **_kw: _agent(
-                placement=_placement(director_agent_id=OTHER_DIRECTOR_ID)
-            ),
-        )
-        result = _invoke(runner, session_id)
-        assert result.exit_code == 1, result.output
-        out = result.output or ""
-        assert f"agent {MEMBER_ID}" in out
-        assert "is not a member of your team" in out
-        assert OTHER_DIRECTOR_ID in out
-
-    def test_pending_pane_exits_one_with_exact_message(
-        self, runner, session_id, monkeypatch
-    ):
-        monkeypatch.setattr(
-            broker,
-            "get_agent",
-            lambda *_a, **_kw: _agent(placement=_placement(tmux_pane_id=None)),
-        )
-        result = _invoke(runner, session_id)
-        assert result.exit_code == 1, result.output
-        out = result.output or ""
-        assert f"member {MEMBER_ID}" in out
-        assert "has no pane yet" in out
-        assert "pending placement" in out
+def test_ping_dispatch__json_output_two_keys(
+    runner, session_id, happy_path_agent, poll_recorder
+):
+    result = runner.invoke(
+        cli,
+        [
+            "--session-id",
+            session_id,
+            "--json",
+            "member",
+            "ping",
+            "--agent-id",
+            DIRECTOR_ID,
+            "--member-id",
+            MEMBER_ID,
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    assert set(data.keys()) == {"member_agent_id", "pane_id"}
+    assert data["member_agent_id"] == MEMBER_ID
+    assert data["pane_id"] == PANE_ID
 
 
-class TestTmuxUnavailable:
-    def test_tmux_not_available_exits_one(
-        self, runner, session_id, happy_path_agent, monkeypatch
-    ):
-        def raise_unavailable():
-            raise tmux.TmuxError(
-                "cafleet member commands must be run inside a tmux session"
-            )
+def test_send_failure__send_poll_trigger_returns_false_exits_one(
+    runner, session_id, happy_path_agent, monkeypatch
+):
+    monkeypatch.setattr(
+        tmux, "send_poll_trigger", lambda **_kw: False, raising=False
+    )
+    result = _invoke(runner, session_id)
+    assert result.exit_code == 1, result.output
+    out = result.output or ""
+    assert "send failed" in out
+    assert "tmux send-keys did not deliver the poll-trigger keystroke" in out
+    assert PANE_ID in out
 
-        monkeypatch.setattr(tmux, "ensure_tmux_available", raise_unavailable)
-        result = _invoke(runner, session_id)
-        assert result.exit_code == 1, result.output
-        assert "cafleet member commands must be run inside a tmux session" in (
-            result.output or ""
+
+def test_send_failure__send_poll_trigger_raises_tmux_error_exits_one(
+    runner, session_id, happy_path_agent, monkeypatch
+):
+    def raise_err(**_kw):
+        raise tmux.TmuxError("simulated")
+
+    monkeypatch.setattr(tmux, "send_poll_trigger", raise_err, raising=False)
+    result = _invoke(runner, session_id)
+    assert result.exit_code == 1, result.output
+    assert "send failed: simulated" in (result.output or "")
+
+
+def test_authorization_boundary__missing_agent_exits_one(runner, session_id, monkeypatch):
+    monkeypatch.setattr(broker, "get_agent", lambda *_a, **_kw: None)
+    result = _invoke(runner, session_id)
+    assert result.exit_code == 1, result.output
+    assert MEMBER_ID in (result.output or "")
+    assert "not found" in (result.output or "").lower()
+
+
+def test_authorization_boundary__placement_none_exits_one_with_exact_message(
+    runner, session_id, monkeypatch
+):
+    monkeypatch.setattr(
+        broker,
+        "get_agent",
+        lambda *_a, **_kw: _agent(placement=None),
+    )
+    result = _invoke(runner, session_id)
+    assert result.exit_code == 1, result.output
+    out = result.output or ""
+    assert f"agent {MEMBER_ID}" in out
+    assert "has no placement row" in out
+    assert "cafleet member create" in out
+
+
+def test_authorization_boundary__cross_director_exits_one_with_exact_message(
+    runner, session_id, monkeypatch
+):
+    monkeypatch.setattr(
+        broker,
+        "get_agent",
+        lambda *_a, **_kw: _agent(
+            placement=_placement(director_agent_id=OTHER_DIRECTOR_ID)
+        ),
+    )
+    result = _invoke(runner, session_id)
+    assert result.exit_code == 1, result.output
+    out = result.output or ""
+    assert f"agent {MEMBER_ID}" in out
+    assert "is not a member of your team" in out
+    assert OTHER_DIRECTOR_ID in out
+
+
+def test_authorization_boundary__pending_pane_exits_one_with_exact_message(
+    runner, session_id, monkeypatch
+):
+    monkeypatch.setattr(
+        broker,
+        "get_agent",
+        lambda *_a, **_kw: _agent(placement=_placement(tmux_pane_id=None)),
+    )
+    result = _invoke(runner, session_id)
+    assert result.exit_code == 1, result.output
+    out = result.output or ""
+    assert f"member {MEMBER_ID}" in out
+    assert "has no pane yet" in out
+    assert "pending placement" in out
+
+
+def test_tmux_unavailable__tmux_not_available_exits_one(
+    runner, session_id, happy_path_agent, monkeypatch
+):
+    def raise_unavailable():
+        raise tmux.TmuxError(
+            "cafleet member commands must be run inside a tmux session"
         )
 
+    monkeypatch.setattr(tmux, "ensure_tmux_available", raise_unavailable)
+    result = _invoke(runner, session_id)
+    assert result.exit_code == 1, result.output
+    assert "cafleet member commands must be run inside a tmux session" in (
+        result.output or ""
+    )
 
-class TestInputValidation:
-    def test_missing_agent_id_exits_two(self, runner, session_id):
-        result = runner.invoke(
-            cli,
-            [
-                "--session-id",
-                session_id,
-                "member",
-                "ping",
-                "--member-id",
-                MEMBER_ID,
-            ],
-        )
-        assert result.exit_code == 2, result.output
-        out = result.output or ""
-        assert "Missing option" in out
-        assert "--agent-id" in out
 
-    def test_missing_member_id_exits_two(self, runner, session_id):
-        result = runner.invoke(
-            cli,
-            [
-                "--session-id",
-                session_id,
-                "member",
-                "ping",
-                "--agent-id",
-                DIRECTOR_ID,
-            ],
-        )
-        assert result.exit_code == 2, result.output
-        out = result.output or ""
-        assert "Missing option" in out
-        assert "--member-id" in out
+def test_input_validation__missing_agent_id_exits_two(runner, session_id):
+    result = runner.invoke(
+        cli,
+        [
+            "--session-id",
+            session_id,
+            "member",
+            "ping",
+            "--member-id",
+            MEMBER_ID,
+        ],
+    )
+    assert result.exit_code == 2, result.output
+    out = result.output or ""
+    assert "Missing option" in out
+    assert "--agent-id" in out
 
-    def test_unexpected_positional_argument_exits_two(self, runner, session_id):
-        result = runner.invoke(
-            cli,
-            [
-                "--session-id",
-                session_id,
-                "member",
-                "ping",
-                "--agent-id",
-                DIRECTOR_ID,
-                "--member-id",
-                MEMBER_ID,
-                "extra",
-            ],
-        )
-        assert result.exit_code == 2, result.output
-        out = result.output or ""
-        assert (
-            "unexpected extra argument" in out.lower()
-            or "got unexpected" in out.lower()
-        )
+
+def test_input_validation__missing_member_id_exits_two(runner, session_id):
+    result = runner.invoke(
+        cli,
+        [
+            "--session-id",
+            session_id,
+            "member",
+            "ping",
+            "--agent-id",
+            DIRECTOR_ID,
+        ],
+    )
+    assert result.exit_code == 2, result.output
+    out = result.output or ""
+    assert "Missing option" in out
+    assert "--member-id" in out
+
+
+def test_input_validation__unexpected_positional_argument_exits_two(runner, session_id):
+    result = runner.invoke(
+        cli,
+        [
+            "--session-id",
+            session_id,
+            "member",
+            "ping",
+            "--agent-id",
+            DIRECTOR_ID,
+            "--member-id",
+            MEMBER_ID,
+            "extra",
+        ],
+    )
+    assert result.exit_code == 2, result.output
+    out = result.output or ""
+    assert (
+        "unexpected extra argument" in out.lower()
+        or "got unexpected" in out.lower()
+    )

--- a/cafleet/tests/test_cli_member_ping.py
+++ b/cafleet/tests/test_cli_member_ping.py
@@ -127,7 +127,9 @@ def test_ping_dispatch__poll_trigger_called_with_correct_kwargs(
     assert call["agent_id"] == MEMBER_ID
 
 
-def test_ping_dispatch__text_output(runner, session_id, happy_path_agent, poll_recorder):
+def test_ping_dispatch__text_output(
+    runner, session_id, happy_path_agent, poll_recorder
+):
     result = _invoke(runner, session_id)
     assert result.exit_code == 0, result.output
     out = result.output or ""
@@ -164,9 +166,7 @@ def test_ping_dispatch__json_output_two_keys(
 def test_send_failure__send_poll_trigger_returns_false_exits_one(
     runner, session_id, happy_path_agent, monkeypatch
 ):
-    monkeypatch.setattr(
-        tmux, "send_poll_trigger", lambda **_kw: False, raising=False
-    )
+    monkeypatch.setattr(tmux, "send_poll_trigger", lambda **_kw: False, raising=False)
     result = _invoke(runner, session_id)
     assert result.exit_code == 1, result.output
     out = result.output or ""
@@ -187,7 +187,9 @@ def test_send_failure__send_poll_trigger_raises_tmux_error_exits_one(
     assert "send failed: simulated" in (result.output or "")
 
 
-def test_authorization_boundary__missing_agent_exits_one(runner, session_id, monkeypatch):
+def test_authorization_boundary__missing_agent_exits_one(
+    runner, session_id, monkeypatch
+):
     monkeypatch.setattr(broker, "get_agent", lambda *_a, **_kw: None)
     result = _invoke(runner, session_id)
     assert result.exit_code == 1, result.output
@@ -314,7 +316,4 @@ def test_input_validation__unexpected_positional_argument_exits_two(runner, sess
     )
     assert result.exit_code == 2, result.output
     out = result.output or ""
-    assert (
-        "unexpected extra argument" in out.lower()
-        or "got unexpected" in out.lower()
-    )
+    assert "unexpected extra argument" in out.lower() or "got unexpected" in out.lower()

--- a/cafleet/tests/test_cli_member_send_input.py
+++ b/cafleet/tests/test_cli_member_send_input.py
@@ -130,352 +130,361 @@ def _invoke(runner, session_id, *extra_args, **invoke_kwargs):
     )
 
 
-class TestFlagValidation:
-    def test_no_flag_supplied_exits_two(self, runner, session_id, happy_path_agent):
-        result = _invoke(runner, session_id)
-        assert result.exit_code == 2, result.output
-        out = result.output or ""
-        assert "--choice and --freetext are mutually exclusive" in out
+def test_flag_validation__no_flag_supplied_exits_two(runner, session_id, happy_path_agent):
+    result = _invoke(runner, session_id)
+    assert result.exit_code == 2, result.output
+    out = result.output or ""
+    assert "--choice and --freetext are mutually exclusive" in out
 
-    def test_choice_and_freetext_combo_exits_two(
-        self, runner, session_id, happy_path_agent
-    ):
-        result = _invoke(
-            runner,
-            session_id,
-            "--choice",
-            "1",
-            "--freetext",
-            "hello",
-        )
-        assert result.exit_code == 2, result.output
-        out = result.output or ""
-        assert "--choice" in out
-        assert "--freetext" in out
-        assert "mutually exclusive" in out
 
-    @pytest.mark.parametrize("bad_digit", ["0", "4", "5", "-1", "a"])
-    def test_choice_out_of_range_exits_two(
-        self, runner, session_id, happy_path_agent, bad_digit
-    ):
-        """``click.IntRange(1, 3)`` rejects anything outside {1,2,3}."""
-        result = _invoke(runner, session_id, "--choice", bad_digit)
-        assert result.exit_code == 2, result.output
+def test_flag_validation__choice_and_freetext_combo_exits_two(
+    runner, session_id, happy_path_agent
+):
+    result = _invoke(
+        runner,
+        session_id,
+        "--choice",
+        "1",
+        "--freetext",
+        "hello",
+    )
+    assert result.exit_code == 2, result.output
+    out = result.output or ""
+    assert "--choice" in out
+    assert "--freetext" in out
+    assert "mutually exclusive" in out
 
-    @pytest.mark.parametrize(
-        "bad_text",
+
+@pytest.mark.parametrize("bad_digit", ["0", "4", "5", "-1", "a"])
+def test_flag_validation__choice_out_of_range_exits_two(
+    runner, session_id, happy_path_agent, bad_digit
+):
+    """``click.IntRange(1, 3)`` rejects anything outside {1,2,3}."""
+    result = _invoke(runner, session_id, "--choice", bad_digit)
+    assert result.exit_code == 2, result.output
+
+
+@pytest.mark.parametrize(
+    "bad_text",
+    [
+        "line1\nline2",
+        "trailing\n",
+        "\nleading",
+        "carriage\rreturn",
+        "mixed\r\nCRLF",
+    ],
+)
+def test_flag_validation__freetext_with_newlines_exits_two(
+    runner, session_id, happy_path_agent, bad_text
+):
+    result = _invoke(runner, session_id, "--freetext", bad_text)
+    assert result.exit_code == 2, result.output
+    assert "free text may not contain newlines" in (result.output or "")
+
+
+def test_flag_validation__freetext_empty_string_is_accepted(
+    runner, session_id, happy_path_agent, freetext_recorder
+):
+    """Empty string is valid -- submits an empty answer to the prompt."""
+    result = _invoke(runner, session_id, "--freetext", "")
+    assert result.exit_code == 0, result.output
+    assert len(freetext_recorder) == 1
+    assert freetext_recorder[0]["text"] == ""
+
+
+def test_authorization_boundary__missing_agent_exits_one(runner, session_id, monkeypatch):
+    monkeypatch.setattr(broker, "get_agent", lambda *_a, **_kw: None)
+    result = _invoke(runner, session_id, "--choice", "1")
+    assert result.exit_code == 1, result.output
+    assert MEMBER_ID in (result.output or "")
+    assert "not found" in (result.output or "").lower()
+
+
+def test_authorization_boundary__placement_none_exits_one_with_exact_message(
+    runner, session_id, monkeypatch
+):
+    monkeypatch.setattr(
+        broker,
+        "get_agent",
+        lambda *_a, **_kw: _agent(placement=None),
+    )
+    result = _invoke(runner, session_id, "--choice", "1")
+    assert result.exit_code == 1, result.output
+    out = result.output or ""
+    assert f"agent {MEMBER_ID}" in out
+    assert "has no placement row" in out
+    assert "cafleet member create" in out
+
+
+def test_authorization_boundary__cross_director_exits_one_with_exact_message(
+    runner, session_id, monkeypatch
+):
+    monkeypatch.setattr(
+        broker,
+        "get_agent",
+        lambda *_a, **_kw: _agent(
+            placement=_placement(director_agent_id=OTHER_DIRECTOR_ID)
+        ),
+    )
+    result = _invoke(runner, session_id, "--choice", "1")
+    assert result.exit_code == 1, result.output
+    out = result.output or ""
+    assert f"agent {MEMBER_ID}" in out
+    assert "is not a member of your team" in out
+    assert OTHER_DIRECTOR_ID in out
+
+
+def test_authorization_boundary__pending_pane_exits_one_with_exact_message(
+    runner, session_id, monkeypatch
+):
+    monkeypatch.setattr(
+        broker,
+        "get_agent",
+        lambda *_a, **_kw: _agent(placement=_placement(tmux_pane_id=None)),
+    )
+    result = _invoke(runner, session_id, "--choice", "1")
+    assert result.exit_code == 1, result.output
+    out = result.output or ""
+    assert f"member {MEMBER_ID}" in out
+    assert "has no pane yet" in out
+    assert "pending placement" in out
+
+
+@pytest.mark.parametrize("digit", [1, 2, 3])
+def test_choice_dispatch__choice_dispatches_with_matching_digit_and_pane(
+    runner,
+    session_id,
+    happy_path_agent,
+    choice_recorder,
+    freetext_recorder,
+    digit,
+):
+    result = _invoke(runner, session_id, "--choice", str(digit))
+    assert result.exit_code == 0, result.output
+    assert len(choice_recorder) == 1
+    call = choice_recorder[0]
+    assert call["digit"] == digit
+    assert call["target_pane_id"] == PANE_ID
+    assert len(freetext_recorder) == 0
+
+
+def test_freetext_dispatch__freetext_plain_ascii_dispatches_exactly(
+    runner,
+    session_id,
+    happy_path_agent,
+    freetext_recorder,
+    choice_recorder,
+):
+    result = _invoke(runner, session_id, "--freetext", "hello")
+    assert result.exit_code == 0, result.output
+    assert len(freetext_recorder) == 1
+    assert freetext_recorder[0]["text"] == "hello"
+    assert freetext_recorder[0]["target_pane_id"] == PANE_ID
+    assert len(choice_recorder) == 0
+
+
+def test_freetext_dispatch__freetext_shell_meta_delivered_as_literal_no_expansion(
+    runner, session_id, happy_path_agent, freetext_recorder
+):
+    """Shell meta characters must reach the helper unchanged; they are
+    delivered via ``subprocess.run([...], shell=False)`` so no shell
+    ever sees them.
+    """
+    payload = "$(echo pwn) `backticks` $VAR ;&&|"
+    result = _invoke(runner, session_id, "--freetext", payload)
+    assert result.exit_code == 0, result.output
+    assert len(freetext_recorder) == 1
+    assert freetext_recorder[0]["text"] == payload
+
+
+def test_freetext_dispatch__freetext_multibyte_delivered_as_literal(
+    runner, session_id, happy_path_agent, freetext_recorder
+):
+    payload = "日本語 !@# テスト ✓"
+    result = _invoke(runner, session_id, "--freetext", payload)
+    assert result.exit_code == 0, result.output
+    assert len(freetext_recorder) == 1
+    assert freetext_recorder[0]["text"] == payload
+
+
+def test_freetext_dispatch__freetext_key_name_lookalike_delivered_as_literal(
+    runner, session_id, happy_path_agent, freetext_recorder
+):
+    """Key-name lookalikes (Enter, C-c, Esc) must be delivered as literal
+    characters because the wrapper always uses ``-l`` for the free-text
+    step, per the design doc's key-sequence table.
+    """
+    payload = "Enter C-c Esc"
+    result = _invoke(runner, session_id, "--freetext", payload)
+    assert result.exit_code == 0, result.output
+    assert len(freetext_recorder) == 1
+    assert freetext_recorder[0]["text"] == payload
+
+
+def test_output_format__text_output_choice(
+    runner, session_id, happy_path_agent, choice_recorder
+):
+    result = _invoke(runner, session_id, "--choice", "1")
+    assert result.exit_code == 0, result.output
+    assert f"Sent choice 1 to member {MEMBER_NAME} ({PANE_ID})." in (
+        result.output or ""
+    )
+
+
+@pytest.mark.parametrize("digit", [1, 2, 3])
+def test_output_format__text_output_choice_varies_by_digit(
+    runner,
+    session_id,
+    happy_path_agent,
+    choice_recorder,
+    digit,
+):
+    result = _invoke(runner, session_id, "--choice", str(digit))
+    assert result.exit_code == 0, result.output
+    assert f"Sent choice {digit} to member " in (result.output or "")
+
+
+def test_output_format__text_output_freetext(
+    runner, session_id, happy_path_agent, freetext_recorder
+):
+    result = _invoke(runner, session_id, "--freetext", "hello")
+    assert result.exit_code == 0, result.output
+    assert f"Sent free text to member {MEMBER_NAME} ({PANE_ID})." in (
+        result.output or ""
+    )
+
+
+def test_output_format__json_output_choice_has_four_keys(
+    runner, session_id, happy_path_agent, choice_recorder
+):
+    result = runner.invoke(
+        cli,
         [
-            "line1\nline2",
-            "trailing\n",
-            "\nleading",
-            "carriage\rreturn",
-            "mixed\r\nCRLF",
+            "--session-id",
+            session_id,
+            "--json",
+            "member",
+            "send-input",
+            "--agent-id",
+            DIRECTOR_ID,
+            "--member-id",
+            MEMBER_ID,
+            "--choice",
+            "2",
         ],
     )
-    def test_freetext_with_newlines_exits_two(
-        self, runner, session_id, happy_path_agent, bad_text
-    ):
-        result = _invoke(runner, session_id, "--freetext", bad_text)
-        assert result.exit_code == 2, result.output
-        assert "free text may not contain newlines" in (result.output or "")
-
-    def test_freetext_empty_string_is_accepted(
-        self, runner, session_id, happy_path_agent, freetext_recorder
-    ):
-        """Empty string is valid -- submits an empty answer to the prompt."""
-        result = _invoke(runner, session_id, "--freetext", "")
-        assert result.exit_code == 0, result.output
-        assert len(freetext_recorder) == 1
-        assert freetext_recorder[0]["text"] == ""
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    assert set(data.keys()) == {
+        "member_agent_id",
+        "pane_id",
+        "action",
+        "value",
+    }
+    assert data["member_agent_id"] == MEMBER_ID
+    assert data["pane_id"] == PANE_ID
+    assert data["action"] == "choice"
+    assert data["value"] == "2"
 
 
-class TestAuthorizationBoundary:
-    def test_missing_agent_exits_one(self, runner, session_id, monkeypatch):
-        monkeypatch.setattr(broker, "get_agent", lambda *_a, **_kw: None)
-        result = _invoke(runner, session_id, "--choice", "1")
-        assert result.exit_code == 1, result.output
-        assert MEMBER_ID in (result.output or "")
-        assert "not found" in (result.output or "").lower()
-
-    def test_placement_none_exits_one_with_exact_message(
-        self, runner, session_id, monkeypatch
-    ):
-        monkeypatch.setattr(
-            broker,
-            "get_agent",
-            lambda *_a, **_kw: _agent(placement=None),
-        )
-        result = _invoke(runner, session_id, "--choice", "1")
-        assert result.exit_code == 1, result.output
-        out = result.output or ""
-        assert f"agent {MEMBER_ID}" in out
-        assert "has no placement row" in out
-        assert "cafleet member create" in out
-
-    def test_cross_director_exits_one_with_exact_message(
-        self, runner, session_id, monkeypatch
-    ):
-        monkeypatch.setattr(
-            broker,
-            "get_agent",
-            lambda *_a, **_kw: _agent(
-                placement=_placement(director_agent_id=OTHER_DIRECTOR_ID)
-            ),
-        )
-        result = _invoke(runner, session_id, "--choice", "1")
-        assert result.exit_code == 1, result.output
-        out = result.output or ""
-        assert f"agent {MEMBER_ID}" in out
-        assert "is not a member of your team" in out
-        assert OTHER_DIRECTOR_ID in out
-
-    def test_pending_pane_exits_one_with_exact_message(
-        self, runner, session_id, monkeypatch
-    ):
-        monkeypatch.setattr(
-            broker,
-            "get_agent",
-            lambda *_a, **_kw: _agent(placement=_placement(tmux_pane_id=None)),
-        )
-        result = _invoke(runner, session_id, "--choice", "1")
-        assert result.exit_code == 1, result.output
-        out = result.output or ""
-        assert f"member {MEMBER_ID}" in out
-        assert "has no pane yet" in out
-        assert "pending placement" in out
+def test_output_format__json_output_freetext_has_four_keys(
+    runner, session_id, happy_path_agent, freetext_recorder
+):
+    payload = "hello world"
+    result = runner.invoke(
+        cli,
+        [
+            "--session-id",
+            session_id,
+            "--json",
+            "member",
+            "send-input",
+            "--agent-id",
+            DIRECTOR_ID,
+            "--member-id",
+            MEMBER_ID,
+            "--freetext",
+            payload,
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    assert set(data.keys()) == {
+        "member_agent_id",
+        "pane_id",
+        "action",
+        "value",
+    }
+    assert data["member_agent_id"] == MEMBER_ID
+    assert data["pane_id"] == PANE_ID
+    assert data["action"] == "freetext"
+    assert data["value"] == payload
 
 
-class TestChoiceDispatch:
-    @pytest.mark.parametrize("digit", [1, 2, 3])
-    def test_choice_dispatches_with_matching_digit_and_pane(
-        self,
-        runner,
-        session_id,
-        happy_path_agent,
-        choice_recorder,
-        freetext_recorder,
-        digit,
-    ):
-        result = _invoke(runner, session_id, "--choice", str(digit))
-        assert result.exit_code == 0, result.output
-        assert len(choice_recorder) == 1
-        call = choice_recorder[0]
-        assert call["digit"] == digit
-        assert call["target_pane_id"] == PANE_ID
-        assert len(freetext_recorder) == 0
+# --- bash_flag_removed: regression guard: the old ``--bash`` flag no longer
+# exists on ``cafleet member send-input``. Per .claude/rules/removal.md, the
+# absence-as-test guards against re-introduction. ---
 
 
-class TestFreetextDispatch:
-    def test_freetext_plain_ascii_dispatches_exactly(
-        self,
-        runner,
-        session_id,
-        happy_path_agent,
-        freetext_recorder,
-        choice_recorder,
-    ):
-        result = _invoke(runner, session_id, "--freetext", "hello")
-        assert result.exit_code == 0, result.output
-        assert len(freetext_recorder) == 1
-        assert freetext_recorder[0]["text"] == "hello"
-        assert freetext_recorder[0]["target_pane_id"] == PANE_ID
-        assert len(choice_recorder) == 0
-
-    def test_freetext_shell_meta_delivered_as_literal_no_expansion(
-        self, runner, session_id, happy_path_agent, freetext_recorder
-    ):
-        """Shell meta characters must reach the helper unchanged; they are
-        delivered via ``subprocess.run([...], shell=False)`` so no shell
-        ever sees them.
-        """
-        payload = "$(echo pwn) `backticks` $VAR ;&&|"
-        result = _invoke(runner, session_id, "--freetext", payload)
-        assert result.exit_code == 0, result.output
-        assert len(freetext_recorder) == 1
-        assert freetext_recorder[0]["text"] == payload
-
-    def test_freetext_multibyte_delivered_as_literal(
-        self, runner, session_id, happy_path_agent, freetext_recorder
-    ):
-        payload = "日本語 !@# テスト ✓"
-        result = _invoke(runner, session_id, "--freetext", payload)
-        assert result.exit_code == 0, result.output
-        assert len(freetext_recorder) == 1
-        assert freetext_recorder[0]["text"] == payload
-
-    def test_freetext_key_name_lookalike_delivered_as_literal(
-        self, runner, session_id, happy_path_agent, freetext_recorder
-    ):
-        """Key-name lookalikes (Enter, C-c, Esc) must be delivered as literal
-        characters because the wrapper always uses ``-l`` for the free-text
-        step, per the design doc's key-sequence table.
-        """
-        payload = "Enter C-c Esc"
-        result = _invoke(runner, session_id, "--freetext", payload)
-        assert result.exit_code == 0, result.output
-        assert len(freetext_recorder) == 1
-        assert freetext_recorder[0]["text"] == payload
+def test_bash_flag_removed__old_bash_flag_form_errors_with_no_such_option(
+    runner, session_id, happy_path_agent
+):
+    result = _invoke(runner, session_id, "--bash", "x")
+    assert result.exit_code == 2, result.output
+    out = result.output or ""
+    assert "No such option" in out
+    assert "--bash" in out
 
 
-class TestOutputFormat:
-    def test_text_output_choice(
-        self, runner, session_id, happy_path_agent, choice_recorder
-    ):
-        result = _invoke(runner, session_id, "--choice", "1")
-        assert result.exit_code == 0, result.output
-        assert f"Sent choice 1 to member {MEMBER_NAME} ({PANE_ID})." in (
-            result.output or ""
-        )
-
-    @pytest.mark.parametrize("digit", [1, 2, 3])
-    def test_text_output_choice_varies_by_digit(
-        self,
-        runner,
-        session_id,
-        happy_path_agent,
-        choice_recorder,
-        digit,
-    ):
-        result = _invoke(runner, session_id, "--choice", str(digit))
-        assert result.exit_code == 0, result.output
-        assert f"Sent choice {digit} to member " in (result.output or "")
-
-    def test_text_output_freetext(
-        self, runner, session_id, happy_path_agent, freetext_recorder
-    ):
-        result = _invoke(runner, session_id, "--freetext", "hello")
-        assert result.exit_code == 0, result.output
-        assert f"Sent free text to member {MEMBER_NAME} ({PANE_ID})." in (
-            result.output or ""
-        )
-
-    def test_json_output_choice_has_four_keys(
-        self, runner, session_id, happy_path_agent, choice_recorder
-    ):
-        result = runner.invoke(
-            cli,
-            [
-                "--session-id",
-                session_id,
-                "--json",
-                "member",
-                "send-input",
-                "--agent-id",
-                DIRECTOR_ID,
-                "--member-id",
-                MEMBER_ID,
-                "--choice",
-                "2",
-            ],
-        )
-        assert result.exit_code == 0, result.output
-        data = json.loads(result.output)
-        assert set(data.keys()) == {
-            "member_agent_id",
-            "pane_id",
-            "action",
-            "value",
-        }
-        assert data["member_agent_id"] == MEMBER_ID
-        assert data["pane_id"] == PANE_ID
-        assert data["action"] == "choice"
-        assert data["value"] == "2"
-
-    def test_json_output_freetext_has_four_keys(
-        self, runner, session_id, happy_path_agent, freetext_recorder
-    ):
-        payload = "hello world"
-        result = runner.invoke(
-            cli,
-            [
-                "--session-id",
-                session_id,
-                "--json",
-                "member",
-                "send-input",
-                "--agent-id",
-                DIRECTOR_ID,
-                "--member-id",
-                MEMBER_ID,
-                "--freetext",
-                payload,
-            ],
-        )
-        assert result.exit_code == 0, result.output
-        data = json.loads(result.output)
-        assert set(data.keys()) == {
-            "member_agent_id",
-            "pane_id",
-            "action",
-            "value",
-        }
-        assert data["member_agent_id"] == MEMBER_ID
-        assert data["pane_id"] == PANE_ID
-        assert data["action"] == "freetext"
-        assert data["value"] == payload
+# --- freetext_bang_rejection: bang-prefix guardrail on ``--freetext``. Any
+# value whose first non-whitespace character (per ``str.lstrip()``) is ``!`` is
+# rejected with exit 2, because Claude Code's ``!`` shortcut would otherwise
+# smuggle a shell command through the AskUserQuestion path and bypass the new
+# ``cafleet member exec`` boundary. ---
 
 
-class TestBashFlagRemoved:
-    """Regression guard: the old ``--bash`` flag no longer exists on
-    ``cafleet member send-input``. Per .claude/rules/removal.md, the
-    absence-as-test guards against re-introduction.
-    """
-
-    def test_old_bash_flag_form_errors_with_no_such_option(
-        self, runner, session_id, happy_path_agent
-    ):
-        result = _invoke(runner, session_id, "--bash", "x")
-        assert result.exit_code == 2, result.output
-        out = result.output or ""
-        assert "No such option" in out
-        assert "--bash" in out
+def test_freetext_bang_rejection__freetext_leading_bang_rejected(runner, session_id, happy_path_agent):
+    result = _invoke(runner, session_id, "--freetext", "!ls")
+    assert result.exit_code == 2, result.output
+    assert "--freetext may not start with" in (result.output or "")
 
 
-class TestFreetextBangRejection:
-    """Bang-prefix guardrail on ``--freetext``. Any value whose first
-    non-whitespace character (per ``str.lstrip()``) is ``!`` is rejected
-    with exit 2, because Claude Code's ``!`` shortcut would otherwise
-    smuggle a shell command through the AskUserQuestion path and bypass
-    the new ``cafleet member exec`` boundary.
-    """
+def test_freetext_bang_rejection__freetext_whitespace_then_bang_rejected(
+    runner, session_id, happy_path_agent
+):
+    result = _invoke(runner, session_id, "--freetext", "  !ls")
+    assert result.exit_code == 2, result.output
+    assert "--freetext may not start with" in (result.output or "")
 
-    def test_freetext_leading_bang_rejected(self, runner, session_id, happy_path_agent):
-        result = _invoke(runner, session_id, "--freetext", "!ls")
-        assert result.exit_code == 2, result.output
-        assert "--freetext may not start with" in (result.output or "")
 
-    def test_freetext_whitespace_then_bang_rejected(
-        self, runner, session_id, happy_path_agent
-    ):
-        result = _invoke(runner, session_id, "--freetext", "  !ls")
-        assert result.exit_code == 2, result.output
-        assert "--freetext may not start with" in (result.output or "")
+def test_freetext_bang_rejection__freetext_lone_bang_rejected(runner, session_id, happy_path_agent):
+    result = _invoke(runner, session_id, "--freetext", "!")
+    assert result.exit_code == 2, result.output
+    assert "--freetext may not start with" in (result.output or "")
 
-    def test_freetext_lone_bang_rejected(self, runner, session_id, happy_path_agent):
-        result = _invoke(runner, session_id, "--freetext", "!")
-        assert result.exit_code == 2, result.output
-        assert "--freetext may not start with" in (result.output or "")
 
-    def test_freetext_bang_not_in_leading_position_accepted(
-        self, runner, session_id, happy_path_agent, freetext_recorder
-    ):
-        result = _invoke(runner, session_id, "--freetext", "hi !")
-        assert result.exit_code == 0, result.output
-        assert len(freetext_recorder) == 1
-        assert freetext_recorder[0]["text"] == "hi !"
+def test_freetext_bang_rejection__freetext_bang_not_in_leading_position_accepted(
+    runner, session_id, happy_path_agent, freetext_recorder
+):
+    result = _invoke(runner, session_id, "--freetext", "hi !")
+    assert result.exit_code == 0, result.output
+    assert len(freetext_recorder) == 1
+    assert freetext_recorder[0]["text"] == "hi !"
 
-    def test_freetext_empty_still_accepted(
-        self, runner, session_id, happy_path_agent, freetext_recorder
-    ):
-        result = _invoke(runner, session_id, "--freetext", "")
-        assert result.exit_code == 0, result.output
-        assert len(freetext_recorder) == 1
-        assert freetext_recorder[0]["text"] == ""
 
-    def test_freetext_whitespace_only_accepted(
-        self, runner, session_id, happy_path_agent, freetext_recorder
-    ):
-        result = _invoke(runner, session_id, "--freetext", "   ")
-        assert result.exit_code == 0, result.output
-        assert len(freetext_recorder) == 1
-        assert freetext_recorder[0]["text"] == "   "
+def test_freetext_bang_rejection__freetext_empty_still_accepted(
+    runner, session_id, happy_path_agent, freetext_recorder
+):
+    result = _invoke(runner, session_id, "--freetext", "")
+    assert result.exit_code == 0, result.output
+    assert len(freetext_recorder) == 1
+    assert freetext_recorder[0]["text"] == ""
+
+
+def test_freetext_bang_rejection__freetext_whitespace_only_accepted(
+    runner, session_id, happy_path_agent, freetext_recorder
+):
+    result = _invoke(runner, session_id, "--freetext", "   ")
+    assert result.exit_code == 0, result.output
+    assert len(freetext_recorder) == 1
+    assert freetext_recorder[0]["text"] == "   "

--- a/cafleet/tests/test_cli_member_send_input.py
+++ b/cafleet/tests/test_cli_member_send_input.py
@@ -130,7 +130,9 @@ def _invoke(runner, session_id, *extra_args, **invoke_kwargs):
     )
 
 
-def test_flag_validation__no_flag_supplied_exits_two(runner, session_id, happy_path_agent):
+def test_flag_validation__no_flag_supplied_exits_two(
+    runner, session_id, happy_path_agent
+):
     result = _invoke(runner, session_id)
     assert result.exit_code == 2, result.output
     out = result.output or ""
@@ -192,7 +194,9 @@ def test_flag_validation__freetext_empty_string_is_accepted(
     assert freetext_recorder[0]["text"] == ""
 
 
-def test_authorization_boundary__missing_agent_exits_one(runner, session_id, monkeypatch):
+def test_authorization_boundary__missing_agent_exits_one(
+    runner, session_id, monkeypatch
+):
     monkeypatch.setattr(broker, "get_agent", lambda *_a, **_kw: None)
     result = _invoke(runner, session_id, "--choice", "1")
     assert result.exit_code == 1, result.output
@@ -443,7 +447,9 @@ def test_bash_flag_removed__old_bash_flag_form_errors_with_no_such_option(
 # ``cafleet member exec`` boundary. ---
 
 
-def test_freetext_bang_rejection__freetext_leading_bang_rejected(runner, session_id, happy_path_agent):
+def test_freetext_bang_rejection__freetext_leading_bang_rejected(
+    runner, session_id, happy_path_agent
+):
     result = _invoke(runner, session_id, "--freetext", "!ls")
     assert result.exit_code == 2, result.output
     assert "--freetext may not start with" in (result.output or "")
@@ -457,7 +463,9 @@ def test_freetext_bang_rejection__freetext_whitespace_then_bang_rejected(
     assert "--freetext may not start with" in (result.output or "")
 
 
-def test_freetext_bang_rejection__freetext_lone_bang_rejected(runner, session_id, happy_path_agent):
+def test_freetext_bang_rejection__freetext_lone_bang_rejected(
+    runner, session_id, happy_path_agent
+):
     result = _invoke(runner, session_id, "--freetext", "!")
     assert result.exit_code == 2, result.output
     assert "--freetext may not start with" in (result.output or "")

--- a/cafleet/tests/test_cli_message.py
+++ b/cafleet/tests/test_cli_message.py
@@ -35,358 +35,359 @@ def runner():
     return CliRunner()
 
 
-class TestMessageShowAuthCheck:
-    def test_rejects_unknown_agent(
-        self, runner, session_id, agent_id, task_id, monkeypatch
-    ):
-        """Caller's ``agent_id`` is not a member of ``session_id`` → exit 1.
+def test_message_show_auth_check__rejects_unknown_agent(
+    runner, session_id, agent_id, task_id, monkeypatch
+):
+    """Caller's ``agent_id`` is not a member of ``session_id`` → exit 1.
 
-        ``broker.get_task`` MUST NOT be called when verification fails: the
-        membership check is the gate.
-        """
-        get_task_calls: list[tuple] = []
-
-        def fake_verify(aid, sid):
-            assert aid == agent_id
-            assert sid == session_id
-            return False
-
-        def fake_get_task(*args, **kwargs):
-            get_task_calls.append((args, kwargs))
-            return {"task": {}}
-
-        monkeypatch.setattr(broker, "verify_agent_session", fake_verify)
-        monkeypatch.setattr(broker, "get_task", fake_get_task)
-
-        result = runner.invoke(
-            cli,
-            [
-                "--session-id",
-                session_id,
-                "message",
-                "show",
-                "--agent-id",
-                agent_id,
-                "--task-id",
-                task_id,
-            ],
-        )
-        assert result.exit_code == 1, result.output
-        out = result.output or ""
-        assert agent_id in out
-        assert "not a member of session" in out
-        assert session_id in out
-        assert get_task_calls == [], (
-            "broker.get_task must not be invoked when verify_agent_session fails"
-        )
-
-    def test_accepts_valid_agent(
-        self, runner, session_id, agent_id, task_id, monkeypatch
-    ):
-        """Registered agent in session → broker.get_task is called and the
-        task JSON reaches the user."""
-        verify_calls: list[tuple] = []
-
-        def fake_verify(aid, sid):
-            verify_calls.append((aid, sid))
-            return True
-
-        fake_task = {
-            "task": {
-                "id": task_id,
-                "kind": "user",
-                "status": "submitted",
-                "history": [],
-                "metadata": {
-                    "fromAgentId": agent_id,
-                    "toAgentId": str(uuid.uuid4()),
-                },
-            }
-        }
-
-        def fake_get_task(sid, tid):
-            assert sid == session_id
-            assert tid == task_id
-            return fake_task
-
-        monkeypatch.setattr(broker, "verify_agent_session", fake_verify)
-        monkeypatch.setattr(broker, "get_task", fake_get_task)
-
-        result = runner.invoke(
-            cli,
-            [
-                "--session-id",
-                session_id,
-                "--json",
-                "message",
-                "show",
-                "--agent-id",
-                agent_id,
-                "--task-id",
-                task_id,
-            ],
-        )
-        assert result.exit_code == 0, result.output
-        assert verify_calls == [(agent_id, session_id)]
-        assert task_id in (result.output or "")
-
-
-class TestMessagePollAuthCheck:
-    """Round-9 consistency follow-up. ``message poll`` must gate its
-    ``broker.poll_tasks`` call on ``broker.verify_agent_session`` so a
-    caller cannot drain another session's inbox by passing any
-    ``--session-id`` they like.
+    ``broker.get_task`` MUST NOT be called when verification fails: the
+    membership check is the gate.
     """
+    get_task_calls: list[tuple] = []
 
-    def test_rejects_unknown_agent(self, runner, session_id, agent_id, monkeypatch):
-        poll_calls: list[tuple] = []
+    def fake_verify(aid, sid):
+        assert aid == agent_id
+        assert sid == session_id
+        return False
 
-        def fake_verify(aid, sid):
-            assert aid == agent_id
-            assert sid == session_id
-            return False
+    def fake_get_task(*args, **kwargs):
+        get_task_calls.append((args, kwargs))
+        return {"task": {}}
 
-        def fake_poll_tasks(*args, **kwargs):
-            poll_calls.append((args, kwargs))
-            return []
+    monkeypatch.setattr(broker, "verify_agent_session", fake_verify)
+    monkeypatch.setattr(broker, "get_task", fake_get_task)
 
-        monkeypatch.setattr(broker, "verify_agent_session", fake_verify)
-        monkeypatch.setattr(broker, "poll_tasks", fake_poll_tasks)
-
-        result = runner.invoke(
-            cli,
-            [
-                "--session-id",
-                session_id,
-                "message",
-                "poll",
-                "--agent-id",
-                agent_id,
-            ],
-        )
-        assert result.exit_code == 1, result.output
-        out = result.output or ""
-        assert agent_id in out
-        assert "not a member of session" in out
-        assert session_id in out
-        assert poll_calls == [], (
-            "broker.poll_tasks must not be invoked when verify_agent_session fails"
-        )
-
-    def test_accepts_valid_agent(self, runner, session_id, agent_id, monkeypatch):
-        verify_calls: list[tuple] = []
-        poll_calls: list[tuple] = []
-
-        def fake_verify(aid, sid):
-            verify_calls.append((aid, sid))
-            return True
-
-        def fake_poll_tasks(aid, **kwargs):
-            poll_calls.append((aid, kwargs))
-            return []
-
-        monkeypatch.setattr(broker, "verify_agent_session", fake_verify)
-        monkeypatch.setattr(broker, "poll_tasks", fake_poll_tasks)
-
-        result = runner.invoke(
-            cli,
-            [
-                "--session-id",
-                session_id,
-                "--json",
-                "message",
-                "poll",
-                "--agent-id",
-                agent_id,
-            ],
-        )
-        assert result.exit_code == 0, result.output
-        assert verify_calls == [(agent_id, session_id)]
-        assert len(poll_calls) == 1
-        assert poll_calls[0][0] == agent_id
+    result = runner.invoke(
+        cli,
+        [
+            "--session-id",
+            session_id,
+            "message",
+            "show",
+            "--agent-id",
+            agent_id,
+            "--task-id",
+            task_id,
+        ],
+    )
+    assert result.exit_code == 1, result.output
+    out = result.output or ""
+    assert agent_id in out
+    assert "not a member of session" in out
+    assert session_id in out
+    assert get_task_calls == [], (
+        "broker.get_task must not be invoked when verify_agent_session fails"
+    )
 
 
-class TestMessageAckAuthCheck:
-    """Round-9 consistency follow-up. ``message ack`` must gate its
-    ``broker.ack_task`` call on ``broker.verify_agent_session``.
-    """
+def test_message_show_auth_check__accepts_valid_agent(
+    runner, session_id, agent_id, task_id, monkeypatch
+):
+    """Registered agent in session → broker.get_task is called and the
+    task JSON reaches the user."""
+    verify_calls: list[tuple] = []
 
-    def test_rejects_unknown_agent(
-        self, runner, session_id, agent_id, task_id, monkeypatch
-    ):
-        ack_calls: list[tuple] = []
+    def fake_verify(aid, sid):
+        verify_calls.append((aid, sid))
+        return True
 
-        def fake_verify(aid, sid):
-            assert aid == agent_id
-            assert sid == session_id
-            return False
-
-        def fake_ack_task(*args, **kwargs):
-            ack_calls.append((args, kwargs))
-            return {"task": {}}
-
-        monkeypatch.setattr(broker, "verify_agent_session", fake_verify)
-        monkeypatch.setattr(broker, "ack_task", fake_ack_task)
-
-        result = runner.invoke(
-            cli,
-            [
-                "--session-id",
-                session_id,
-                "message",
-                "ack",
-                "--agent-id",
-                agent_id,
-                "--task-id",
-                task_id,
-            ],
-        )
-        assert result.exit_code == 1, result.output
-        out = result.output or ""
-        assert agent_id in out
-        assert "not a member of session" in out
-        assert session_id in out
-        assert ack_calls == [], (
-            "broker.ack_task must not be invoked when verify_agent_session fails"
-        )
-
-    def test_accepts_valid_agent(
-        self, runner, session_id, agent_id, task_id, monkeypatch
-    ):
-        verify_calls: list[tuple] = []
-        ack_calls: list[tuple] = []
-
-        def fake_verify(aid, sid):
-            verify_calls.append((aid, sid))
-            return True
-
-        fake_task = {
-            "task": {
-                "id": task_id,
-                "kind": "user",
-                "status": "acknowledged",
-                "history": [],
-                "metadata": {
-                    "fromAgentId": str(uuid.uuid4()),
-                    "toAgentId": agent_id,
-                },
-            }
+    fake_task = {
+        "task": {
+            "id": task_id,
+            "kind": "user",
+            "status": "submitted",
+            "history": [],
+            "metadata": {
+                "fromAgentId": agent_id,
+                "toAgentId": str(uuid.uuid4()),
+            },
         }
+    }
 
-        def fake_ack_task(aid, tid):
-            ack_calls.append((aid, tid))
-            return fake_task
+    def fake_get_task(sid, tid):
+        assert sid == session_id
+        assert tid == task_id
+        return fake_task
 
-        monkeypatch.setattr(broker, "verify_agent_session", fake_verify)
-        monkeypatch.setattr(broker, "ack_task", fake_ack_task)
+    monkeypatch.setattr(broker, "verify_agent_session", fake_verify)
+    monkeypatch.setattr(broker, "get_task", fake_get_task)
 
-        result = runner.invoke(
-            cli,
-            [
-                "--session-id",
-                session_id,
-                "--json",
-                "message",
-                "ack",
-                "--agent-id",
-                agent_id,
-                "--task-id",
-                task_id,
-            ],
-        )
-        assert result.exit_code == 0, result.output
-        assert verify_calls == [(agent_id, session_id)]
-        assert ack_calls == [(agent_id, task_id)]
+    result = runner.invoke(
+        cli,
+        [
+            "--session-id",
+            session_id,
+            "--json",
+            "message",
+            "show",
+            "--agent-id",
+            agent_id,
+            "--task-id",
+            task_id,
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert verify_calls == [(agent_id, session_id)]
+    assert task_id in (result.output or "")
 
 
-class TestMessageCancelAuthCheck:
-    """Round-9 consistency follow-up. ``message cancel`` must gate its
-    ``broker.cancel_task`` call on ``broker.verify_agent_session``.
-    """
+# --- message_poll_auth_check: round-9 consistency follow-up. ``message poll``
+# must gate its ``broker.poll_tasks`` call on ``broker.verify_agent_session`` so
+# a caller cannot drain another session's inbox by passing any ``--session-id``
+# they like. ---
 
-    def test_rejects_unknown_agent(
-        self, runner, session_id, agent_id, task_id, monkeypatch
-    ):
-        cancel_calls: list[tuple] = []
 
-        def fake_verify(aid, sid):
-            assert aid == agent_id
-            assert sid == session_id
-            return False
+def test_message_poll_auth_check__rejects_unknown_agent(runner, session_id, agent_id, monkeypatch):
+    poll_calls: list[tuple] = []
 
-        def fake_cancel_task(*args, **kwargs):
-            cancel_calls.append((args, kwargs))
-            return {"task": {}}
+    def fake_verify(aid, sid):
+        assert aid == agent_id
+        assert sid == session_id
+        return False
 
-        monkeypatch.setattr(broker, "verify_agent_session", fake_verify)
-        monkeypatch.setattr(broker, "cancel_task", fake_cancel_task)
+    def fake_poll_tasks(*args, **kwargs):
+        poll_calls.append((args, kwargs))
+        return []
 
-        result = runner.invoke(
-            cli,
-            [
-                "--session-id",
-                session_id,
-                "message",
-                "cancel",
-                "--agent-id",
-                agent_id,
-                "--task-id",
-                task_id,
-            ],
-        )
-        assert result.exit_code == 1, result.output
-        out = result.output or ""
-        assert agent_id in out
-        assert "not a member of session" in out
-        assert session_id in out
-        assert cancel_calls == [], (
-            "broker.cancel_task must not be invoked when verify_agent_session fails"
-        )
+    monkeypatch.setattr(broker, "verify_agent_session", fake_verify)
+    monkeypatch.setattr(broker, "poll_tasks", fake_poll_tasks)
 
-    def test_accepts_valid_agent(
-        self, runner, session_id, agent_id, task_id, monkeypatch
-    ):
-        verify_calls: list[tuple] = []
-        cancel_calls: list[tuple] = []
+    result = runner.invoke(
+        cli,
+        [
+            "--session-id",
+            session_id,
+            "message",
+            "poll",
+            "--agent-id",
+            agent_id,
+        ],
+    )
+    assert result.exit_code == 1, result.output
+    out = result.output or ""
+    assert agent_id in out
+    assert "not a member of session" in out
+    assert session_id in out
+    assert poll_calls == [], (
+        "broker.poll_tasks must not be invoked when verify_agent_session fails"
+    )
 
-        def fake_verify(aid, sid):
-            verify_calls.append((aid, sid))
-            return True
 
-        fake_task = {
-            "task": {
-                "id": task_id,
-                "kind": "user",
-                "status": "canceled",
-                "history": [],
-                "metadata": {
-                    "fromAgentId": agent_id,
-                    "toAgentId": str(uuid.uuid4()),
-                },
-            }
+def test_message_poll_auth_check__accepts_valid_agent(runner, session_id, agent_id, monkeypatch):
+    verify_calls: list[tuple] = []
+    poll_calls: list[tuple] = []
+
+    def fake_verify(aid, sid):
+        verify_calls.append((aid, sid))
+        return True
+
+    def fake_poll_tasks(aid, **kwargs):
+        poll_calls.append((aid, kwargs))
+        return []
+
+    monkeypatch.setattr(broker, "verify_agent_session", fake_verify)
+    monkeypatch.setattr(broker, "poll_tasks", fake_poll_tasks)
+
+    result = runner.invoke(
+        cli,
+        [
+            "--session-id",
+            session_id,
+            "--json",
+            "message",
+            "poll",
+            "--agent-id",
+            agent_id,
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert verify_calls == [(agent_id, session_id)]
+    assert len(poll_calls) == 1
+    assert poll_calls[0][0] == agent_id
+
+
+# --- message_ack_auth_check: round-9 consistency follow-up. ``message ack``
+# must gate its ``broker.ack_task`` call on ``broker.verify_agent_session``. ---
+
+
+def test_message_ack_auth_check__rejects_unknown_agent(
+    runner, session_id, agent_id, task_id, monkeypatch
+):
+    ack_calls: list[tuple] = []
+
+    def fake_verify(aid, sid):
+        assert aid == agent_id
+        assert sid == session_id
+        return False
+
+    def fake_ack_task(*args, **kwargs):
+        ack_calls.append((args, kwargs))
+        return {"task": {}}
+
+    monkeypatch.setattr(broker, "verify_agent_session", fake_verify)
+    monkeypatch.setattr(broker, "ack_task", fake_ack_task)
+
+    result = runner.invoke(
+        cli,
+        [
+            "--session-id",
+            session_id,
+            "message",
+            "ack",
+            "--agent-id",
+            agent_id,
+            "--task-id",
+            task_id,
+        ],
+    )
+    assert result.exit_code == 1, result.output
+    out = result.output or ""
+    assert agent_id in out
+    assert "not a member of session" in out
+    assert session_id in out
+    assert ack_calls == [], (
+        "broker.ack_task must not be invoked when verify_agent_session fails"
+    )
+
+
+def test_message_ack_auth_check__accepts_valid_agent(
+    runner, session_id, agent_id, task_id, monkeypatch
+):
+    verify_calls: list[tuple] = []
+    ack_calls: list[tuple] = []
+
+    def fake_verify(aid, sid):
+        verify_calls.append((aid, sid))
+        return True
+
+    fake_task = {
+        "task": {
+            "id": task_id,
+            "kind": "user",
+            "status": "acknowledged",
+            "history": [],
+            "metadata": {
+                "fromAgentId": str(uuid.uuid4()),
+                "toAgentId": agent_id,
+            },
         }
+    }
 
-        def fake_cancel_task(aid, tid):
-            cancel_calls.append((aid, tid))
-            return fake_task
+    def fake_ack_task(aid, tid):
+        ack_calls.append((aid, tid))
+        return fake_task
 
-        monkeypatch.setattr(broker, "verify_agent_session", fake_verify)
-        monkeypatch.setattr(broker, "cancel_task", fake_cancel_task)
+    monkeypatch.setattr(broker, "verify_agent_session", fake_verify)
+    monkeypatch.setattr(broker, "ack_task", fake_ack_task)
 
-        result = runner.invoke(
-            cli,
-            [
-                "--session-id",
-                session_id,
-                "--json",
-                "message",
-                "cancel",
-                "--agent-id",
-                agent_id,
-                "--task-id",
-                task_id,
-            ],
-        )
-        assert result.exit_code == 0, result.output
-        assert verify_calls == [(agent_id, session_id)]
-        assert cancel_calls == [(agent_id, task_id)]
+    result = runner.invoke(
+        cli,
+        [
+            "--session-id",
+            session_id,
+            "--json",
+            "message",
+            "ack",
+            "--agent-id",
+            agent_id,
+            "--task-id",
+            task_id,
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert verify_calls == [(agent_id, session_id)]
+    assert ack_calls == [(agent_id, task_id)]
+
+
+# --- message_cancel_auth_check: round-9 consistency follow-up. ``message
+# cancel`` must gate its ``broker.cancel_task`` call on
+# ``broker.verify_agent_session``. ---
+
+
+def test_message_cancel_auth_check__rejects_unknown_agent(
+    runner, session_id, agent_id, task_id, monkeypatch
+):
+    cancel_calls: list[tuple] = []
+
+    def fake_verify(aid, sid):
+        assert aid == agent_id
+        assert sid == session_id
+        return False
+
+    def fake_cancel_task(*args, **kwargs):
+        cancel_calls.append((args, kwargs))
+        return {"task": {}}
+
+    monkeypatch.setattr(broker, "verify_agent_session", fake_verify)
+    monkeypatch.setattr(broker, "cancel_task", fake_cancel_task)
+
+    result = runner.invoke(
+        cli,
+        [
+            "--session-id",
+            session_id,
+            "message",
+            "cancel",
+            "--agent-id",
+            agent_id,
+            "--task-id",
+            task_id,
+        ],
+    )
+    assert result.exit_code == 1, result.output
+    out = result.output or ""
+    assert agent_id in out
+    assert "not a member of session" in out
+    assert session_id in out
+    assert cancel_calls == [], (
+        "broker.cancel_task must not be invoked when verify_agent_session fails"
+    )
+
+
+def test_message_cancel_auth_check__accepts_valid_agent(
+    runner, session_id, agent_id, task_id, monkeypatch
+):
+    verify_calls: list[tuple] = []
+    cancel_calls: list[tuple] = []
+
+    def fake_verify(aid, sid):
+        verify_calls.append((aid, sid))
+        return True
+
+    fake_task = {
+        "task": {
+            "id": task_id,
+            "kind": "user",
+            "status": "canceled",
+            "history": [],
+            "metadata": {
+                "fromAgentId": agent_id,
+                "toAgentId": str(uuid.uuid4()),
+            },
+        }
+    }
+
+    def fake_cancel_task(aid, tid):
+        cancel_calls.append((aid, tid))
+        return fake_task
+
+    monkeypatch.setattr(broker, "verify_agent_session", fake_verify)
+    monkeypatch.setattr(broker, "cancel_task", fake_cancel_task)
+
+    result = runner.invoke(
+        cli,
+        [
+            "--session-id",
+            session_id,
+            "--json",
+            "message",
+            "cancel",
+            "--agent-id",
+            agent_id,
+            "--task-id",
+            task_id,
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert verify_calls == [(agent_id, session_id)]
+    assert cancel_calls == [(agent_id, task_id)]

--- a/cafleet/tests/test_cli_message.py
+++ b/cafleet/tests/test_cli_message.py
@@ -137,7 +137,9 @@ def test_message_show_auth_check__accepts_valid_agent(
 # they like. ---
 
 
-def test_message_poll_auth_check__rejects_unknown_agent(runner, session_id, agent_id, monkeypatch):
+def test_message_poll_auth_check__rejects_unknown_agent(
+    runner, session_id, agent_id, monkeypatch
+):
     poll_calls: list[tuple] = []
 
     def fake_verify(aid, sid):
@@ -173,7 +175,9 @@ def test_message_poll_auth_check__rejects_unknown_agent(runner, session_id, agen
     )
 
 
-def test_message_poll_auth_check__accepts_valid_agent(runner, session_id, agent_id, monkeypatch):
+def test_message_poll_auth_check__accepts_valid_agent(
+    runner, session_id, agent_id, monkeypatch
+):
     verify_calls: list[tuple] = []
     poll_calls: list[tuple] = []
 

--- a/cafleet/tests/test_cli_message_truncation.py
+++ b/cafleet/tests/test_cli_message_truncation.py
@@ -79,553 +79,502 @@ def _task_payload(task_id, *, sender, recipient, text, type_="unicast"):
     }
 
 
-class TestMessagePollTruncation:
-    def test_default_truncates_text_in_text_output(
-        self, runner, session_id, agent_id, monkeypatch
-    ):
-        monkeypatch.setattr(
-            broker,
-            "poll_tasks",
-            lambda *_a, **_k: [
-                _task_payload(
-                    "t-1", sender="from-1", recipient=agent_id, text=LONG_BODY
-                )
-            ],
-        )
-        result = runner.invoke(
-            cli,
-            [
-                "--session-id",
-                session_id,
-                "message",
-                "poll",
-                "--agent-id",
-                agent_id,
-            ],
-        )
-        assert result.exit_code == 0, result.output
-        assert TRUNCATED_BODY in result.output
-        assert LONG_BODY not in result.output
-
-    def test_full_emits_full_text_in_text_output(
-        self, runner, session_id, agent_id, monkeypatch
-    ):
-        monkeypatch.setattr(
-            broker,
-            "poll_tasks",
-            lambda *_a, **_k: [
-                _task_payload(
-                    "t-1", sender="from-1", recipient=agent_id, text=LONG_BODY
-                )
-            ],
-        )
-        result = runner.invoke(
-            cli,
-            [
-                "--session-id",
-                session_id,
-                "message",
-                "poll",
-                "--agent-id",
-                agent_id,
-                "--full",
-            ],
-        )
-        assert result.exit_code == 0, result.output
-        assert LONG_BODY in result.output
-        assert TRUNCATED_BODY not in result.output
-
-    def test_default_truncates_text_in_json_output(
-        self, runner, session_id, agent_id, monkeypatch
-    ):
-        monkeypatch.setattr(
-            broker,
-            "poll_tasks",
-            lambda *_a, **_k: [
-                _task_payload(
-                    "t-1", sender="from-1", recipient=agent_id, text=LONG_BODY
-                )
-            ],
-        )
-        result = runner.invoke(
-            cli,
-            [
-                "--session-id",
-                session_id,
-                "--json",
-                "message",
-                "poll",
-                "--agent-id",
-                agent_id,
-            ],
-        )
-        assert result.exit_code == 0, result.output
-        payload = json.loads(result.output)
-        assert payload[0]["artifacts"][0]["parts"][0]["text"] == TRUNCATED_BODY
-
-    def test_full_emits_full_text_in_json_output(
-        self, runner, session_id, agent_id, monkeypatch
-    ):
-        monkeypatch.setattr(
-            broker,
-            "poll_tasks",
-            lambda *_a, **_k: [
-                _task_payload(
-                    "t-1", sender="from-1", recipient=agent_id, text=LONG_BODY
-                )
-            ],
-        )
-        result = runner.invoke(
-            cli,
-            [
-                "--session-id",
-                session_id,
-                "--json",
-                "message",
-                "poll",
-                "--agent-id",
-                agent_id,
-                "--full",
-            ],
-        )
-        assert result.exit_code == 0, result.output
-        payload = json.loads(result.output)
-        assert payload[0]["artifacts"][0]["parts"][0]["text"] == LONG_BODY
-
-    def test_empty_inbox_unchanged_by_full_flag(
-        self, runner, session_id, agent_id, monkeypatch
-    ):
-        monkeypatch.setattr(broker, "poll_tasks", lambda *_a, **_k: [])
-        default = runner.invoke(
-            cli,
-            [
-                "--session-id",
-                session_id,
-                "message",
-                "poll",
-                "--agent-id",
-                agent_id,
-            ],
-        )
-        full = runner.invoke(
-            cli,
-            [
-                "--session-id",
-                session_id,
-                "message",
-                "poll",
-                "--agent-id",
-                agent_id,
-                "--full",
-            ],
-        )
-        assert default.exit_code == 0, default.output
-        assert full.exit_code == 0, full.output
-        assert default.output == full.output
-
-    def test_list_of_three_tasks_each_truncated(
-        self, runner, session_id, agent_id, monkeypatch
-    ):
-        bodies = [LONG_BODY + "X", LONG_BODY + "Y", LONG_BODY + "Z"]
-        monkeypatch.setattr(
-            broker,
-            "poll_tasks",
-            lambda *_a, **_k: [
-                _task_payload(
-                    f"t-{i}", sender=f"from-{i}", recipient=agent_id, text=bodies[i]
-                )
-                for i in range(3)
-            ],
-        )
-        result = runner.invoke(
-            cli,
-            [
-                "--session-id",
-                session_id,
-                "--json",
-                "message",
-                "poll",
-                "--agent-id",
-                agent_id,
-            ],
-        )
-        assert result.exit_code == 0, result.output
-        payload = json.loads(result.output)
-        assert len(payload) == 3
-        for item in payload:
-            assert item["artifacts"][0]["parts"][0]["text"] == TRUNCATED_BODY
-
-    def test_non_text_fields_byte_identical_between_default_and_full(
-        self, runner, session_id, agent_id, monkeypatch
-    ):
-        def fresh_payload():
-            return [
-                _task_payload(
-                    "t-1", sender="from-1", recipient=agent_id, text=LONG_BODY
-                )
-            ]
-
-        monkeypatch.setattr(broker, "poll_tasks", lambda *_a, **_k: fresh_payload())
-        default_res = runner.invoke(
-            cli,
-            [
-                "--session-id",
-                session_id,
-                "--json",
-                "message",
-                "poll",
-                "--agent-id",
-                agent_id,
-            ],
-        )
-        full_res = runner.invoke(
-            cli,
-            [
-                "--session-id",
-                session_id,
-                "--json",
-                "message",
-                "poll",
-                "--agent-id",
-                agent_id,
-                "--full",
-            ],
-        )
-        assert default_res.exit_code == 0, default_res.output
-        assert full_res.exit_code == 0, full_res.output
-
-        default_task = json.loads(default_res.output)[0]
-        full_task = json.loads(full_res.output)[0]
-        assert default_task["id"] == full_task["id"]
-        assert default_task["status"]["state"] == full_task["status"]["state"]
-        assert (
-            default_task["metadata"]["fromAgentId"]
-            == full_task["metadata"]["fromAgentId"]
-        )
-        assert (
-            default_task["metadata"]["toAgentId"] == full_task["metadata"]["toAgentId"]
-        )
-        assert default_task["metadata"]["type"] == full_task["metadata"]["type"]
+def test_message_poll_truncation__default_truncates_text_in_text_output(
+    runner, session_id, agent_id, monkeypatch
+):
+    monkeypatch.setattr(
+        broker,
+        "poll_tasks",
+        lambda *_a, **_k: [
+            _task_payload(
+                "t-1", sender="from-1", recipient=agent_id, text=LONG_BODY
+            )
+        ],
+    )
+    result = runner.invoke(
+        cli,
+        [
+            "--session-id",
+            session_id,
+            "message",
+            "poll",
+            "--agent-id",
+            agent_id,
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert TRUNCATED_BODY in result.output
+    assert LONG_BODY not in result.output
 
 
-class TestMessageShowTruncation:
-    def test_default_truncates_text_in_text_output(
-        self, runner, session_id, agent_id, task_id, other_agent_id, monkeypatch
-    ):
-        monkeypatch.setattr(
-            broker,
-            "get_task",
-            lambda *_a, **_k: {
-                "task": _task_payload(
-                    task_id, sender=other_agent_id, recipient=agent_id, text=LONG_BODY
-                )
-            },
-        )
-        result = runner.invoke(
-            cli,
-            [
-                "--session-id",
-                session_id,
-                "message",
-                "show",
-                "--agent-id",
-                agent_id,
-                "--task-id",
-                task_id,
-            ],
-        )
-        assert result.exit_code == 0, result.output
-        assert TRUNCATED_BODY in result.output
-        assert LONG_BODY not in result.output
-
-    def test_full_emits_full_text_in_text_output(
-        self, runner, session_id, agent_id, task_id, other_agent_id, monkeypatch
-    ):
-        monkeypatch.setattr(
-            broker,
-            "get_task",
-            lambda *_a, **_k: {
-                "task": _task_payload(
-                    task_id, sender=other_agent_id, recipient=agent_id, text=LONG_BODY
-                )
-            },
-        )
-        result = runner.invoke(
-            cli,
-            [
-                "--session-id",
-                session_id,
-                "message",
-                "show",
-                "--agent-id",
-                agent_id,
-                "--task-id",
-                task_id,
-                "--full",
-            ],
-        )
-        assert result.exit_code == 0, result.output
-        assert LONG_BODY in result.output
-
-    def test_default_truncates_text_in_json_output(
-        self, runner, session_id, agent_id, task_id, other_agent_id, monkeypatch
-    ):
-        monkeypatch.setattr(
-            broker,
-            "get_task",
-            lambda *_a, **_k: {
-                "task": _task_payload(
-                    task_id, sender=other_agent_id, recipient=agent_id, text=LONG_BODY
-                )
-            },
-        )
-        result = runner.invoke(
-            cli,
-            [
-                "--session-id",
-                session_id,
-                "--json",
-                "message",
-                "show",
-                "--agent-id",
-                agent_id,
-                "--task-id",
-                task_id,
-            ],
-        )
-        assert result.exit_code == 0, result.output
-        payload = json.loads(result.output)
-        assert payload["task"]["artifacts"][0]["parts"][0]["text"] == TRUNCATED_BODY
-
-    def test_full_emits_full_text_in_json_output(
-        self, runner, session_id, agent_id, task_id, other_agent_id, monkeypatch
-    ):
-        monkeypatch.setattr(
-            broker,
-            "get_task",
-            lambda *_a, **_k: {
-                "task": _task_payload(
-                    task_id, sender=other_agent_id, recipient=agent_id, text=LONG_BODY
-                )
-            },
-        )
-        result = runner.invoke(
-            cli,
-            [
-                "--session-id",
-                session_id,
-                "--json",
-                "message",
-                "show",
-                "--agent-id",
-                agent_id,
-                "--task-id",
-                task_id,
-                "--full",
-            ],
-        )
-        assert result.exit_code == 0, result.output
-        payload = json.loads(result.output)
-        assert payload["task"]["artifacts"][0]["parts"][0]["text"] == LONG_BODY
-
-    def test_non_text_fields_byte_identical_between_default_and_full(
-        self, runner, session_id, agent_id, task_id, other_agent_id, monkeypatch
-    ):
-        def fresh_payload():
-            return {
-                "task": _task_payload(
-                    task_id, sender=other_agent_id, recipient=agent_id, text=LONG_BODY
-                )
-            }
-
-        monkeypatch.setattr(broker, "get_task", lambda *_a, **_k: fresh_payload())
-        default_res = runner.invoke(
-            cli,
-            [
-                "--session-id",
-                session_id,
-                "--json",
-                "message",
-                "show",
-                "--agent-id",
-                agent_id,
-                "--task-id",
-                task_id,
-            ],
-        )
-        full_res = runner.invoke(
-            cli,
-            [
-                "--session-id",
-                session_id,
-                "--json",
-                "message",
-                "show",
-                "--agent-id",
-                agent_id,
-                "--task-id",
-                task_id,
-                "--full",
-            ],
-        )
-        assert default_res.exit_code == 0, default_res.output
-        assert full_res.exit_code == 0, full_res.output
-
-        default_task = json.loads(default_res.output)["task"]
-        full_task = json.loads(full_res.output)["task"]
-        assert default_task["id"] == full_task["id"]
-        assert default_task["status"]["state"] == full_task["status"]["state"]
-        assert (
-            default_task["metadata"]["fromAgentId"]
-            == full_task["metadata"]["fromAgentId"]
-        )
-        assert (
-            default_task["metadata"]["toAgentId"] == full_task["metadata"]["toAgentId"]
-        )
-        assert default_task["metadata"]["type"] == full_task["metadata"]["type"]
+def test_message_poll_truncation__full_emits_full_text_in_text_output(
+    runner, session_id, agent_id, monkeypatch
+):
+    monkeypatch.setattr(
+        broker,
+        "poll_tasks",
+        lambda *_a, **_k: [
+            _task_payload(
+                "t-1", sender="from-1", recipient=agent_id, text=LONG_BODY
+            )
+        ],
+    )
+    result = runner.invoke(
+        cli,
+        [
+            "--session-id",
+            session_id,
+            "message",
+            "poll",
+            "--agent-id",
+            agent_id,
+            "--full",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert LONG_BODY in result.output
+    assert TRUNCATED_BODY not in result.output
 
 
-class TestMessageSendTruncation:
-    def test_default_truncates_echo_in_text_output(
-        self, runner, session_id, agent_id, task_id, other_agent_id, monkeypatch
-    ):
-        monkeypatch.setattr(
-            broker,
-            "send_message",
-            lambda *_a, **_k: {
-                "task": _task_payload(
-                    task_id, sender=agent_id, recipient=other_agent_id, text=LONG_BODY
-                )
-            },
-        )
-        result = runner.invoke(
-            cli,
-            [
-                "--session-id",
-                session_id,
-                "message",
-                "send",
-                "--agent-id",
-                agent_id,
-                "--to",
-                other_agent_id,
-                "--text",
-                LONG_BODY,
-            ],
-        )
-        assert result.exit_code == 0, result.output
-        assert "Message sent." in result.output
-        assert TRUNCATED_BODY in result.output
-        assert LONG_BODY not in result.output
+def test_message_poll_truncation__default_truncates_text_in_json_output(
+    runner, session_id, agent_id, monkeypatch
+):
+    monkeypatch.setattr(
+        broker,
+        "poll_tasks",
+        lambda *_a, **_k: [
+            _task_payload(
+                "t-1", sender="from-1", recipient=agent_id, text=LONG_BODY
+            )
+        ],
+    )
+    result = runner.invoke(
+        cli,
+        [
+            "--session-id",
+            session_id,
+            "--json",
+            "message",
+            "poll",
+            "--agent-id",
+            agent_id,
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload[0]["artifacts"][0]["parts"][0]["text"] == TRUNCATED_BODY
 
-    def test_full_emits_full_echo_in_text_output(
-        self, runner, session_id, agent_id, task_id, other_agent_id, monkeypatch
-    ):
-        monkeypatch.setattr(
-            broker,
-            "send_message",
-            lambda *_a, **_k: {
-                "task": _task_payload(
-                    task_id, sender=agent_id, recipient=other_agent_id, text=LONG_BODY
-                )
-            },
-        )
-        result = runner.invoke(
-            cli,
-            [
-                "--session-id",
-                session_id,
-                "message",
-                "send",
-                "--agent-id",
-                agent_id,
-                "--to",
-                other_agent_id,
-                "--text",
-                LONG_BODY,
-                "--full",
-            ],
-        )
-        assert result.exit_code == 0, result.output
-        assert LONG_BODY in result.output
 
-    def test_default_truncates_echo_in_json_output(
-        self, runner, session_id, agent_id, task_id, other_agent_id, monkeypatch
-    ):
-        monkeypatch.setattr(
-            broker,
-            "send_message",
-            lambda *_a, **_k: {
-                "task": _task_payload(
-                    task_id, sender=agent_id, recipient=other_agent_id, text=LONG_BODY
-                )
-            },
-        )
-        result = runner.invoke(
-            cli,
-            [
-                "--session-id",
-                session_id,
-                "--json",
-                "message",
-                "send",
-                "--agent-id",
-                agent_id,
-                "--to",
-                other_agent_id,
-                "--text",
-                LONG_BODY,
-            ],
-        )
-        assert result.exit_code == 0, result.output
-        payload = json.loads(result.output)
-        assert payload["task"]["artifacts"][0]["parts"][0]["text"] == TRUNCATED_BODY
+def test_message_poll_truncation__full_emits_full_text_in_json_output(
+    runner, session_id, agent_id, monkeypatch
+):
+    monkeypatch.setattr(
+        broker,
+        "poll_tasks",
+        lambda *_a, **_k: [
+            _task_payload(
+                "t-1", sender="from-1", recipient=agent_id, text=LONG_BODY
+            )
+        ],
+    )
+    result = runner.invoke(
+        cli,
+        [
+            "--session-id",
+            session_id,
+            "--json",
+            "message",
+            "poll",
+            "--agent-id",
+            agent_id,
+            "--full",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload[0]["artifacts"][0]["parts"][0]["text"] == LONG_BODY
 
-    def test_full_emits_full_echo_in_json_output(
-        self, runner, session_id, agent_id, task_id, other_agent_id, monkeypatch
-    ):
-        monkeypatch.setattr(
-            broker,
-            "send_message",
-            lambda *_a, **_k: {
-                "task": _task_payload(
-                    task_id, sender=agent_id, recipient=other_agent_id, text=LONG_BODY
-                )
-            },
-        )
-        result = runner.invoke(
-            cli,
-            [
-                "--session-id",
-                session_id,
-                "--json",
-                "message",
-                "send",
-                "--agent-id",
-                agent_id,
-                "--to",
-                other_agent_id,
-                "--text",
-                LONG_BODY,
-                "--full",
-            ],
-        )
-        assert result.exit_code == 0, result.output
-        payload = json.loads(result.output)
-        assert payload["task"]["artifacts"][0]["parts"][0]["text"] == LONG_BODY
 
-    def test_non_text_fields_byte_identical_between_default_and_full(
-        self, runner, session_id, agent_id, task_id, other_agent_id, monkeypatch
-    ):
-        def fresh_payload():
-            return {
-                "task": _task_payload(
-                    task_id, sender=agent_id, recipient=other_agent_id, text=LONG_BODY
-                )
-            }
+def test_message_poll_truncation__empty_inbox_unchanged_by_full_flag(
+    runner, session_id, agent_id, monkeypatch
+):
+    monkeypatch.setattr(broker, "poll_tasks", lambda *_a, **_k: [])
+    default = runner.invoke(
+        cli,
+        [
+            "--session-id",
+            session_id,
+            "message",
+            "poll",
+            "--agent-id",
+            agent_id,
+        ],
+    )
+    full = runner.invoke(
+        cli,
+        [
+            "--session-id",
+            session_id,
+            "message",
+            "poll",
+            "--agent-id",
+            agent_id,
+            "--full",
+        ],
+    )
+    assert default.exit_code == 0, default.output
+    assert full.exit_code == 0, full.output
+    assert default.output == full.output
 
-        monkeypatch.setattr(broker, "send_message", lambda *_a, **_k: fresh_payload())
-        common = [
+
+def test_message_poll_truncation__list_of_three_tasks_each_truncated(
+    runner, session_id, agent_id, monkeypatch
+):
+    bodies = [LONG_BODY + "X", LONG_BODY + "Y", LONG_BODY + "Z"]
+    monkeypatch.setattr(
+        broker,
+        "poll_tasks",
+        lambda *_a, **_k: [
+            _task_payload(
+                f"t-{i}", sender=f"from-{i}", recipient=agent_id, text=bodies[i]
+            )
+            for i in range(3)
+        ],
+    )
+    result = runner.invoke(
+        cli,
+        [
+            "--session-id",
+            session_id,
+            "--json",
+            "message",
+            "poll",
+            "--agent-id",
+            agent_id,
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert len(payload) == 3
+    for item in payload:
+        assert item["artifacts"][0]["parts"][0]["text"] == TRUNCATED_BODY
+
+
+def test_message_poll_truncation__non_text_fields_byte_identical_between_default_and_full(
+    runner, session_id, agent_id, monkeypatch
+):
+    def fresh_payload():
+        return [
+            _task_payload(
+                "t-1", sender="from-1", recipient=agent_id, text=LONG_BODY
+            )
+        ]
+
+    monkeypatch.setattr(broker, "poll_tasks", lambda *_a, **_k: fresh_payload())
+    default_res = runner.invoke(
+        cli,
+        [
+            "--session-id",
+            session_id,
+            "--json",
+            "message",
+            "poll",
+            "--agent-id",
+            agent_id,
+        ],
+    )
+    full_res = runner.invoke(
+        cli,
+        [
+            "--session-id",
+            session_id,
+            "--json",
+            "message",
+            "poll",
+            "--agent-id",
+            agent_id,
+            "--full",
+        ],
+    )
+    assert default_res.exit_code == 0, default_res.output
+    assert full_res.exit_code == 0, full_res.output
+
+    default_task = json.loads(default_res.output)[0]
+    full_task = json.loads(full_res.output)[0]
+    assert default_task["id"] == full_task["id"]
+    assert default_task["status"]["state"] == full_task["status"]["state"]
+    assert (
+        default_task["metadata"]["fromAgentId"]
+        == full_task["metadata"]["fromAgentId"]
+    )
+    assert (
+        default_task["metadata"]["toAgentId"] == full_task["metadata"]["toAgentId"]
+    )
+    assert default_task["metadata"]["type"] == full_task["metadata"]["type"]
+
+
+def test_message_show_truncation__default_truncates_text_in_text_output(
+    runner, session_id, agent_id, task_id, other_agent_id, monkeypatch
+):
+    monkeypatch.setattr(
+        broker,
+        "get_task",
+        lambda *_a, **_k: {
+            "task": _task_payload(
+                task_id, sender=other_agent_id, recipient=agent_id, text=LONG_BODY
+            )
+        },
+    )
+    result = runner.invoke(
+        cli,
+        [
+            "--session-id",
+            session_id,
+            "message",
+            "show",
+            "--agent-id",
+            agent_id,
+            "--task-id",
+            task_id,
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert TRUNCATED_BODY in result.output
+    assert LONG_BODY not in result.output
+
+
+def test_message_show_truncation__full_emits_full_text_in_text_output(
+    runner, session_id, agent_id, task_id, other_agent_id, monkeypatch
+):
+    monkeypatch.setattr(
+        broker,
+        "get_task",
+        lambda *_a, **_k: {
+            "task": _task_payload(
+                task_id, sender=other_agent_id, recipient=agent_id, text=LONG_BODY
+            )
+        },
+    )
+    result = runner.invoke(
+        cli,
+        [
+            "--session-id",
+            session_id,
+            "message",
+            "show",
+            "--agent-id",
+            agent_id,
+            "--task-id",
+            task_id,
+            "--full",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert LONG_BODY in result.output
+
+
+def test_message_show_truncation__default_truncates_text_in_json_output(
+    runner, session_id, agent_id, task_id, other_agent_id, monkeypatch
+):
+    monkeypatch.setattr(
+        broker,
+        "get_task",
+        lambda *_a, **_k: {
+            "task": _task_payload(
+                task_id, sender=other_agent_id, recipient=agent_id, text=LONG_BODY
+            )
+        },
+    )
+    result = runner.invoke(
+        cli,
+        [
+            "--session-id",
+            session_id,
+            "--json",
+            "message",
+            "show",
+            "--agent-id",
+            agent_id,
+            "--task-id",
+            task_id,
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["task"]["artifacts"][0]["parts"][0]["text"] == TRUNCATED_BODY
+
+
+def test_message_show_truncation__full_emits_full_text_in_json_output(
+    runner, session_id, agent_id, task_id, other_agent_id, monkeypatch
+):
+    monkeypatch.setattr(
+        broker,
+        "get_task",
+        lambda *_a, **_k: {
+            "task": _task_payload(
+                task_id, sender=other_agent_id, recipient=agent_id, text=LONG_BODY
+            )
+        },
+    )
+    result = runner.invoke(
+        cli,
+        [
+            "--session-id",
+            session_id,
+            "--json",
+            "message",
+            "show",
+            "--agent-id",
+            agent_id,
+            "--task-id",
+            task_id,
+            "--full",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["task"]["artifacts"][0]["parts"][0]["text"] == LONG_BODY
+
+
+def test_message_show_truncation__non_text_fields_byte_identical_between_default_and_full(
+    runner, session_id, agent_id, task_id, other_agent_id, monkeypatch
+):
+    def fresh_payload():
+        return {
+            "task": _task_payload(
+                task_id, sender=other_agent_id, recipient=agent_id, text=LONG_BODY
+            )
+        }
+
+    monkeypatch.setattr(broker, "get_task", lambda *_a, **_k: fresh_payload())
+    default_res = runner.invoke(
+        cli,
+        [
+            "--session-id",
+            session_id,
+            "--json",
+            "message",
+            "show",
+            "--agent-id",
+            agent_id,
+            "--task-id",
+            task_id,
+        ],
+    )
+    full_res = runner.invoke(
+        cli,
+        [
+            "--session-id",
+            session_id,
+            "--json",
+            "message",
+            "show",
+            "--agent-id",
+            agent_id,
+            "--task-id",
+            task_id,
+            "--full",
+        ],
+    )
+    assert default_res.exit_code == 0, default_res.output
+    assert full_res.exit_code == 0, full_res.output
+
+    default_task = json.loads(default_res.output)["task"]
+    full_task = json.loads(full_res.output)["task"]
+    assert default_task["id"] == full_task["id"]
+    assert default_task["status"]["state"] == full_task["status"]["state"]
+    assert (
+        default_task["metadata"]["fromAgentId"]
+        == full_task["metadata"]["fromAgentId"]
+    )
+    assert (
+        default_task["metadata"]["toAgentId"] == full_task["metadata"]["toAgentId"]
+    )
+    assert default_task["metadata"]["type"] == full_task["metadata"]["type"]
+
+
+def test_message_send_truncation__default_truncates_echo_in_text_output(
+    runner, session_id, agent_id, task_id, other_agent_id, monkeypatch
+):
+    monkeypatch.setattr(
+        broker,
+        "send_message",
+        lambda *_a, **_k: {
+            "task": _task_payload(
+                task_id, sender=agent_id, recipient=other_agent_id, text=LONG_BODY
+            )
+        },
+    )
+    result = runner.invoke(
+        cli,
+        [
+            "--session-id",
+            session_id,
+            "message",
+            "send",
+            "--agent-id",
+            agent_id,
+            "--to",
+            other_agent_id,
+            "--text",
+            LONG_BODY,
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert "Message sent." in result.output
+    assert TRUNCATED_BODY in result.output
+    assert LONG_BODY not in result.output
+
+
+def test_message_send_truncation__full_emits_full_echo_in_text_output(
+    runner, session_id, agent_id, task_id, other_agent_id, monkeypatch
+):
+    monkeypatch.setattr(
+        broker,
+        "send_message",
+        lambda *_a, **_k: {
+            "task": _task_payload(
+                task_id, sender=agent_id, recipient=other_agent_id, text=LONG_BODY
+            )
+        },
+    )
+    result = runner.invoke(
+        cli,
+        [
+            "--session-id",
+            session_id,
+            "message",
+            "send",
+            "--agent-id",
+            agent_id,
+            "--to",
+            other_agent_id,
+            "--text",
+            LONG_BODY,
+            "--full",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert LONG_BODY in result.output
+
+
+def test_message_send_truncation__default_truncates_echo_in_json_output(
+    runner, session_id, agent_id, task_id, other_agent_id, monkeypatch
+):
+    monkeypatch.setattr(
+        broker,
+        "send_message",
+        lambda *_a, **_k: {
+            "task": _task_payload(
+                task_id, sender=agent_id, recipient=other_agent_id, text=LONG_BODY
+            )
+        },
+    )
+    result = runner.invoke(
+        cli,
+        [
+            "--session-id",
+            session_id,
             "--json",
             "message",
             "send",
@@ -635,24 +584,86 @@ class TestMessageSendTruncation:
             other_agent_id,
             "--text",
             LONG_BODY,
-        ]
-        default_res = runner.invoke(cli, ["--session-id", session_id, *common])
-        full_res = runner.invoke(cli, ["--session-id", session_id, *common, "--full"])
-        assert default_res.exit_code == 0, default_res.output
-        assert full_res.exit_code == 0, full_res.output
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["task"]["artifacts"][0]["parts"][0]["text"] == TRUNCATED_BODY
 
-        default_task = json.loads(default_res.output)["task"]
-        full_task = json.loads(full_res.output)["task"]
-        assert default_task["id"] == full_task["id"]
-        assert default_task["status"]["state"] == full_task["status"]["state"]
-        assert (
-            default_task["metadata"]["fromAgentId"]
-            == full_task["metadata"]["fromAgentId"]
-        )
-        assert (
-            default_task["metadata"]["toAgentId"] == full_task["metadata"]["toAgentId"]
-        )
-        assert default_task["metadata"]["type"] == full_task["metadata"]["type"]
+
+def test_message_send_truncation__full_emits_full_echo_in_json_output(
+    runner, session_id, agent_id, task_id, other_agent_id, monkeypatch
+):
+    monkeypatch.setattr(
+        broker,
+        "send_message",
+        lambda *_a, **_k: {
+            "task": _task_payload(
+                task_id, sender=agent_id, recipient=other_agent_id, text=LONG_BODY
+            )
+        },
+    )
+    result = runner.invoke(
+        cli,
+        [
+            "--session-id",
+            session_id,
+            "--json",
+            "message",
+            "send",
+            "--agent-id",
+            agent_id,
+            "--to",
+            other_agent_id,
+            "--text",
+            LONG_BODY,
+            "--full",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["task"]["artifacts"][0]["parts"][0]["text"] == LONG_BODY
+
+
+def test_message_send_truncation__non_text_fields_byte_identical_between_default_and_full(
+    runner, session_id, agent_id, task_id, other_agent_id, monkeypatch
+):
+    def fresh_payload():
+        return {
+            "task": _task_payload(
+                task_id, sender=agent_id, recipient=other_agent_id, text=LONG_BODY
+            )
+        }
+
+    monkeypatch.setattr(broker, "send_message", lambda *_a, **_k: fresh_payload())
+    common = [
+        "--json",
+        "message",
+        "send",
+        "--agent-id",
+        agent_id,
+        "--to",
+        other_agent_id,
+        "--text",
+        LONG_BODY,
+    ]
+    default_res = runner.invoke(cli, ["--session-id", session_id, *common])
+    full_res = runner.invoke(cli, ["--session-id", session_id, *common, "--full"])
+    assert default_res.exit_code == 0, default_res.output
+    assert full_res.exit_code == 0, full_res.output
+
+    default_task = json.loads(default_res.output)["task"]
+    full_task = json.loads(full_res.output)["task"]
+    assert default_task["id"] == full_task["id"]
+    assert default_task["status"]["state"] == full_task["status"]["state"]
+    assert (
+        default_task["metadata"]["fromAgentId"]
+        == full_task["metadata"]["fromAgentId"]
+    )
+    assert (
+        default_task["metadata"]["toAgentId"] == full_task["metadata"]["toAgentId"]
+    )
+    assert default_task["metadata"]["type"] == full_task["metadata"]["type"]
 
 
 SUMMARY_TEXT = "Broadcast sent to 3 recipients"
@@ -687,167 +698,86 @@ def _broadcast_summary_payload(task_id, *, sender, count):
     ]
 
 
-class TestMessageBroadcastNoTruncation:
-    """``message broadcast`` returns a ``broadcast_summary`` envelope, not a
-    list of per-recipient delivery tasks. The summary text is generated by the
-    broker and carries no user-supplied body, so truncating it would only
-    obscure operator-relevant detail (notifications-sent count, etc.). The
-    subcommand therefore disables ``truncates_task_text`` and the ``--full``
-    flag is a no-op here.
-    """
+# --- message_broadcast_no_truncation: ``message broadcast`` returns a
+# ``broadcast_summary`` envelope, not a list of per-recipient delivery tasks.
+# The summary text is generated by the broker and carries no user-supplied
+# body, so truncating it would only obscure operator-relevant detail
+# (notifications-sent count, etc.). The subcommand therefore disables
+# ``truncates_task_text`` and the ``--full`` flag is a no-op here. ---
 
-    def test_summary_text_emitted_verbatim_in_text_output(
-        self, runner, session_id, agent_id, task_id, monkeypatch
-    ):
-        monkeypatch.setattr(
-            broker,
-            "broadcast_message",
-            lambda *_a, **_k: _broadcast_summary_payload(
-                task_id, sender=agent_id, count=3
-            ),
-        )
-        result = runner.invoke(
-            cli,
-            [
-                "--session-id",
-                session_id,
-                "message",
-                "broadcast",
-                "--agent-id",
-                agent_id,
-                "--text",
-                LONG_BODY,
-            ],
-        )
-        assert result.exit_code == 0, result.output
-        assert "Broadcast sent." in result.output
-        assert SUMMARY_TEXT in result.output
-        assert TRUNCATED_BODY not in result.output
 
-    def test_summary_text_emitted_verbatim_with_full_in_text_output(
-        self, runner, session_id, agent_id, task_id, monkeypatch
-    ):
-        monkeypatch.setattr(
-            broker,
-            "broadcast_message",
-            lambda *_a, **_k: _broadcast_summary_payload(
-                task_id, sender=agent_id, count=3
-            ),
-        )
-        result = runner.invoke(
-            cli,
-            [
-                "--session-id",
-                session_id,
-                "message",
-                "broadcast",
-                "--agent-id",
-                agent_id,
-                "--text",
-                LONG_BODY,
-                "--full",
-            ],
-        )
-        assert result.exit_code == 0, result.output
-        assert SUMMARY_TEXT in result.output
+def test_message_broadcast_no_truncation__summary_text_emitted_verbatim_in_text_output(
+    runner, session_id, agent_id, task_id, monkeypatch
+):
+    monkeypatch.setattr(
+        broker,
+        "broadcast_message",
+        lambda *_a, **_k: _broadcast_summary_payload(
+            task_id, sender=agent_id, count=3
+        ),
+    )
+    result = runner.invoke(
+        cli,
+        [
+            "--session-id",
+            session_id,
+            "message",
+            "broadcast",
+            "--agent-id",
+            agent_id,
+            "--text",
+            LONG_BODY,
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert "Broadcast sent." in result.output
+    assert SUMMARY_TEXT in result.output
+    assert TRUNCATED_BODY not in result.output
 
-    def test_summary_text_emitted_verbatim_in_json_output(
-        self, runner, session_id, agent_id, task_id, monkeypatch
-    ):
-        monkeypatch.setattr(
-            broker,
-            "broadcast_message",
-            lambda *_a, **_k: _broadcast_summary_payload(
-                task_id, sender=agent_id, count=3
-            ),
-        )
-        result = runner.invoke(
-            cli,
-            [
-                "--session-id",
-                session_id,
-                "--json",
-                "message",
-                "broadcast",
-                "--agent-id",
-                agent_id,
-                "--text",
-                LONG_BODY,
-            ],
-        )
-        assert result.exit_code == 0, result.output
-        payload = json.loads(result.output)
-        assert len(payload) == 1
-        assert payload[0]["task"]["artifacts"][0]["parts"][0]["text"] == SUMMARY_TEXT
 
-    def test_summary_text_emitted_verbatim_with_full_in_json_output(
-        self, runner, session_id, agent_id, task_id, monkeypatch
-    ):
-        monkeypatch.setattr(
-            broker,
-            "broadcast_message",
-            lambda *_a, **_k: _broadcast_summary_payload(
-                task_id, sender=agent_id, count=3
-            ),
-        )
-        result = runner.invoke(
-            cli,
-            [
-                "--session-id",
-                session_id,
-                "--json",
-                "message",
-                "broadcast",
-                "--agent-id",
-                agent_id,
-                "--text",
-                LONG_BODY,
-                "--full",
-            ],
-        )
-        assert result.exit_code == 0, result.output
-        payload = json.loads(result.output)
-        assert payload[0]["task"]["artifacts"][0]["parts"][0]["text"] == SUMMARY_TEXT
+def test_message_broadcast_no_truncation__summary_text_emitted_verbatim_with_full_in_text_output(
+    runner, session_id, agent_id, task_id, monkeypatch
+):
+    monkeypatch.setattr(
+        broker,
+        "broadcast_message",
+        lambda *_a, **_k: _broadcast_summary_payload(
+            task_id, sender=agent_id, count=3
+        ),
+    )
+    result = runner.invoke(
+        cli,
+        [
+            "--session-id",
+            session_id,
+            "message",
+            "broadcast",
+            "--agent-id",
+            agent_id,
+            "--text",
+            LONG_BODY,
+            "--full",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert SUMMARY_TEXT in result.output
 
-    def test_notifications_sent_count_preserved_in_json_output(
-        self, runner, session_id, agent_id, task_id, monkeypatch
-    ):
-        monkeypatch.setattr(
-            broker,
-            "broadcast_message",
-            lambda *_a, **_k: _broadcast_summary_payload(
-                task_id, sender=agent_id, count=7
-            ),
-        )
-        result = runner.invoke(
-            cli,
-            [
-                "--session-id",
-                session_id,
-                "--json",
-                "message",
-                "broadcast",
-                "--agent-id",
-                agent_id,
-                "--text",
-                LONG_BODY,
-            ],
-        )
-        assert result.exit_code == 0, result.output
-        payload = json.loads(result.output)
-        assert payload[0]["notifications_sent_count"] == 7
-        assert payload[0]["task"]["metadata"]["notificationsSentCount"] == 7
 
-    def test_default_and_full_json_output_byte_identical(
-        self, runner, session_id, agent_id, task_id, monkeypatch
-    ):
-        def fresh_payload():
-            return _broadcast_summary_payload(task_id, sender=agent_id, count=5)
-
-        monkeypatch.setattr(
-            broker, "broadcast_message", lambda *_a, **_k: fresh_payload()
-        )
-        common = [
+def test_message_broadcast_no_truncation__summary_text_emitted_verbatim_in_json_output(
+    runner, session_id, agent_id, task_id, monkeypatch
+):
+    monkeypatch.setattr(
+        broker,
+        "broadcast_message",
+        lambda *_a, **_k: _broadcast_summary_payload(
+            task_id, sender=agent_id, count=3
+        ),
+    )
+    result = runner.invoke(
+        cli,
+        [
+            "--session-id",
+            session_id,
             "--json",
             "message",
             "broadcast",
@@ -855,9 +785,94 @@ class TestMessageBroadcastNoTruncation:
             agent_id,
             "--text",
             LONG_BODY,
-        ]
-        default_res = runner.invoke(cli, ["--session-id", session_id, *common])
-        full_res = runner.invoke(cli, ["--session-id", session_id, *common, "--full"])
-        assert default_res.exit_code == 0, default_res.output
-        assert full_res.exit_code == 0, full_res.output
-        assert default_res.output == full_res.output
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert len(payload) == 1
+    assert payload[0]["task"]["artifacts"][0]["parts"][0]["text"] == SUMMARY_TEXT
+
+
+def test_message_broadcast_no_truncation__summary_text_emitted_verbatim_with_full_in_json_output(
+    runner, session_id, agent_id, task_id, monkeypatch
+):
+    monkeypatch.setattr(
+        broker,
+        "broadcast_message",
+        lambda *_a, **_k: _broadcast_summary_payload(
+            task_id, sender=agent_id, count=3
+        ),
+    )
+    result = runner.invoke(
+        cli,
+        [
+            "--session-id",
+            session_id,
+            "--json",
+            "message",
+            "broadcast",
+            "--agent-id",
+            agent_id,
+            "--text",
+            LONG_BODY,
+            "--full",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload[0]["task"]["artifacts"][0]["parts"][0]["text"] == SUMMARY_TEXT
+
+
+def test_message_broadcast_no_truncation__notifications_sent_count_preserved_in_json_output(
+    runner, session_id, agent_id, task_id, monkeypatch
+):
+    monkeypatch.setattr(
+        broker,
+        "broadcast_message",
+        lambda *_a, **_k: _broadcast_summary_payload(
+            task_id, sender=agent_id, count=7
+        ),
+    )
+    result = runner.invoke(
+        cli,
+        [
+            "--session-id",
+            session_id,
+            "--json",
+            "message",
+            "broadcast",
+            "--agent-id",
+            agent_id,
+            "--text",
+            LONG_BODY,
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload[0]["notifications_sent_count"] == 7
+    assert payload[0]["task"]["metadata"]["notificationsSentCount"] == 7
+
+
+def test_message_broadcast_no_truncation__default_and_full_json_output_byte_identical(
+    runner, session_id, agent_id, task_id, monkeypatch
+):
+    def fresh_payload():
+        return _broadcast_summary_payload(task_id, sender=agent_id, count=5)
+
+    monkeypatch.setattr(
+        broker, "broadcast_message", lambda *_a, **_k: fresh_payload()
+    )
+    common = [
+        "--json",
+        "message",
+        "broadcast",
+        "--agent-id",
+        agent_id,
+        "--text",
+        LONG_BODY,
+    ]
+    default_res = runner.invoke(cli, ["--session-id", session_id, *common])
+    full_res = runner.invoke(cli, ["--session-id", session_id, *common, "--full"])
+    assert default_res.exit_code == 0, default_res.output
+    assert full_res.exit_code == 0, full_res.output
+    assert default_res.output == full_res.output

--- a/cafleet/tests/test_cli_message_truncation.py
+++ b/cafleet/tests/test_cli_message_truncation.py
@@ -86,9 +86,7 @@ def test_message_poll_truncation__default_truncates_text_in_text_output(
         broker,
         "poll_tasks",
         lambda *_a, **_k: [
-            _task_payload(
-                "t-1", sender="from-1", recipient=agent_id, text=LONG_BODY
-            )
+            _task_payload("t-1", sender="from-1", recipient=agent_id, text=LONG_BODY)
         ],
     )
     result = runner.invoke(
@@ -114,9 +112,7 @@ def test_message_poll_truncation__full_emits_full_text_in_text_output(
         broker,
         "poll_tasks",
         lambda *_a, **_k: [
-            _task_payload(
-                "t-1", sender="from-1", recipient=agent_id, text=LONG_BODY
-            )
+            _task_payload("t-1", sender="from-1", recipient=agent_id, text=LONG_BODY)
         ],
     )
     result = runner.invoke(
@@ -143,9 +139,7 @@ def test_message_poll_truncation__default_truncates_text_in_json_output(
         broker,
         "poll_tasks",
         lambda *_a, **_k: [
-            _task_payload(
-                "t-1", sender="from-1", recipient=agent_id, text=LONG_BODY
-            )
+            _task_payload("t-1", sender="from-1", recipient=agent_id, text=LONG_BODY)
         ],
     )
     result = runner.invoke(
@@ -172,9 +166,7 @@ def test_message_poll_truncation__full_emits_full_text_in_json_output(
         broker,
         "poll_tasks",
         lambda *_a, **_k: [
-            _task_payload(
-                "t-1", sender="from-1", recipient=agent_id, text=LONG_BODY
-            )
+            _task_payload("t-1", sender="from-1", recipient=agent_id, text=LONG_BODY)
         ],
     )
     result = runner.invoke(
@@ -265,9 +257,7 @@ def test_message_poll_truncation__non_text_fields_byte_identical_between_default
 ):
     def fresh_payload():
         return [
-            _task_payload(
-                "t-1", sender="from-1", recipient=agent_id, text=LONG_BODY
-            )
+            _task_payload("t-1", sender="from-1", recipient=agent_id, text=LONG_BODY)
         ]
 
     monkeypatch.setattr(broker, "poll_tasks", lambda *_a, **_k: fresh_payload())
@@ -304,12 +294,9 @@ def test_message_poll_truncation__non_text_fields_byte_identical_between_default
     assert default_task["id"] == full_task["id"]
     assert default_task["status"]["state"] == full_task["status"]["state"]
     assert (
-        default_task["metadata"]["fromAgentId"]
-        == full_task["metadata"]["fromAgentId"]
+        default_task["metadata"]["fromAgentId"] == full_task["metadata"]["fromAgentId"]
     )
-    assert (
-        default_task["metadata"]["toAgentId"] == full_task["metadata"]["toAgentId"]
-    )
+    assert default_task["metadata"]["toAgentId"] == full_task["metadata"]["toAgentId"]
     assert default_task["metadata"]["type"] == full_task["metadata"]["type"]
 
 
@@ -484,12 +471,9 @@ def test_message_show_truncation__non_text_fields_byte_identical_between_default
     assert default_task["id"] == full_task["id"]
     assert default_task["status"]["state"] == full_task["status"]["state"]
     assert (
-        default_task["metadata"]["fromAgentId"]
-        == full_task["metadata"]["fromAgentId"]
+        default_task["metadata"]["fromAgentId"] == full_task["metadata"]["fromAgentId"]
     )
-    assert (
-        default_task["metadata"]["toAgentId"] == full_task["metadata"]["toAgentId"]
-    )
+    assert default_task["metadata"]["toAgentId"] == full_task["metadata"]["toAgentId"]
     assert default_task["metadata"]["type"] == full_task["metadata"]["type"]
 
 
@@ -657,12 +641,9 @@ def test_message_send_truncation__non_text_fields_byte_identical_between_default
     assert default_task["id"] == full_task["id"]
     assert default_task["status"]["state"] == full_task["status"]["state"]
     assert (
-        default_task["metadata"]["fromAgentId"]
-        == full_task["metadata"]["fromAgentId"]
+        default_task["metadata"]["fromAgentId"] == full_task["metadata"]["fromAgentId"]
     )
-    assert (
-        default_task["metadata"]["toAgentId"] == full_task["metadata"]["toAgentId"]
-    )
+    assert default_task["metadata"]["toAgentId"] == full_task["metadata"]["toAgentId"]
     assert default_task["metadata"]["type"] == full_task["metadata"]["type"]
 
 
@@ -712,9 +693,7 @@ def test_message_broadcast_no_truncation__summary_text_emitted_verbatim_in_text_
     monkeypatch.setattr(
         broker,
         "broadcast_message",
-        lambda *_a, **_k: _broadcast_summary_payload(
-            task_id, sender=agent_id, count=3
-        ),
+        lambda *_a, **_k: _broadcast_summary_payload(task_id, sender=agent_id, count=3),
     )
     result = runner.invoke(
         cli,
@@ -741,9 +720,7 @@ def test_message_broadcast_no_truncation__summary_text_emitted_verbatim_with_ful
     monkeypatch.setattr(
         broker,
         "broadcast_message",
-        lambda *_a, **_k: _broadcast_summary_payload(
-            task_id, sender=agent_id, count=3
-        ),
+        lambda *_a, **_k: _broadcast_summary_payload(task_id, sender=agent_id, count=3),
     )
     result = runner.invoke(
         cli,
@@ -769,9 +746,7 @@ def test_message_broadcast_no_truncation__summary_text_emitted_verbatim_in_json_
     monkeypatch.setattr(
         broker,
         "broadcast_message",
-        lambda *_a, **_k: _broadcast_summary_payload(
-            task_id, sender=agent_id, count=3
-        ),
+        lambda *_a, **_k: _broadcast_summary_payload(task_id, sender=agent_id, count=3),
     )
     result = runner.invoke(
         cli,
@@ -799,9 +774,7 @@ def test_message_broadcast_no_truncation__summary_text_emitted_verbatim_with_ful
     monkeypatch.setattr(
         broker,
         "broadcast_message",
-        lambda *_a, **_k: _broadcast_summary_payload(
-            task_id, sender=agent_id, count=3
-        ),
+        lambda *_a, **_k: _broadcast_summary_payload(task_id, sender=agent_id, count=3),
     )
     result = runner.invoke(
         cli,
@@ -829,9 +802,7 @@ def test_message_broadcast_no_truncation__notifications_sent_count_preserved_in_
     monkeypatch.setattr(
         broker,
         "broadcast_message",
-        lambda *_a, **_k: _broadcast_summary_payload(
-            task_id, sender=agent_id, count=7
-        ),
+        lambda *_a, **_k: _broadcast_summary_payload(task_id, sender=agent_id, count=7),
     )
     result = runner.invoke(
         cli,
@@ -859,9 +830,7 @@ def test_message_broadcast_no_truncation__default_and_full_json_output_byte_iden
     def fresh_payload():
         return _broadcast_summary_payload(task_id, sender=agent_id, count=5)
 
-    monkeypatch.setattr(
-        broker, "broadcast_message", lambda *_a, **_k: fresh_payload()
-    )
+    monkeypatch.setattr(broker, "broadcast_message", lambda *_a, **_k: fresh_payload())
     common = [
         "--json",
         "message",

--- a/cafleet/tests/test_cli_session_bootstrap.py
+++ b/cafleet/tests/test_cli_session_bootstrap.py
@@ -83,219 +83,236 @@ def _agent_rows(db_path) -> list[tuple]:
         conn.close()
 
 
-class TestSessionCreateTextOutput:
-    def test_line_1_is_session_id_and_line_2_is_director_agent_id(
-        self, db_file, mock_tmux_ok
+def test_session_create_text_output__line_1_is_session_id_and_line_2_is_director_agent_id(
+    db_file, mock_tmux_ok
+):
+    runner = CliRunner()
+    result = runner.invoke(cli, ["session", "create"])
+    assert result.exit_code == 0, result.output
+
+    lines = [ln for ln in result.output.splitlines() if ln.strip() != ""]
+    assert len(lines) >= 2
+
+    sid_line = lines[0].strip()
+    uuid.UUID(sid_line)
+
+    director_line = lines[1].strip()
+    uuid.UUID(director_line)
+    assert director_line != sid_line
+
+    rows = _session_rows(db_file)
+    assert any(r[0] == sid_line for r in rows)
+
+
+def test_session_create_text_output__contains_label_director_name_pane_and_administrator_labels(
+    db_file, mock_tmux_ok
+):
+    runner = CliRunner()
+    result = runner.invoke(cli, ["session", "create", "--label", "bootstrap-check"])
+    assert result.exit_code == 0
+
+    text = result.output
+    assert "label:" in text
+    assert "director_name:" in text
+    assert "pane:" in text
+    assert "administrator:" in text
+
+    assert "Director" in text
+    assert "bootstrap-check" in text
+
+    assert (
+        f"{_FAKE_DIRECTOR_CTX.session}:{_FAKE_DIRECTOR_CTX.window_id}:"
+        f"{_FAKE_DIRECTOR_CTX.pane_id}" in text
+    )
+
+
+def test_session_create_text_output__administrator_line_references_the_seeded_administrator(
+    db_file, mock_tmux_ok
+):
+    runner = CliRunner()
+    result = runner.invoke(cli, ["session", "create"])
+    assert result.exit_code == 0
+
+    admin_line = next(
+        (
+            ln.strip()
+            for ln in result.output.splitlines()
+            if ln.strip().lower().startswith("administrator")
+        ),
+        None,
+    )
+    assert admin_line is not None
+    admin_id = None
+    for token in admin_line.replace(":", " ").split():
+        try:
+            uuid.UUID(token)
+            admin_id = token
+            break
+        except ValueError:
+            continue
+    assert admin_id is not None
+
+    rows = _agent_rows(db_file)
+    matches = [r for r in rows if r[0] == admin_id]
+    assert len(matches) == 1
+    assert matches[0][2] == "Administrator"
+
+
+def test_session_create_json_output__top_level_keys(db_file, mock_tmux_ok):
+    runner = CliRunner()
+    result = runner.invoke(cli, ["session", "create", "--json"])
+    assert result.exit_code == 0, result.output
+
+    data = json.loads(result.output)
+    for key in (
+        "session_id",
+        "label",
+        "created_at",
+        "administrator_agent_id",
+        "director",
     ):
-        runner = CliRunner()
-        result = runner.invoke(cli, ["session", "create"])
-        assert result.exit_code == 0, result.output
+        assert key in data
 
-        lines = [ln for ln in result.output.splitlines() if ln.strip() != ""]
-        assert len(lines) >= 2
-
-        sid_line = lines[0].strip()
-        uuid.UUID(sid_line)
-
-        director_line = lines[1].strip()
-        uuid.UUID(director_line)
-        assert director_line != sid_line
-
-        rows = _session_rows(db_file)
-        assert any(r[0] == sid_line for r in rows)
-
-    def test_contains_label_director_name_pane_and_administrator_labels(
-        self, db_file, mock_tmux_ok
-    ):
-        runner = CliRunner()
-        result = runner.invoke(cli, ["session", "create", "--label", "bootstrap-check"])
-        assert result.exit_code == 0
-
-        text = result.output
-        assert "label:" in text
-        assert "director_name:" in text
-        assert "pane:" in text
-        assert "administrator:" in text
-
-        assert "Director" in text
-        assert "bootstrap-check" in text
-
-        assert (
-            f"{_FAKE_DIRECTOR_CTX.session}:{_FAKE_DIRECTOR_CTX.window_id}:"
-            f"{_FAKE_DIRECTOR_CTX.pane_id}" in text
-        )
-
-    def test_administrator_line_references_the_seeded_administrator(
-        self, db_file, mock_tmux_ok
-    ):
-        runner = CliRunner()
-        result = runner.invoke(cli, ["session", "create"])
-        assert result.exit_code == 0
-
-        admin_line = next(
-            (
-                ln.strip()
-                for ln in result.output.splitlines()
-                if ln.strip().lower().startswith("administrator")
-            ),
-            None,
-        )
-        assert admin_line is not None
-        admin_id = None
-        for token in admin_line.replace(":", " ").split():
-            try:
-                uuid.UUID(token)
-                admin_id = token
-                break
-            except ValueError:
-                continue
-        assert admin_id is not None
-
-        rows = _agent_rows(db_file)
-        matches = [r for r in rows if r[0] == admin_id]
-        assert len(matches) == 1
-        assert matches[0][2] == "Administrator"
+    uuid.UUID(data["administrator_agent_id"])
 
 
-class TestSessionCreateJsonOutput:
-    def test_top_level_keys(self, db_file, mock_tmux_ok):
-        runner = CliRunner()
-        result = runner.invoke(cli, ["session", "create", "--json"])
-        assert result.exit_code == 0, result.output
-
-        data = json.loads(result.output)
-        for key in (
-            "session_id",
-            "label",
-            "created_at",
-            "administrator_agent_id",
-            "director",
-        ):
-            assert key in data
-
-        uuid.UUID(data["administrator_agent_id"])
-
-    def test_director_sub_dict(self, db_file, mock_tmux_ok):
-        runner = CliRunner()
-        result = runner.invoke(cli, ["session", "create", "--json"])
-        assert result.exit_code == 0
-        data = json.loads(result.output)
-        director = data["director"]
-        for key in ("agent_id", "name", "description", "registered_at", "placement"):
-            assert key in director
-        assert director["name"] == "Director"
-        assert director["description"] == "Root Director for this session"
-        uuid.UUID(director["agent_id"])
-
-    def test_placement_sub_dict_matches_spec(self, db_file, mock_tmux_ok):
-        runner = CliRunner()
-        result = runner.invoke(cli, ["session", "create", "--json"])
-        assert result.exit_code == 0
-        data = json.loads(result.output)
-        placement = data["director"]["placement"]
-
-        assert placement["director_agent_id"] is None
-        assert placement["coding_agent"] == "unknown"
-        assert placement["tmux_session"] == _FAKE_DIRECTOR_CTX.session
-        assert placement["tmux_window_id"] == _FAKE_DIRECTOR_CTX.window_id
-        assert placement["tmux_pane_id"] == _FAKE_DIRECTOR_CTX.pane_id
-        assert "created_at" in placement
-
-    def test_label_propagates_to_json(self, db_file, mock_tmux_ok):
-        runner = CliRunner()
-        result = runner.invoke(
-            cli, ["session", "create", "--label", "json-label", "--json"]
-        )
-        assert result.exit_code == 0
-        data = json.loads(result.output)
-        assert data["label"] == "json-label"
-
-    def test_administrator_and_director_are_distinct_uuids(self, db_file, mock_tmux_ok):
-        runner = CliRunner()
-        result = runner.invoke(cli, ["session", "create", "--json"])
-        assert result.exit_code == 0
-        data = json.loads(result.output)
-        assert data["administrator_agent_id"] != data["director"]["agent_id"]
+def test_session_create_json_output__director_sub_dict(db_file, mock_tmux_ok):
+    runner = CliRunner()
+    result = runner.invoke(cli, ["session", "create", "--json"])
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    director = data["director"]
+    for key in ("agent_id", "name", "description", "registered_at", "placement"):
+        assert key in director
+    assert director["name"] == "Director"
+    assert director["description"] == "Root Director for this session"
+    uuid.UUID(director["agent_id"])
 
 
-class TestSessionCreateOutsideTmux:
-    def test_fails_with_specific_error_and_exit_1(self, db_file, mock_tmux_unavailable):
-        runner = CliRunner()
-        result = runner.invoke(cli, ["session", "create"])
-        assert result.exit_code == 1, result.output
-        combined = (result.output or "") + (result.stderr or "")
-        assert "cafleet session create must be run inside a tmux session" in combined
+def test_session_create_json_output__placement_sub_dict_matches_spec(db_file, mock_tmux_ok):
+    runner = CliRunner()
+    result = runner.invoke(cli, ["session", "create", "--json"])
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    placement = data["director"]["placement"]
 
-    def test_no_session_row_is_written_when_tmux_is_missing(
-        self, db_file, mock_tmux_unavailable
-    ):
-        runner = CliRunner()
-        before = _session_rows(db_file)
-        result = runner.invoke(cli, ["session", "create"])
-        assert result.exit_code == 1, result.output
-        after = _session_rows(db_file)
-        assert before == after
+    assert placement["director_agent_id"] is None
+    assert placement["coding_agent"] == "unknown"
+    assert placement["tmux_session"] == _FAKE_DIRECTOR_CTX.session
+    assert placement["tmux_window_id"] == _FAKE_DIRECTOR_CTX.window_id
+    assert placement["tmux_pane_id"] == _FAKE_DIRECTOR_CTX.pane_id
+    assert "created_at" in placement
 
 
-class TestSessionListHidesSoftDeleted:
-    def test_deleted_session_is_hidden_from_text_list(self, db_file, mock_tmux_ok):
-        runner = CliRunner()
-        r1 = runner.invoke(cli, ["session", "create", "--label", "keep", "--json"])
-        r2 = runner.invoke(cli, ["session", "create", "--label", "drop", "--json"])
-        assert r1.exit_code == 0
-        assert r2.exit_code == 0
-        keep_sid = json.loads(r1.output)["session_id"]
-        drop_sid = json.loads(r2.output)["session_id"]
-
-        del_result = runner.invoke(cli, ["session", "delete", drop_sid])
-        assert del_result.exit_code == 0, del_result.output
-
-        list_result = runner.invoke(cli, ["session", "list"])
-        assert list_result.exit_code == 0
-        assert keep_sid in list_result.output
-        assert drop_sid not in list_result.output
-
-    def test_deleted_session_is_hidden_from_json_list(self, db_file, mock_tmux_ok):
-        runner = CliRunner()
-        r1 = runner.invoke(cli, ["session", "create", "--json"])
-        r2 = runner.invoke(cli, ["session", "create", "--json"])
-        keep_sid = json.loads(r1.output)["session_id"]
-        drop_sid = json.loads(r2.output)["session_id"]
-        runner.invoke(cli, ["session", "delete", drop_sid])
-
-        list_result = runner.invoke(cli, ["session", "list", "--json"])
-        assert list_result.exit_code == 0
-        data = json.loads(list_result.output)
-        ids = {s["session_id"] for s in data}
-        assert keep_sid in ids
-        assert drop_sid not in ids
-
-    def test_list_has_no_all_flag(self, db_file):
-        """Design 0000026 explicitly removes/omits an ``--all`` flag."""
-        runner = CliRunner()
-        result = runner.invoke(cli, ["session", "list", "--all"])
-        assert result.exit_code == 2, result.output
+def test_session_create_json_output__label_propagates_to_json(db_file, mock_tmux_ok):
+    runner = CliRunner()
+    result = runner.invoke(
+        cli, ["session", "create", "--label", "json-label", "--json"]
+    )
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert data["label"] == "json-label"
 
 
-class TestSessionDeleteUnknownAndIdempotent:
-    def test_unknown_session_id_exits_1_with_not_found(self, db_file, mock_tmux_ok):
-        runner = CliRunner()
-        fake = str(uuid.uuid4())
-        result = runner.invoke(cli, ["session", "delete", fake])
-        assert result.exit_code == 1, result.output
-        combined = ((result.output or "") + (result.stderr or "")).lower()
-        assert "not found" in combined
-        assert fake in (result.output or "") + (result.stderr or "")
+def test_session_create_json_output__administrator_and_director_are_distinct_uuids(
+    db_file, mock_tmux_ok
+):
+    runner = CliRunner()
+    result = runner.invoke(cli, ["session", "create", "--json"])
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert data["administrator_agent_id"] != data["director"]["agent_id"]
 
-    def test_second_delete_is_idempotent_and_reports_zero(self, db_file, mock_tmux_ok):
-        runner = CliRunner()
-        r = runner.invoke(cli, ["session", "create", "--json"])
-        assert r.exit_code == 0
-        sid = json.loads(r.output)["session_id"]
 
-        first = runner.invoke(cli, ["session", "delete", sid])
-        second = runner.invoke(cli, ["session", "delete", sid])
+def test_session_create_outside_tmux__fails_with_specific_error_and_exit_1(
+    db_file, mock_tmux_unavailable
+):
+    runner = CliRunner()
+    result = runner.invoke(cli, ["session", "create"])
+    assert result.exit_code == 1, result.output
+    combined = (result.output or "") + (result.stderr or "")
+    assert "cafleet session create must be run inside a tmux session" in combined
 
-        assert first.exit_code == 0, first.output
-        assert second.exit_code == 0, second.output
-        assert "0 agents" in second.output
+
+def test_session_create_outside_tmux__no_session_row_is_written_when_tmux_is_missing(
+    db_file, mock_tmux_unavailable
+):
+    runner = CliRunner()
+    before = _session_rows(db_file)
+    result = runner.invoke(cli, ["session", "create"])
+    assert result.exit_code == 1, result.output
+    after = _session_rows(db_file)
+    assert before == after
+
+
+def test_session_list_hides_soft_deleted__deleted_session_is_hidden_from_text_list(
+    db_file, mock_tmux_ok
+):
+    runner = CliRunner()
+    r1 = runner.invoke(cli, ["session", "create", "--label", "keep", "--json"])
+    r2 = runner.invoke(cli, ["session", "create", "--label", "drop", "--json"])
+    assert r1.exit_code == 0
+    assert r2.exit_code == 0
+    keep_sid = json.loads(r1.output)["session_id"]
+    drop_sid = json.loads(r2.output)["session_id"]
+
+    del_result = runner.invoke(cli, ["session", "delete", drop_sid])
+    assert del_result.exit_code == 0, del_result.output
+
+    list_result = runner.invoke(cli, ["session", "list"])
+    assert list_result.exit_code == 0
+    assert keep_sid in list_result.output
+    assert drop_sid not in list_result.output
+
+
+def test_session_list_hides_soft_deleted__deleted_session_is_hidden_from_json_list(
+    db_file, mock_tmux_ok
+):
+    runner = CliRunner()
+    r1 = runner.invoke(cli, ["session", "create", "--json"])
+    r2 = runner.invoke(cli, ["session", "create", "--json"])
+    keep_sid = json.loads(r1.output)["session_id"]
+    drop_sid = json.loads(r2.output)["session_id"]
+    runner.invoke(cli, ["session", "delete", drop_sid])
+
+    list_result = runner.invoke(cli, ["session", "list", "--json"])
+    assert list_result.exit_code == 0
+    data = json.loads(list_result.output)
+    ids = {s["session_id"] for s in data}
+    assert keep_sid in ids
+    assert drop_sid not in ids
+
+
+def test_session_list_hides_soft_deleted__list_has_no_all_flag(db_file):
+    """Design 0000026 explicitly removes/omits an ``--all`` flag."""
+    runner = CliRunner()
+    result = runner.invoke(cli, ["session", "list", "--all"])
+    assert result.exit_code == 2, result.output
+
+
+def test_session_delete_unknown_and_idempotent__unknown_session_id_exits_1_with_not_found(
+    db_file, mock_tmux_ok
+):
+    runner = CliRunner()
+    fake = str(uuid.uuid4())
+    result = runner.invoke(cli, ["session", "delete", fake])
+    assert result.exit_code == 1, result.output
+    combined = ((result.output or "") + (result.stderr or "")).lower()
+    assert "not found" in combined
+    assert fake in (result.output or "") + (result.stderr or "")
+
+
+def test_session_delete_unknown_and_idempotent__second_delete_is_idempotent_and_reports_zero(
+    db_file, mock_tmux_ok
+):
+    runner = CliRunner()
+    r = runner.invoke(cli, ["session", "create", "--json"])
+    assert r.exit_code == 0
+    sid = json.loads(r.output)["session_id"]
+
+    first = runner.invoke(cli, ["session", "delete", sid])
+    second = runner.invoke(cli, ["session", "delete", sid])
+
+    assert first.exit_code == 0, first.output
+    assert second.exit_code == 0, second.output
+    assert "0 agents" in second.output

--- a/cafleet/tests/test_cli_session_bootstrap.py
+++ b/cafleet/tests/test_cli_session_bootstrap.py
@@ -189,7 +189,9 @@ def test_session_create_json_output__director_sub_dict(db_file, mock_tmux_ok):
     uuid.UUID(director["agent_id"])
 
 
-def test_session_create_json_output__placement_sub_dict_matches_spec(db_file, mock_tmux_ok):
+def test_session_create_json_output__placement_sub_dict_matches_spec(
+    db_file, mock_tmux_ok
+):
     runner = CliRunner()
     result = runner.invoke(cli, ["session", "create", "--json"])
     assert result.exit_code == 0

--- a/cafleet/tests/test_cli_session_flag.py
+++ b/cafleet/tests/test_cli_session_flag.py
@@ -44,7 +44,9 @@ def db_runner(tmp_path, monkeypatch):
     return runner
 
 
-def test_missing_session_id_fails_client_subcommands__register_without_session_id_shows_new_error_message(db_runner):
+def test_missing_session_id_fails_client_subcommands__register_without_session_id_shows_new_error_message(
+    db_runner,
+):
     result = db_runner.invoke(
         cli,
         ["agent", "register", "--name", "A", "--description", "a"],
@@ -57,7 +59,9 @@ def test_missing_session_id_fails_client_subcommands__register_without_session_i
     assert "environment variable" not in out.lower()
 
 
-def test_session_id_flag_flows_into_broker__register_passes_session_id_to_broker(db_runner, monkeypatch):
+def test_session_id_flag_flows_into_broker__register_passes_session_id_to_broker(
+    db_runner, monkeypatch
+):
     captured: dict = {}
 
     def fake_register_agent(*args, **kwargs):
@@ -91,7 +95,9 @@ def test_session_id_flag_flows_into_broker__register_passes_session_id_to_broker
     assert sid in all_values
 
 
-def test_session_id_flag_flows_into_broker__send_passes_session_id_to_broker(db_runner, monkeypatch):
+def test_session_id_flag_flows_into_broker__send_passes_session_id_to_broker(
+    db_runner, monkeypatch
+):
     captured: dict = {}
 
     def fake_send_message(*args, **kwargs):
@@ -142,7 +148,9 @@ def test_session_id_flag_flows_into_broker__send_passes_session_id_to_broker(db_
     assert sid in all_values
 
 
-def test_session_id_flag_flows_into_broker__session_id_not_read_from_environment(db_runner, monkeypatch):
+def test_session_id_flag_flows_into_broker__session_id_not_read_from_environment(
+    db_runner, monkeypatch
+):
     """The env var CAFLEET_SESSION_ID was removed; only the CLI flag works."""
     monkeypatch.setenv("CAFLEET_SESSION_ID", str(uuid.uuid4()))
     result = db_runner.invoke(
@@ -152,7 +160,9 @@ def test_session_id_flag_flows_into_broker__session_id_not_read_from_environment
     assert result.exit_code == 1, result.output
 
 
-def test_subcommands_that_do_not_require_session_id__db_init_without_session_id(tmp_path, monkeypatch):
+def test_subcommands_that_do_not_require_session_id__db_init_without_session_id(
+    tmp_path, monkeypatch
+):
     db_file = tmp_path / "registry.db"
     monkeypatch.setattr(
         config.settings,
@@ -164,13 +174,17 @@ def test_subcommands_that_do_not_require_session_id__db_init_without_session_id(
     assert result.exit_code == 0, result.output
 
 
-def test_subcommands_that_do_not_require_session_id__session_create_without_session_id(db_runner):
+def test_subcommands_that_do_not_require_session_id__session_create_without_session_id(
+    db_runner,
+):
     """session create mints a session, so it cannot itself require one."""
     result = db_runner.invoke(cli, ["session", "create", "--label", "smoke"])
     assert result.exit_code == 0, result.output
 
 
-def test_subcommands_that_do_not_require_session_id__session_list_without_session_id(db_runner):
+def test_subcommands_that_do_not_require_session_id__session_list_without_session_id(
+    db_runner,
+):
     result = db_runner.invoke(cli, ["session", "list"])
     assert result.exit_code == 0, result.output
 
@@ -193,7 +207,9 @@ def test_session_id_silently_accepted_where_not_required__db_init_accepts_sessio
     assert "unexpected" not in combined
 
 
-def test_session_id_silently_accepted_where_not_required__session_create_accepts_session_id_silently(db_runner):
+def test_session_id_silently_accepted_where_not_required__session_create_accepts_session_id_silently(
+    db_runner,
+):
     sid = str(uuid.uuid4())
     result = db_runner.invoke(
         cli,
@@ -224,7 +240,9 @@ def _fetch_agent_status(db_file, agent_id: str) -> tuple[str, str | None]:
     return row[0], row[1]
 
 
-def test_deregister_administrator_cli_guard__cli_deregister_admin_exits_nonzero(tmp_path, monkeypatch):
+def test_deregister_administrator_cli_guard__cli_deregister_admin_exits_nonzero(
+    tmp_path, monkeypatch
+):
     db_file = tmp_path / "registry.db"
     monkeypatch.setattr(
         config.settings,
@@ -299,7 +317,9 @@ def test_deregister_administrator_cli_guard__cli_deregister_unknown_agent_exits_
     assert "is not a member of session" in (result.output or "")
 
 
-def test_deregister_administrator_cli_guard__cli_deregister_admin_leaves_row_active(tmp_path, monkeypatch):
+def test_deregister_administrator_cli_guard__cli_deregister_admin_leaves_row_active(
+    tmp_path, monkeypatch
+):
     db_file = tmp_path / "registry.db"
     monkeypatch.setattr(
         config.settings,

--- a/cafleet/tests/test_cli_session_flag.py
+++ b/cafleet/tests/test_cli_session_flag.py
@@ -44,159 +44,162 @@ def db_runner(tmp_path, monkeypatch):
     return runner
 
 
-class TestMissingSessionIdFailsClientSubcommands:
-    def test_register_without_session_id_shows_new_error_message(self, db_runner):
-        result = db_runner.invoke(
-            cli,
-            ["agent", "register", "--name", "A", "--description", "a"],
-        )
-        out = result.output or ""
-        assert "--session-id" in out
-        assert "is required" in out
-        assert "cafleet session create" in out
-        assert "CAFLEET_SESSION_ID" not in out
-        assert "environment variable" not in out.lower()
+def test_missing_session_id_fails_client_subcommands__register_without_session_id_shows_new_error_message(db_runner):
+    result = db_runner.invoke(
+        cli,
+        ["agent", "register", "--name", "A", "--description", "a"],
+    )
+    out = result.output or ""
+    assert "--session-id" in out
+    assert "is required" in out
+    assert "cafleet session create" in out
+    assert "CAFLEET_SESSION_ID" not in out
+    assert "environment variable" not in out.lower()
 
 
-class TestSessionIdFlagFlowsIntoBroker:
-    def test_register_passes_session_id_to_broker(self, db_runner, monkeypatch):
-        captured: dict = {}
+def test_session_id_flag_flows_into_broker__register_passes_session_id_to_broker(db_runner, monkeypatch):
+    captured: dict = {}
 
-        def fake_register_agent(*args, **kwargs):
-            captured["args"] = args
-            captured["kwargs"] = kwargs
-            return {
-                "agent_id": "cccccccc-cccc-cccc-cccc-cccccccccccc",
-                "name": "A",
-                "registered_at": "2026-01-01T00:00:00+00:00",
+    def fake_register_agent(*args, **kwargs):
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+        return {
+            "agent_id": "cccccccc-cccc-cccc-cccc-cccccccccccc",
+            "name": "A",
+            "registered_at": "2026-01-01T00:00:00+00:00",
+        }
+
+    monkeypatch.setattr(broker, "register_agent", fake_register_agent)
+
+    sid = str(uuid.uuid4())
+    result = db_runner.invoke(
+        cli,
+        [
+            "--session-id",
+            sid,
+            "agent",
+            "register",
+            "--name",
+            "A",
+            "--description",
+            "a",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    all_values = list(captured["args"]) + list(captured["kwargs"].values())
+    assert sid in all_values
+
+
+def test_session_id_flag_flows_into_broker__send_passes_session_id_to_broker(db_runner, monkeypatch):
+    captured: dict = {}
+
+    def fake_send_message(*args, **kwargs):
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+        sender = args[1] if len(args) > 1 else kwargs.get("agent_id")
+        recipient = args[2] if len(args) > 2 else kwargs.get("to")
+        return {
+            "task": {
+                "id": "tttttttt-tttt-tttt-tttt-tttttttttttt",
+                "contextId": recipient,
+                "status": {
+                    "state": "input_required",
+                    "timestamp": "2026-01-01T00:00:00+00:00",
+                },
+                "artifacts": [],
+                "metadata": {
+                    "fromAgentId": sender,
+                    "toAgentId": recipient,
+                    "type": "unicast",
+                },
             }
+        }
 
-        monkeypatch.setattr(broker, "register_agent", fake_register_agent)
+    monkeypatch.setattr(broker, "send_message", fake_send_message)
 
-        sid = str(uuid.uuid4())
-        result = db_runner.invoke(
-            cli,
-            [
-                "--session-id",
-                sid,
-                "agent",
-                "register",
-                "--name",
-                "A",
-                "--description",
-                "a",
-            ],
-        )
+    sid = str(uuid.uuid4())
+    aid = str(uuid.uuid4())
+    bid = str(uuid.uuid4())
+    result = db_runner.invoke(
+        cli,
+        [
+            "--session-id",
+            sid,
+            "message",
+            "send",
+            "--agent-id",
+            aid,
+            "--to",
+            bid,
+            "--text",
+            "hi",
+        ],
+    )
 
-        assert result.exit_code == 0, result.output
-        all_values = list(captured["args"]) + list(captured["kwargs"].values())
-        assert sid in all_values
-
-    def test_send_passes_session_id_to_broker(self, db_runner, monkeypatch):
-        captured: dict = {}
-
-        def fake_send_message(*args, **kwargs):
-            captured["args"] = args
-            captured["kwargs"] = kwargs
-            sender = args[1] if len(args) > 1 else kwargs.get("agent_id")
-            recipient = args[2] if len(args) > 2 else kwargs.get("to")
-            return {
-                "task": {
-                    "id": "tttttttt-tttt-tttt-tttt-tttttttttttt",
-                    "contextId": recipient,
-                    "status": {
-                        "state": "input_required",
-                        "timestamp": "2026-01-01T00:00:00+00:00",
-                    },
-                    "artifacts": [],
-                    "metadata": {
-                        "fromAgentId": sender,
-                        "toAgentId": recipient,
-                        "type": "unicast",
-                    },
-                }
-            }
-
-        monkeypatch.setattr(broker, "send_message", fake_send_message)
-
-        sid = str(uuid.uuid4())
-        aid = str(uuid.uuid4())
-        bid = str(uuid.uuid4())
-        result = db_runner.invoke(
-            cli,
-            [
-                "--session-id",
-                sid,
-                "message",
-                "send",
-                "--agent-id",
-                aid,
-                "--to",
-                bid,
-                "--text",
-                "hi",
-            ],
-        )
-
-        assert result.exit_code == 0, result.output
-        all_values = list(captured["args"]) + list(captured["kwargs"].values())
-        assert sid in all_values
-
-    def test_session_id_not_read_from_environment(self, db_runner, monkeypatch):
-        """The env var CAFLEET_SESSION_ID was removed; only the CLI flag works."""
-        monkeypatch.setenv("CAFLEET_SESSION_ID", str(uuid.uuid4()))
-        result = db_runner.invoke(
-            cli,
-            ["agent", "register", "--name", "A", "--description", "a"],
-        )
-        assert result.exit_code == 1, result.output
+    assert result.exit_code == 0, result.output
+    all_values = list(captured["args"]) + list(captured["kwargs"].values())
+    assert sid in all_values
 
 
-class TestSubcommandsThatDoNotRequireSessionId:
-    def test_db_init_without_session_id(self, tmp_path, monkeypatch):
-        db_file = tmp_path / "registry.db"
-        monkeypatch.setattr(
-            config.settings,
-            "database_url",
-            f"sqlite+aiosqlite:///{db_file}",
-        )
-        runner = CliRunner()
-        result = runner.invoke(cli, ["db", "init"])
-        assert result.exit_code == 0, result.output
-
-    def test_session_create_without_session_id(self, db_runner):
-        """session create mints a session, so it cannot itself require one."""
-        result = db_runner.invoke(cli, ["session", "create", "--label", "smoke"])
-        assert result.exit_code == 0, result.output
-
-    def test_session_list_without_session_id(self, db_runner):
-        result = db_runner.invoke(cli, ["session", "list"])
-        assert result.exit_code == 0, result.output
+def test_session_id_flag_flows_into_broker__session_id_not_read_from_environment(db_runner, monkeypatch):
+    """The env var CAFLEET_SESSION_ID was removed; only the CLI flag works."""
+    monkeypatch.setenv("CAFLEET_SESSION_ID", str(uuid.uuid4()))
+    result = db_runner.invoke(
+        cli,
+        ["agent", "register", "--name", "A", "--description", "a"],
+    )
+    assert result.exit_code == 1, result.output
 
 
-class TestSessionIdSilentlyAcceptedWhereNotRequired:
-    def test_db_init_accepts_session_id_silently(self, tmp_path, monkeypatch):
-        db_file = tmp_path / "registry.db"
-        monkeypatch.setattr(
-            config.settings,
-            "database_url",
-            f"sqlite+aiosqlite:///{db_file}",
-        )
-        runner = CliRunner()
-        sid = str(uuid.uuid4())
-        result = runner.invoke(cli, ["--session-id", sid, "db", "init"])
-        assert result.exit_code == 0, result.output
-        combined = (result.output or "").lower()
-        assert "unused" not in combined
-        assert "unexpected" not in combined
+def test_subcommands_that_do_not_require_session_id__db_init_without_session_id(tmp_path, monkeypatch):
+    db_file = tmp_path / "registry.db"
+    monkeypatch.setattr(
+        config.settings,
+        "database_url",
+        f"sqlite+aiosqlite:///{db_file}",
+    )
+    runner = CliRunner()
+    result = runner.invoke(cli, ["db", "init"])
+    assert result.exit_code == 0, result.output
 
-    def test_session_create_accepts_session_id_silently(self, db_runner):
-        sid = str(uuid.uuid4())
-        result = db_runner.invoke(
-            cli,
-            ["--session-id", sid, "session", "create", "--label", "x"],
-        )
-        assert result.exit_code == 0, result.output
+
+def test_subcommands_that_do_not_require_session_id__session_create_without_session_id(db_runner):
+    """session create mints a session, so it cannot itself require one."""
+    result = db_runner.invoke(cli, ["session", "create", "--label", "smoke"])
+    assert result.exit_code == 0, result.output
+
+
+def test_subcommands_that_do_not_require_session_id__session_list_without_session_id(db_runner):
+    result = db_runner.invoke(cli, ["session", "list"])
+    assert result.exit_code == 0, result.output
+
+
+def test_session_id_silently_accepted_where_not_required__db_init_accepts_session_id_silently(
+    tmp_path, monkeypatch
+):
+    db_file = tmp_path / "registry.db"
+    monkeypatch.setattr(
+        config.settings,
+        "database_url",
+        f"sqlite+aiosqlite:///{db_file}",
+    )
+    runner = CliRunner()
+    sid = str(uuid.uuid4())
+    result = runner.invoke(cli, ["--session-id", sid, "db", "init"])
+    assert result.exit_code == 0, result.output
+    combined = (result.output or "").lower()
+    assert "unused" not in combined
+    assert "unexpected" not in combined
+
+
+def test_session_id_silently_accepted_where_not_required__session_create_accepts_session_id_silently(db_runner):
+    sid = str(uuid.uuid4())
+    result = db_runner.invoke(
+        cli,
+        ["--session-id", sid, "session", "create", "--label", "x"],
+    )
+    assert result.exit_code == 0, result.output
 
 
 def _create_session_via_cli(runner: CliRunner) -> tuple[str, str]:
@@ -221,92 +224,98 @@ def _fetch_agent_status(db_file, agent_id: str) -> tuple[str, str | None]:
     return row[0], row[1]
 
 
-class TestDeregisterAdministratorCliGuard:
-    def test_cli_deregister_admin_exits_nonzero(self, tmp_path, monkeypatch):
-        db_file = tmp_path / "registry.db"
-        monkeypatch.setattr(
-            config.settings,
-            "database_url",
-            f"sqlite+aiosqlite:///{db_file}",
-        )
-        runner = CliRunner()
-        init = runner.invoke(cli, ["db", "init"])
-        assert init.exit_code == 0
+def test_deregister_administrator_cli_guard__cli_deregister_admin_exits_nonzero(tmp_path, monkeypatch):
+    db_file = tmp_path / "registry.db"
+    monkeypatch.setattr(
+        config.settings,
+        "database_url",
+        f"sqlite+aiosqlite:///{db_file}",
+    )
+    runner = CliRunner()
+    init = runner.invoke(cli, ["db", "init"])
+    assert init.exit_code == 0
 
-        session_id, admin_id = _create_session_via_cli(runner)
+    session_id, admin_id = _create_session_via_cli(runner)
 
-        result = runner.invoke(
-            cli,
-            ["--session-id", session_id, "agent", "deregister", "--agent-id", admin_id],
-        )
-        assert result.exit_code == 1, result.output
+    result = runner.invoke(
+        cli,
+        ["--session-id", session_id, "agent", "deregister", "--agent-id", admin_id],
+    )
+    assert result.exit_code == 1, result.output
 
-    def test_cli_deregister_admin_message_is_user_friendly(self, tmp_path, monkeypatch):
-        db_file = tmp_path / "registry.db"
-        monkeypatch.setattr(
-            config.settings,
-            "database_url",
-            f"sqlite+aiosqlite:///{db_file}",
-        )
-        runner = CliRunner()
-        init = runner.invoke(cli, ["db", "init"])
-        assert init.exit_code == 0
 
-        session_id, admin_id = _create_session_via_cli(runner)
+def test_deregister_administrator_cli_guard__cli_deregister_admin_message_is_user_friendly(
+    tmp_path, monkeypatch
+):
+    db_file = tmp_path / "registry.db"
+    monkeypatch.setattr(
+        config.settings,
+        "database_url",
+        f"sqlite+aiosqlite:///{db_file}",
+    )
+    runner = CliRunner()
+    init = runner.invoke(cli, ["db", "init"])
+    assert init.exit_code == 0
 
-        result = runner.invoke(
-            cli,
-            ["--session-id", session_id, "agent", "deregister", "--agent-id", admin_id],
-        )
-        out = result.output or ""
-        assert "Administrator cannot be deregistered" in out
-        assert "Traceback" not in out
+    session_id, admin_id = _create_session_via_cli(runner)
 
-    def test_cli_deregister_unknown_agent_exits_nonzero(self, tmp_path, monkeypatch):
-        db_file = tmp_path / "registry.db"
-        monkeypatch.setattr(
-            config.settings,
-            "database_url",
-            f"sqlite+aiosqlite:///{db_file}",
-        )
-        runner = CliRunner()
-        init = runner.invoke(cli, ["db", "init"])
-        assert init.exit_code == 0
+    result = runner.invoke(
+        cli,
+        ["--session-id", session_id, "agent", "deregister", "--agent-id", admin_id],
+    )
+    out = result.output or ""
+    assert "Administrator cannot be deregistered" in out
+    assert "Traceback" not in out
 
-        session_id, _admin_id = _create_session_via_cli(runner)
-        bogus_agent_id = str(uuid.uuid4())
 
-        result = runner.invoke(
-            cli,
-            [
-                "--session-id",
-                session_id,
-                "agent",
-                "deregister",
-                "--agent-id",
-                bogus_agent_id,
-            ],
-        )
-        assert result.exit_code == 1, result.output
-        assert "is not a member of session" in (result.output or "")
+def test_deregister_administrator_cli_guard__cli_deregister_unknown_agent_exits_nonzero(
+    tmp_path, monkeypatch
+):
+    db_file = tmp_path / "registry.db"
+    monkeypatch.setattr(
+        config.settings,
+        "database_url",
+        f"sqlite+aiosqlite:///{db_file}",
+    )
+    runner = CliRunner()
+    init = runner.invoke(cli, ["db", "init"])
+    assert init.exit_code == 0
 
-    def test_cli_deregister_admin_leaves_row_active(self, tmp_path, monkeypatch):
-        db_file = tmp_path / "registry.db"
-        monkeypatch.setattr(
-            config.settings,
-            "database_url",
-            f"sqlite+aiosqlite:///{db_file}",
-        )
-        runner = CliRunner()
-        init = runner.invoke(cli, ["db", "init"])
-        assert init.exit_code == 0
+    session_id, _admin_id = _create_session_via_cli(runner)
+    bogus_agent_id = str(uuid.uuid4())
 
-        session_id, admin_id = _create_session_via_cli(runner)
+    result = runner.invoke(
+        cli,
+        [
+            "--session-id",
+            session_id,
+            "agent",
+            "deregister",
+            "--agent-id",
+            bogus_agent_id,
+        ],
+    )
+    assert result.exit_code == 1, result.output
+    assert "is not a member of session" in (result.output or "")
 
-        runner.invoke(
-            cli,
-            ["--session-id", session_id, "agent", "deregister", "--agent-id", admin_id],
-        )
-        status, deregistered_at = _fetch_agent_status(db_file, admin_id)
-        assert status == "active"
-        assert deregistered_at is None
+
+def test_deregister_administrator_cli_guard__cli_deregister_admin_leaves_row_active(tmp_path, monkeypatch):
+    db_file = tmp_path / "registry.db"
+    monkeypatch.setattr(
+        config.settings,
+        "database_url",
+        f"sqlite+aiosqlite:///{db_file}",
+    )
+    runner = CliRunner()
+    init = runner.invoke(cli, ["db", "init"])
+    assert init.exit_code == 0
+
+    session_id, admin_id = _create_session_via_cli(runner)
+
+    runner.invoke(
+        cli,
+        ["--session-id", session_id, "agent", "deregister", "--agent-id", admin_id],
+    )
+    status, deregistered_at = _fetch_agent_status(db_file, admin_id)
+    assert status == "active"
+    assert deregistered_at is None

--- a/cafleet/tests/test_output.py
+++ b/cafleet/tests/test_output.py
@@ -39,79 +39,86 @@ def _list_entry(*, agent_id: str, name: str, coding_agent: str, pane_id: str) ->
     }
 
 
-class TestFormatMember:
-    def test_includes_backend_line(self):
-        assert "backend:" in format_member(_member())
-
-    def test_backend_shows_claude(self):
-        result = format_member(_member())
-        assert "claude" in result
+def test_format_member__includes_backend_line():
+    assert "backend:" in format_member(_member())
 
 
-class TestFormatMemberList:
-    def test_table_header_includes_backend(self):
-        result = format_member_list(
-            [
-                _list_entry(
-                    agent_id="agent-001",
-                    name="Claude-B",
-                    coding_agent="claude",
-                    pane_id="%7",
-                )
-            ]
-        )
-        assert "backend" in result.lower()
-
-    def test_row_shows_claude_backend(self):
-        result = format_member_list(
-            [
-                _list_entry(
-                    agent_id="agent-001",
-                    name="Claude-B",
-                    coding_agent="claude",
-                    pane_id="%7",
-                )
-            ]
-        )
-        data_lines = [line for line in result.split("\n") if "Claude-B" in line]
-        assert len(data_lines) == 1
-        assert "claude" in data_lines[0]
-
-    def test_empty_list_unchanged(self):
-        assert "0 members" in format_member_list([])
+def test_format_member__backend_shows_claude():
+    result = format_member(_member())
+    assert "claude" in result
 
 
-class TestTruncateText:
-    def test_none_passes_through(self):
-        assert truncate_text(None, full=False) is None
+def test_format_member_list__table_header_includes_backend():
+    result = format_member_list(
+        [
+            _list_entry(
+                agent_id="agent-001",
+                name="Claude-B",
+                coding_agent="claude",
+                pane_id="%7",
+            )
+        ]
+    )
+    assert "backend" in result.lower()
 
-    def test_empty_string_passes_through(self):
-        assert truncate_text("", full=False) == ""
 
-    def test_exactly_ten_codepoints_unchanged(self):
-        value = "abcdefghij"
-        assert len(value) == 10
-        assert truncate_text(value, full=False) == "abcdefghij"
+def test_format_member_list__row_shows_claude_backend():
+    result = format_member_list(
+        [
+            _list_entry(
+                agent_id="agent-001",
+                name="Claude-B",
+                coding_agent="claude",
+                pane_id="%7",
+            )
+        ]
+    )
+    data_lines = [line for line in result.split("\n") if "Claude-B" in line]
+    assert len(data_lines) == 1
+    assert "claude" in data_lines[0]
 
-    def test_eleven_codepoint_ascii_is_truncated(self):
-        value = "abcdefghijk"
-        assert len(value) == 11
-        assert truncate_text(value, full=False) == "abcdefghij..."
 
-    def test_eleven_codepoint_multibyte_is_truncated_by_codepoint(self):
-        value = "あいうえおかきくけこさ"
-        assert len(value) == 11
-        assert truncate_text(value, full=False) == "あいうえおかきくけこ..."
+def test_format_member_list__empty_list_unchanged():
+    assert "0 members" in format_member_list([])
 
-    def test_full_true_passes_long_string_through(self):
-        value = "abcdefghijklmnopqrstuvwxyz"
-        assert truncate_text(value, full=True) == value
 
-    def test_full_true_passes_none_through(self):
-        assert truncate_text(None, full=True) is None
+def test_truncate_text__none_passes_through():
+    assert truncate_text(None, full=False) is None
 
-    def test_custom_limit_is_respected(self):
-        assert truncate_text("abcdef", full=False, limit=3) == "abc..."
+
+def test_truncate_text__empty_string_passes_through():
+    assert truncate_text("", full=False) == ""
+
+
+def test_truncate_text__exactly_ten_codepoints_unchanged():
+    value = "abcdefghij"
+    assert len(value) == 10
+    assert truncate_text(value, full=False) == "abcdefghij"
+
+
+def test_truncate_text__eleven_codepoint_ascii_is_truncated():
+    value = "abcdefghijk"
+    assert len(value) == 11
+    assert truncate_text(value, full=False) == "abcdefghij..."
+
+
+def test_truncate_text__eleven_codepoint_multibyte_is_truncated_by_codepoint():
+    value = "あいうえおかきくけこさ"
+    assert len(value) == 11
+    assert truncate_text(value, full=False) == "あいうえおかきくけこ..."
+
+
+def test_truncate_text__full_true_passes_long_string_through():
+    value = "abcdefghijklmnopqrstuvwxyz"
+    assert truncate_text(value, full=True) == value
+
+
+def test_truncate_text__full_true_passes_none_through():
+    assert truncate_text(None, full=True) is None
+
+
+def test_truncate_text__custom_limit_is_respected():
+    assert truncate_text("abcdef", full=False, limit=3) == "abc..."
 
 
 def _task(text: str | None = "the body of the message") -> dict:
@@ -128,110 +135,122 @@ def _task(text: str | None = "the body of the message") -> dict:
     }
 
 
-class TestTruncateTaskText:
-    def test_single_task_shape_truncates_text(self):
-        task = _task("abcdefghijklmnop")
-        result = truncate_task_text(task, full=False)
-        assert result is task
-        assert task["artifacts"][0]["parts"][0]["text"] == "abcdefghij..."
+def test_truncate_task_text__single_task_shape_truncates_text():
+    task = _task("abcdefghijklmnop")
+    result = truncate_task_text(task, full=False)
+    assert result is task
+    assert task["artifacts"][0]["parts"][0]["text"] == "abcdefghij..."
 
-    def test_envelope_shape_truncates_text(self):
-        envelope = {"task": _task("abcdefghijklmnop")}
-        result = truncate_task_text(envelope, full=False)
-        assert result is envelope
-        assert envelope["task"]["artifacts"][0]["parts"][0]["text"] == "abcdefghij..."
 
-    def test_list_of_tasks_truncates_each(self):
-        tasks = [_task("abcdefghijklmnop"), _task("0123456789ABCDEF")]
-        result = truncate_task_text(tasks, full=False)
-        assert result is tasks
-        assert tasks[0]["artifacts"][0]["parts"][0]["text"] == "abcdefghij..."
-        assert tasks[1]["artifacts"][0]["parts"][0]["text"] == "0123456789..."
+def test_truncate_task_text__envelope_shape_truncates_text():
+    envelope = {"task": _task("abcdefghijklmnop")}
+    result = truncate_task_text(envelope, full=False)
+    assert result is envelope
+    assert envelope["task"]["artifacts"][0]["parts"][0]["text"] == "abcdefghij..."
 
-    def test_list_of_envelopes_truncates_each(self):
-        items = [{"task": _task("abcdefghijklmnop")}, {"task": _task("short")}]
-        truncate_task_text(items, full=False)
-        assert items[0]["task"]["artifacts"][0]["parts"][0]["text"] == "abcdefghij..."
-        assert items[1]["task"]["artifacts"][0]["parts"][0]["text"] == "short"
 
-    def test_full_true_does_not_mutate(self):
-        task = _task("abcdefghijklmnop")
-        truncate_task_text(task, full=True)
-        assert task["artifacts"][0]["parts"][0]["text"] == "abcdefghijklmnop"
+def test_truncate_task_text__list_of_tasks_truncates_each():
+    tasks = [_task("abcdefghijklmnop"), _task("0123456789ABCDEF")]
+    result = truncate_task_text(tasks, full=False)
+    assert result is tasks
+    assert tasks[0]["artifacts"][0]["parts"][0]["text"] == "abcdefghij..."
+    assert tasks[1]["artifacts"][0]["parts"][0]["text"] == "0123456789..."
 
-    def test_short_text_is_not_truncated(self):
-        task = _task("hello")
-        truncate_task_text(task, full=False)
-        assert task["artifacts"][0]["parts"][0]["text"] == "hello"
 
-    def test_missing_artifacts_key_is_noop(self):
-        task = {
-            "id": "task-001",
-            "status": {"state": "input_required"},
-            "metadata": {"fromAgentId": "a", "type": "unicast"},
-        }
-        result = truncate_task_text(task, full=False)
-        assert result is task
-        assert "artifacts" not in task
+def test_truncate_task_text__list_of_envelopes_truncates_each():
+    items = [{"task": _task("abcdefghijklmnop")}, {"task": _task("short")}]
+    truncate_task_text(items, full=False)
+    assert items[0]["task"]["artifacts"][0]["parts"][0]["text"] == "abcdefghij..."
+    assert items[1]["task"]["artifacts"][0]["parts"][0]["text"] == "short"
 
-    def test_missing_parts_key_is_noop(self):
-        task = {"artifacts": [{}]}
-        truncate_task_text(task, full=False)
-        assert task == {"artifacts": [{}]}
 
-    def test_missing_text_key_in_part_is_noop(self):
-        task = {"artifacts": [{"parts": [{"data": "binary"}]}]}
-        truncate_task_text(task, full=False)
-        assert task == {"artifacts": [{"parts": [{"data": "binary"}]}]}
-        assert "text" not in task["artifacts"][0]["parts"][0]
+def test_truncate_task_text__full_true_does_not_mutate():
+    task = _task("abcdefghijklmnop")
+    truncate_task_text(task, full=True)
+    assert task["artifacts"][0]["parts"][0]["text"] == "abcdefghijklmnop"
 
-    def test_part_with_explicit_none_text_is_left_untouched(self):
-        task = {"artifacts": [{"parts": [{"text": None}]}]}
-        truncate_task_text(task, full=False)
-        assert task["artifacts"][0]["parts"][0]["text"] is None
 
-    def test_mixed_parts_only_truncates_text_bearing(self):
-        task = {
-            "artifacts": [
-                {
-                    "parts": [
-                        {"text": "abcdefghijklmnop"},
-                        {"data": "binary"},
-                        {"text": "short"},
-                    ]
-                }
-            ]
-        }
-        truncate_task_text(task, full=False)
-        parts = task["artifacts"][0]["parts"]
-        assert parts[0]["text"] == "abcdefghij..."
-        assert parts[1] == {"data": "binary"}
-        assert parts[2]["text"] == "short"
+def test_truncate_task_text__short_text_is_not_truncated():
+    task = _task("hello")
+    truncate_task_text(task, full=False)
+    assert task["artifacts"][0]["parts"][0]["text"] == "hello"
 
-    def test_multiple_artifacts_each_processed(self):
-        task = {
-            "artifacts": [
-                {"parts": [{"text": "abcdefghijklmnop"}]},
-                {"parts": [{"text": "0123456789ABC"}]},
-            ]
-        }
-        truncate_task_text(task, full=False)
-        assert task["artifacts"][0]["parts"][0]["text"] == "abcdefghij..."
-        assert task["artifacts"][1]["parts"][0]["text"] == "0123456789..."
 
-    def test_non_dict_item_in_list_is_skipped(self):
-        items = [None, _task("abcdefghijklmnop")]
-        truncate_task_text(items, full=False)
-        assert items[0] is None
-        assert items[1]["artifacts"][0]["parts"][0]["text"] == "abcdefghij..."
+def test_truncate_task_text__missing_artifacts_key_is_noop():
+    task = {
+        "id": "task-001",
+        "status": {"state": "input_required"},
+        "metadata": {"fromAgentId": "a", "type": "unicast"},
+    }
+    result = truncate_task_text(task, full=False)
+    assert result is task
+    assert "artifacts" not in task
 
-    def test_sibling_metadata_fields_unchanged(self):
-        task = _task("abcdefghijklmnop")
-        truncate_task_text(task, full=False)
-        assert task["id"] == "task-001"
-        assert task["status"] == {"state": "input_required"}
-        assert task["metadata"] == {
-            "fromAgentId": "agent-from",
-            "toAgentId": "agent-to",
-            "type": "unicast",
-        }
+
+def test_truncate_task_text__missing_parts_key_is_noop():
+    task = {"artifacts": [{}]}
+    truncate_task_text(task, full=False)
+    assert task == {"artifacts": [{}]}
+
+
+def test_truncate_task_text__missing_text_key_in_part_is_noop():
+    task = {"artifacts": [{"parts": [{"data": "binary"}]}]}
+    truncate_task_text(task, full=False)
+    assert task == {"artifacts": [{"parts": [{"data": "binary"}]}]}
+    assert "text" not in task["artifacts"][0]["parts"][0]
+
+
+def test_truncate_task_text__part_with_explicit_none_text_is_left_untouched():
+    task = {"artifacts": [{"parts": [{"text": None}]}]}
+    truncate_task_text(task, full=False)
+    assert task["artifacts"][0]["parts"][0]["text"] is None
+
+
+def test_truncate_task_text__mixed_parts_only_truncates_text_bearing():
+    task = {
+        "artifacts": [
+            {
+                "parts": [
+                    {"text": "abcdefghijklmnop"},
+                    {"data": "binary"},
+                    {"text": "short"},
+                ]
+            }
+        ]
+    }
+    truncate_task_text(task, full=False)
+    parts = task["artifacts"][0]["parts"]
+    assert parts[0]["text"] == "abcdefghij..."
+    assert parts[1] == {"data": "binary"}
+    assert parts[2]["text"] == "short"
+
+
+def test_truncate_task_text__multiple_artifacts_each_processed():
+    task = {
+        "artifacts": [
+            {"parts": [{"text": "abcdefghijklmnop"}]},
+            {"parts": [{"text": "0123456789ABC"}]},
+        ]
+    }
+    truncate_task_text(task, full=False)
+    assert task["artifacts"][0]["parts"][0]["text"] == "abcdefghij..."
+    assert task["artifacts"][1]["parts"][0]["text"] == "0123456789..."
+
+
+def test_truncate_task_text__non_dict_item_in_list_is_skipped():
+    items = [None, _task("abcdefghijklmnop")]
+    truncate_task_text(items, full=False)
+    assert items[0] is None
+    assert items[1]["artifacts"][0]["parts"][0]["text"] == "abcdefghij..."
+
+
+def test_truncate_task_text__sibling_metadata_fields_unchanged():
+    task = _task("abcdefghijklmnop")
+    truncate_task_text(task, full=False)
+    assert task["id"] == "task-001"
+    assert task["status"] == {"state": "input_required"}
+    assert task["metadata"] == {
+        "fromAgentId": "agent-from",
+        "toAgentId": "agent-to",
+        "type": "unicast",
+    }

--- a/cafleet/tests/test_output_indexed_list.py
+++ b/cafleet/tests/test_output_indexed_list.py
@@ -9,70 +9,72 @@ item's ``formatter(item)`` rendering.
 from cafleet.output import format_agent, format_indexed_list, format_task
 
 
-class TestFormatIndexedList:
-    def test_empty_items_returns_empty_msg_verbatim(self):
-        formatter_calls = []
+def test_format_indexed_list__empty_items_returns_empty_msg_verbatim():
+    formatter_calls = []
 
-        def formatter(item):
-            formatter_calls.append(item)
-            return "never called"
+    def formatter(item):
+        formatter_calls.append(item)
+        return "never called"
 
-        result = format_indexed_list([], formatter, "No widgets found.")
-        assert result == "No widgets found."
-        assert formatter_calls == []
+    result = format_indexed_list([], formatter, "No widgets found.")
+    assert result == "No widgets found."
+    assert formatter_calls == []
 
-    def test_non_empty_calls_formatter_per_item_with_indexed_prefix(self):
-        formatter_calls = []
 
-        def formatter(item):
-            formatter_calls.append(item)
-            return f"FMT-{item}"
+def test_format_indexed_list__non_empty_calls_formatter_per_item_with_indexed_prefix():
+    formatter_calls = []
 
-        result = format_indexed_list(["a", "b", "c"], formatter, "unused empty msg")
+    def formatter(item):
+        formatter_calls.append(item)
+        return f"FMT-{item}"
 
-        assert formatter_calls == ["a", "b", "c"]
-        assert result == "[1]\nFMT-a\n[2]\nFMT-b\n[3]\nFMT-c"
+    result = format_indexed_list(["a", "b", "c"], formatter, "unused empty msg")
 
-    def test_byte_identical_output_for_task_list_shape(self):
-        task = {
-            "id": "tid-1",
-            "status": {"state": "input_required"},
-            "metadata": {
-                "fromAgentId": "a1",
-                "toAgentId": "a2",
-                "type": "unicast",
-            },
-            "artifacts": [{"parts": [{"text": "hello world"}]}],
-        }
-        result = format_indexed_list([task], format_task, "No messages found.")
-        expected = "\n".join(
-            [
-                "[1]",
-                "  id:    tid-1",
-                "  state: input_required",
-                "  from:  a1",
-                "  to:    a2",
-                "  type:  unicast",
-                "  text:  hello world",
-            ]
-        )
-        assert result == expected
+    assert formatter_calls == ["a", "b", "c"]
+    assert result == "[1]\nFMT-a\n[2]\nFMT-b\n[3]\nFMT-c"
 
-    def test_byte_identical_output_for_agent_list_shape(self):
-        agent = {
-            "agent_id": "a1",
-            "name": "alpha",
-            "description": "A test agent",
-            "status": "active",
-        }
-        result = format_indexed_list([agent], format_agent, "No agents found.")
-        expected = "\n".join(
-            [
-                "[1]",
-                "  agent_id:    a1",
-                "  name:        alpha",
-                "  description: A test agent",
-                "  status:      active",
-            ]
-        )
-        assert result == expected
+
+def test_format_indexed_list__byte_identical_output_for_task_list_shape():
+    task = {
+        "id": "tid-1",
+        "status": {"state": "input_required"},
+        "metadata": {
+            "fromAgentId": "a1",
+            "toAgentId": "a2",
+            "type": "unicast",
+        },
+        "artifacts": [{"parts": [{"text": "hello world"}]}],
+    }
+    result = format_indexed_list([task], format_task, "No messages found.")
+    expected = "\n".join(
+        [
+            "[1]",
+            "  id:    tid-1",
+            "  state: input_required",
+            "  from:  a1",
+            "  to:    a2",
+            "  type:  unicast",
+            "  text:  hello world",
+        ]
+    )
+    assert result == expected
+
+
+def test_format_indexed_list__byte_identical_output_for_agent_list_shape():
+    agent = {
+        "agent_id": "a1",
+        "name": "alpha",
+        "description": "A test agent",
+        "status": "active",
+    }
+    result = format_indexed_list([agent], format_agent, "No agents found.")
+    expected = "\n".join(
+        [
+            "[1]",
+            "  agent_id:    a1",
+            "  name:        alpha",
+            "  description: A test agent",
+            "  status:      active",
+        ]
+    )
+    assert result == expected

--- a/cafleet/tests/test_server_cli.py
+++ b/cafleet/tests/test_server_cli.py
@@ -194,7 +194,7 @@ def test_broker_host_default__broker_host_default_is_loopback(monkeypatch):
     assert s.broker_host == "127.0.0.1"
 
 
-def test_broker_host_default__broker_port_default_is_8000(monkeypatch):
+def test_broker_port_default__is_8000(monkeypatch):
     """Asserted alongside broker_host so any accidental regression in
     the Field() rewrite is caught.
     """
@@ -211,7 +211,7 @@ def test_broker_host_default__cafleet_broker_host_env_var_is_read(monkeypatch):
     assert s.broker_host == "10.20.30.40"
 
 
-def test_broker_host_default__cafleet_broker_port_env_var_is_read(monkeypatch):
+def test_broker_port_default__cafleet_env_var_is_read(monkeypatch):
     monkeypatch.delenv("BROKER_PORT", raising=False)
     monkeypatch.setenv("CAFLEET_BROKER_PORT", "9876")
     s = Settings()

--- a/cafleet/tests/test_server_cli.py
+++ b/cafleet/tests/test_server_cli.py
@@ -10,193 +10,201 @@ from cafleet.cli import cli
 from cafleet.config import Settings, settings
 
 
-class TestServerCommandHelp:
-    def test_server_help_exits_zero(self):
-        runner = CliRunner()
-        result = runner.invoke(cli, ["server", "--help"])
-        assert result.exit_code == 0, result.output
-
-    def test_server_help_mentions_host_flag(self):
-        runner = CliRunner()
-        result = runner.invoke(cli, ["server", "--help"])
-        assert "--host" in result.output
-
-    def test_server_help_mentions_port_flag(self):
-        runner = CliRunner()
-        result = runner.invoke(cli, ["server", "--help"])
-        assert "--port" in result.output
+def test_server_command_help__server_help_exits_zero():
+    runner = CliRunner()
+    result = runner.invoke(cli, ["server", "--help"])
+    assert result.exit_code == 0, result.output
 
 
-class TestServerCommandFlagParsing:
-    def test_default_flags_pass_settings_defaults_to_uvicorn(self, monkeypatch):
-        captured: dict = {}
-
-        def fake_run(*args, **kwargs):
-            captured["args"] = args
-            captured["kwargs"] = kwargs
-
-        monkeypatch.setattr(uvicorn, "run", fake_run)
-
-        runner = CliRunner()
-        result = runner.invoke(cli, ["server"])
-
-        assert result.exit_code == 0, result.output
-        assert captured
-        kwargs = captured["kwargs"]
-        assert kwargs["host"] == settings.broker_host
-        assert kwargs["port"] == settings.broker_port
-
-    def test_explicit_flags_override_defaults(self, monkeypatch):
-        captured: dict = {}
-
-        def fake_run(*args, **kwargs):
-            captured["args"] = args
-            captured["kwargs"] = kwargs
-
-        monkeypatch.setattr(uvicorn, "run", fake_run)
-
-        runner = CliRunner()
-        result = runner.invoke(
-            cli,
-            ["server", "--host", "0.0.0.0", "--port", "9000"],
-        )
-
-        assert result.exit_code == 0, result.output
-        kwargs = captured["kwargs"]
-        assert kwargs["host"] == "0.0.0.0"
-        assert kwargs["port"] == 9000
-
-    def test_app_import_string_passed_as_first_positional(self, monkeypatch):
-        captured: dict = {}
-
-        def fake_run(*args, **kwargs):
-            captured["args"] = args
-            captured["kwargs"] = kwargs
-
-        monkeypatch.setattr(uvicorn, "run", fake_run)
-
-        runner = CliRunner()
-        result = runner.invoke(cli, ["server"])
-        assert result.exit_code == 0, result.output
-        args = captured["args"]
-        assert args
-        assert args[0] == "cafleet.server:app"
-
-    def test_port_string_rejected_by_click_type_int(self):
-        runner = CliRunner()
-        result = runner.invoke(cli, ["server", "--port", "not-a-port"])
-        assert result.exit_code == 2, result.output
+def test_server_command_help__server_help_mentions_host_flag():
+    runner = CliRunner()
+    result = runner.invoke(cli, ["server", "--help"])
+    assert "--host" in result.output
 
 
-class TestServerDoesNotRequireSessionId:
-    """Uses ``--help`` so ``uvicorn.run`` is never called and tests do not
-    need to monkey-patch it.
+def test_server_command_help__server_help_mentions_port_flag():
+    runner = CliRunner()
+    result = runner.invoke(cli, ["server", "--help"])
+    assert "--port" in result.output
+
+
+def test_server_command_flag_parsing__default_flags_pass_settings_defaults_to_uvicorn(monkeypatch):
+    captured: dict = {}
+
+    def fake_run(*args, **kwargs):
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+
+    monkeypatch.setattr(uvicorn, "run", fake_run)
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["server"])
+
+    assert result.exit_code == 0, result.output
+    assert captured
+    kwargs = captured["kwargs"]
+    assert kwargs["host"] == settings.broker_host
+    assert kwargs["port"] == settings.broker_port
+
+
+def test_server_command_flag_parsing__explicit_flags_override_defaults(monkeypatch):
+    captured: dict = {}
+
+    def fake_run(*args, **kwargs):
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+
+    monkeypatch.setattr(uvicorn, "run", fake_run)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        ["server", "--host", "0.0.0.0", "--port", "9000"],
+    )
+
+    assert result.exit_code == 0, result.output
+    kwargs = captured["kwargs"]
+    assert kwargs["host"] == "0.0.0.0"
+    assert kwargs["port"] == 9000
+
+
+def test_server_command_flag_parsing__app_import_string_passed_as_first_positional(monkeypatch):
+    captured: dict = {}
+
+    def fake_run(*args, **kwargs):
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+
+    monkeypatch.setattr(uvicorn, "run", fake_run)
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["server"])
+    assert result.exit_code == 0, result.output
+    args = captured["args"]
+    assert args
+    assert args[0] == "cafleet.server:app"
+
+
+def test_server_command_flag_parsing__port_string_rejected_by_click_type_int():
+    runner = CliRunner()
+    result = runner.invoke(cli, ["server", "--port", "not-a-port"])
+    assert result.exit_code == 2, result.output
+
+
+# --- server_does_not_require_session_id: uses ``--help`` so ``uvicorn.run`` is
+# never called and tests do not need to monkey-patch it. ---
+
+
+def test_server_does_not_require_session_id__server_help_without_session_id_succeeds():
+    runner = CliRunner()
+    result = runner.invoke(cli, ["server", "--help"])
+    assert result.exit_code == 0, result.output
+    out = result.output or ""
+    assert "is required" not in out
+
+
+def test_server_does_not_require_session_id__server_help_with_session_id_silently_accepted():
+    runner = CliRunner()
+    sid = str(uuid.uuid4())
+    result = runner.invoke(cli, ["--session-id", sid, "server", "--help"])
+    assert result.exit_code == 0, result.output
+    combined = (result.output or "").lower()
+    assert "unused" not in combined
+    assert "unexpected" not in combined
+    assert "no such option" not in combined
+
+
+def test_server_does_not_require_session_id__server_invocation_without_session_id_runs_handler(monkeypatch):
+    """Regression guard: the handler must NOT call _require_session_id,
+    so invoking without --session-id must reach uvicorn.run (patched out).
     """
+    captured: dict = {}
 
-    def test_server_help_without_session_id_succeeds(self):
-        runner = CliRunner()
-        result = runner.invoke(cli, ["server", "--help"])
-        assert result.exit_code == 0, result.output
-        out = result.output or ""
-        assert "is required" not in out
+    def fake_run(*args, **kwargs):
+        captured["called"] = True
+        captured["kwargs"] = kwargs
 
-    def test_server_help_with_session_id_silently_accepted(self):
-        runner = CliRunner()
-        sid = str(uuid.uuid4())
-        result = runner.invoke(cli, ["--session-id", sid, "server", "--help"])
-        assert result.exit_code == 0, result.output
-        combined = (result.output or "").lower()
-        assert "unused" not in combined
-        assert "unexpected" not in combined
-        assert "no such option" not in combined
+    monkeypatch.setattr(uvicorn, "run", fake_run)
 
-    def test_server_invocation_without_session_id_runs_handler(self, monkeypatch):
-        """Regression guard: the handler must NOT call _require_session_id,
-        so invoking without --session-id must reach uvicorn.run (patched out).
-        """
-        captured: dict = {}
-
-        def fake_run(*args, **kwargs):
-            captured["called"] = True
-            captured["kwargs"] = kwargs
-
-        monkeypatch.setattr(uvicorn, "run", fake_run)
-
-        runner = CliRunner()
-        result = runner.invoke(cli, ["server"])
-        assert result.exit_code == 0, result.output
-        assert captured["called"] is True
+    runner = CliRunner()
+    result = runner.invoke(cli, ["server"])
+    assert result.exit_code == 0, result.output
+    assert captured["called"] is True
 
 
-class TestWebUIDistWarning:
-    """``create_app()`` emits the missing-WebUI-dist warning only when the
-    default path is used; explicit overrides must stay quiet.
+# --- webui_dist_warning: ``create_app()`` emits the missing-WebUI-dist warning
+# only when the default path is used; explicit overrides must stay quiet. ---
+
+
+_WARNING_PREFIX = "warning: admin WebUI is not built"
+
+
+def test_webui_dist_warning__warning_emitted_when_default_dir_missing(
+    tmp_path, monkeypatch, capsys
+):
+    nonexistent = tmp_path / "never_built"
+    assert not nonexistent.exists()
+    monkeypatch.setattr(server_mod, "default_webui_dist_dir", lambda: nonexistent)
+    server_mod.create_app()
+    captured = capsys.readouterr()
+    assert _WARNING_PREFIX in captured.err
+    assert "mise //admin:build" in captured.err
+    assert "/ui/" in captured.err
+
+
+def test_webui_dist_warning__warning_suppressed_on_explicit_override(
+    tmp_path, monkeypatch, capsys
+):
+    """Proves the ``emit_warning_if_missing = webui_dist_dir is None`` gate:
+    explicit overrides suppress the warning even when the path is missing.
     """
-
-    _WARNING_PREFIX = "warning: admin WebUI is not built"
-
-    def test_warning_emitted_when_default_dir_missing(
-        self, tmp_path, monkeypatch, capsys
-    ):
-        nonexistent = tmp_path / "never_built"
-        assert not nonexistent.exists()
-        monkeypatch.setattr(server_mod, "default_webui_dist_dir", lambda: nonexistent)
-        server_mod.create_app()
-        captured = capsys.readouterr()
-        assert self._WARNING_PREFIX in captured.err
-        assert "mise //admin:build" in captured.err
-        assert "/ui/" in captured.err
-
-    def test_warning_suppressed_on_explicit_override(
-        self, tmp_path, monkeypatch, capsys
-    ):
-        """Proves the ``emit_warning_if_missing = webui_dist_dir is None`` gate:
-        explicit overrides suppress the warning even when the path is missing.
-        """
-        nonexistent = tmp_path / "never_built"
-        assert not nonexistent.exists()
-        monkeypatch.setattr(
-            server_mod,
-            "default_webui_dist_dir",
-            lambda: tmp_path / "default_also_missing",
-        )
-        server_mod.create_app(webui_dist_dir=str(nonexistent))
-        captured = capsys.readouterr()
-        assert self._WARNING_PREFIX not in captured.err
-
-    def test_no_warning_when_default_dir_exists(self, tmp_path, monkeypatch, capsys):
-        built = tmp_path / "dist"
-        built.mkdir()
-        monkeypatch.setattr(server_mod, "default_webui_dist_dir", lambda: built)
-        server_mod.create_app()
-        captured = capsys.readouterr()
-        assert self._WARNING_PREFIX not in captured.err
+    nonexistent = tmp_path / "never_built"
+    assert not nonexistent.exists()
+    monkeypatch.setattr(
+        server_mod,
+        "default_webui_dist_dir",
+        lambda: tmp_path / "default_also_missing",
+    )
+    server_mod.create_app(webui_dist_dir=str(nonexistent))
+    captured = capsys.readouterr()
+    assert _WARNING_PREFIX not in captured.err
 
 
-class TestBrokerHostDefault:
-    def test_broker_host_default_is_loopback(self, monkeypatch):
-        monkeypatch.delenv("BROKER_HOST", raising=False)
-        monkeypatch.delenv("CAFLEET_BROKER_HOST", raising=False)
-        s = Settings()
-        assert s.broker_host == "127.0.0.1"
+def test_webui_dist_warning__no_warning_when_default_dir_exists(tmp_path, monkeypatch, capsys):
+    built = tmp_path / "dist"
+    built.mkdir()
+    monkeypatch.setattr(server_mod, "default_webui_dist_dir", lambda: built)
+    server_mod.create_app()
+    captured = capsys.readouterr()
+    assert _WARNING_PREFIX not in captured.err
 
-    def test_broker_port_default_is_8000(self, monkeypatch):
-        """Asserted alongside broker_host so any accidental regression in
-        the Field() rewrite is caught.
-        """
-        monkeypatch.delenv("BROKER_PORT", raising=False)
-        monkeypatch.delenv("CAFLEET_BROKER_PORT", raising=False)
-        s = Settings()
-        assert s.broker_port == 8000
 
-    def test_cafleet_broker_host_env_var_is_read(self, monkeypatch):
-        monkeypatch.delenv("BROKER_HOST", raising=False)
-        monkeypatch.setenv("CAFLEET_BROKER_HOST", "10.20.30.40")
-        s = Settings()
-        assert s.broker_host == "10.20.30.40"
+def test_broker_host_default__broker_host_default_is_loopback(monkeypatch):
+    monkeypatch.delenv("BROKER_HOST", raising=False)
+    monkeypatch.delenv("CAFLEET_BROKER_HOST", raising=False)
+    s = Settings()
+    assert s.broker_host == "127.0.0.1"
 
-    def test_cafleet_broker_port_env_var_is_read(self, monkeypatch):
-        monkeypatch.delenv("BROKER_PORT", raising=False)
-        monkeypatch.setenv("CAFLEET_BROKER_PORT", "9876")
-        s = Settings()
-        assert s.broker_port == 9876
+
+def test_broker_host_default__broker_port_default_is_8000(monkeypatch):
+    """Asserted alongside broker_host so any accidental regression in
+    the Field() rewrite is caught.
+    """
+    monkeypatch.delenv("BROKER_PORT", raising=False)
+    monkeypatch.delenv("CAFLEET_BROKER_PORT", raising=False)
+    s = Settings()
+    assert s.broker_port == 8000
+
+
+def test_broker_host_default__cafleet_broker_host_env_var_is_read(monkeypatch):
+    monkeypatch.delenv("BROKER_HOST", raising=False)
+    monkeypatch.setenv("CAFLEET_BROKER_HOST", "10.20.30.40")
+    s = Settings()
+    assert s.broker_host == "10.20.30.40"
+
+
+def test_broker_host_default__cafleet_broker_port_env_var_is_read(monkeypatch):
+    monkeypatch.delenv("BROKER_PORT", raising=False)
+    monkeypatch.setenv("CAFLEET_BROKER_PORT", "9876")
+    s = Settings()
+    assert s.broker_port == 9876

--- a/cafleet/tests/test_server_cli.py
+++ b/cafleet/tests/test_server_cli.py
@@ -211,7 +211,7 @@ def test_broker_host_default__cafleet_broker_host_env_var_is_read(monkeypatch):
     assert s.broker_host == "10.20.30.40"
 
 
-def test_broker_port_default__cafleet_env_var_is_read(monkeypatch):
+def test_broker_port_default__cafleet_broker_port_env_var_is_read(monkeypatch):
     monkeypatch.delenv("BROKER_PORT", raising=False)
     monkeypatch.setenv("CAFLEET_BROKER_PORT", "9876")
     s = Settings()

--- a/cafleet/tests/test_server_cli.py
+++ b/cafleet/tests/test_server_cli.py
@@ -28,7 +28,9 @@ def test_server_command_help__server_help_mentions_port_flag():
     assert "--port" in result.output
 
 
-def test_server_command_flag_parsing__default_flags_pass_settings_defaults_to_uvicorn(monkeypatch):
+def test_server_command_flag_parsing__default_flags_pass_settings_defaults_to_uvicorn(
+    monkeypatch,
+):
     captured: dict = {}
 
     def fake_run(*args, **kwargs):
@@ -68,7 +70,9 @@ def test_server_command_flag_parsing__explicit_flags_override_defaults(monkeypat
     assert kwargs["port"] == 9000
 
 
-def test_server_command_flag_parsing__app_import_string_passed_as_first_positional(monkeypatch):
+def test_server_command_flag_parsing__app_import_string_passed_as_first_positional(
+    monkeypatch,
+):
     captured: dict = {}
 
     def fake_run(*args, **kwargs):
@@ -114,7 +118,9 @@ def test_server_does_not_require_session_id__server_help_with_session_id_silentl
     assert "no such option" not in combined
 
 
-def test_server_does_not_require_session_id__server_invocation_without_session_id_runs_handler(monkeypatch):
+def test_server_does_not_require_session_id__server_invocation_without_session_id_runs_handler(
+    monkeypatch,
+):
     """Regression guard: the handler must NOT call _require_session_id,
     so invoking without --session-id must reach uvicorn.run (patched out).
     """
@@ -170,7 +176,9 @@ def test_webui_dist_warning__warning_suppressed_on_explicit_override(
     assert _WARNING_PREFIX not in captured.err
 
 
-def test_webui_dist_warning__no_warning_when_default_dir_exists(tmp_path, monkeypatch, capsys):
+def test_webui_dist_warning__no_warning_when_default_dir_exists(
+    tmp_path, monkeypatch, capsys
+):
     built = tmp_path / "dist"
     built.mkdir()
     monkeypatch.setattr(server_mod, "default_webui_dist_dir", lambda: built)

--- a/cafleet/tests/test_session_bootstrap.py
+++ b/cafleet/tests/test_session_bootstrap.py
@@ -53,409 +53,433 @@ def _bootstrap(label: str | None = None, ctx: DirectorContext | None = None) -> 
     )
 
 
-class TestCreateSessionBootstrap:
-    """``broker.create_session`` writes session + Director + placement + Admin."""
+# --- create_session_bootstrap: ``broker.create_session`` writes session +
+# Director + placement + Admin. ---
 
-    def test_returns_nested_dict_with_required_top_level_keys(self, director_context):
-        result = _bootstrap(label="bootstrap-1", ctx=director_context)
-        assert isinstance(result, dict)
-        for key in (
-            "session_id",
-            "label",
-            "created_at",
-            "administrator_agent_id",
-            "director",
-        ):
-            assert key in result, f"missing top-level key {key!r} in {result!r}"
 
-    def test_director_sub_dict_has_required_keys(self, director_context):
-        result = _bootstrap(ctx=director_context)
-        director = result["director"]
-        for key in ("agent_id", "name", "description", "registered_at", "placement"):
-            assert key in director, f"missing director key {key!r} in {director!r}"
-
-    def test_director_name_and_description_are_hardcoded(self, director_context):
-        result = _bootstrap(ctx=director_context)
-        assert result["director"]["name"] == "Director"
-        assert result["director"]["description"] == "Root Director for this session"
-
-    def test_placement_sub_dict_matches_director_context_and_unknown_coding_agent(
-        self, director_context
+def test_create_session_bootstrap__returns_nested_dict_with_required_top_level_keys(director_context):
+    result = _bootstrap(label="bootstrap-1", ctx=director_context)
+    assert isinstance(result, dict)
+    for key in (
+        "session_id",
+        "label",
+        "created_at",
+        "administrator_agent_id",
+        "director",
     ):
-        result = _bootstrap(ctx=director_context)
-        placement = result["director"]["placement"]
-        assert placement["director_agent_id"] is None
-        assert placement["tmux_session"] == director_context.session
-        assert placement["tmux_window_id"] == director_context.window_id
-        assert placement["tmux_pane_id"] == director_context.pane_id
-        assert placement["coding_agent"] == "unknown"
-        assert "created_at" in placement
-
-    def test_writes_exactly_one_session_row(self, broker_session, director_context):
-        result = _bootstrap(ctx=director_context)
-        with broker_session() as s:
-            rows = s.query(SessionModel).all()
-        assert len(rows) == 1
-        assert rows[0].session_id == result["session_id"]
-
-    def test_writes_two_agent_rows_director_and_administrator(
-        self, broker_session, director_context
-    ):
-        """After bootstrap: one Director row and one Administrator row, both active."""
-        result = _bootstrap(ctx=director_context)
-        sid = result["session_id"]
-
-        with broker_session() as s:
-            rows = s.query(Agent).filter(Agent.session_id == sid).all()
-
-        assert len(rows) == 2
-        by_name = {r.name: r for r in rows}
-        assert "Director" in by_name
-        assert "Administrator" in by_name
-
-        director_row = by_name["Director"]
-        admin_row = by_name["Administrator"]
-        assert director_row.status == "active"
-        assert admin_row.status == "active"
-        assert director_row.agent_id == result["director"]["agent_id"]
-        assert admin_row.agent_id == result["administrator_agent_id"]
-        assert _is_administrator(admin_row.agent_card_json)
-        assert not _is_administrator(director_row.agent_card_json)
-
-    def test_writes_one_placement_row_for_the_director_only(
-        self, broker_session, director_context
-    ):
-        result = _bootstrap(ctx=director_context)
-        director_id = result["director"]["agent_id"]
-
-        with broker_session() as s:
-            placements = s.query(AgentPlacement).all()
-
-        assert len(placements) == 1
-        placement = placements[0]
-        assert placement.agent_id == director_id
-        assert placement.director_agent_id is None
-        assert placement.tmux_session == director_context.session
-        assert placement.tmux_window_id == director_context.window_id
-        assert placement.tmux_pane_id == director_context.pane_id
-        assert placement.coding_agent == "unknown"
-
-    def test_sessions_director_agent_id_is_set_to_the_director(
-        self, broker_session, director_context
-    ):
-        result = _bootstrap(ctx=director_context)
-        sid = result["session_id"]
-        director_id = result["director"]["agent_id"]
-
-        with broker_session() as s:
-            row = s.query(SessionModel).filter(SessionModel.session_id == sid).one()
-
-        assert row.director_agent_id == director_id
-
-    def test_administrator_registered_at_equals_session_created_at(
-        self, broker_session, director_context
-    ):
-        result = _bootstrap(ctx=director_context)
-        sid = result["session_id"]
-        admin_id = result["administrator_agent_id"]
-
-        with broker_session() as s:
-            session_row = (
-                s.query(SessionModel).filter(SessionModel.session_id == sid).one()
-            )
-            admin_row = s.query(Agent).filter(Agent.agent_id == admin_id).one()
-
-        assert admin_row.registered_at == session_row.created_at
-
-    def test_sessions_deleted_at_is_null_after_bootstrap(
-        self, broker_session, director_context
-    ):
-        result = _bootstrap(ctx=director_context)
-        with broker_session() as s:
-            row = (
-                s.query(SessionModel)
-                .filter(SessionModel.session_id == result["session_id"])
-                .one()
-            )
-        assert row.deleted_at is None
-
-    def test_label_is_preserved(self, director_context):
-        result = _bootstrap(label="hello-world", ctx=director_context)
-        assert result["label"] == "hello-world"
-
-    def test_label_may_be_none(self, director_context):
-        result = _bootstrap(label=None, ctx=director_context)
-        assert result["label"] is None
+        assert key in result, f"missing top-level key {key!r} in {result!r}"
+
+
+def test_create_session_bootstrap__director_sub_dict_has_required_keys(director_context):
+    result = _bootstrap(ctx=director_context)
+    director = result["director"]
+    for key in ("agent_id", "name", "description", "registered_at", "placement"):
+        assert key in director, f"missing director key {key!r} in {director!r}"
+
+
+def test_create_session_bootstrap__director_name_and_description_are_hardcoded(director_context):
+    result = _bootstrap(ctx=director_context)
+    assert result["director"]["name"] == "Director"
+    assert result["director"]["description"] == "Root Director for this session"
+
+
+def test_create_session_bootstrap__placement_sub_dict_matches_director_context_and_unknown_coding_agent(
+    director_context,
+):
+    result = _bootstrap(ctx=director_context)
+    placement = result["director"]["placement"]
+    assert placement["director_agent_id"] is None
+    assert placement["tmux_session"] == director_context.session
+    assert placement["tmux_window_id"] == director_context.window_id
+    assert placement["tmux_pane_id"] == director_context.pane_id
+    assert placement["coding_agent"] == "unknown"
+    assert "created_at" in placement
+
+
+def test_create_session_bootstrap__writes_exactly_one_session_row(broker_session, director_context):
+    result = _bootstrap(ctx=director_context)
+    with broker_session() as s:
+        rows = s.query(SessionModel).all()
+    assert len(rows) == 1
+    assert rows[0].session_id == result["session_id"]
+
+
+def test_create_session_bootstrap__writes_two_agent_rows_director_and_administrator(
+    broker_session, director_context
+):
+    """After bootstrap: one Director row and one Administrator row, both active."""
+    result = _bootstrap(ctx=director_context)
+    sid = result["session_id"]
+
+    with broker_session() as s:
+        rows = s.query(Agent).filter(Agent.session_id == sid).all()
 
-    def test_each_call_mints_unique_ids(self, director_context):
-        a = _bootstrap(ctx=director_context)
-        b = _bootstrap(ctx=director_context)
-        assert a["session_id"] != b["session_id"]
-        assert a["director"]["agent_id"] != b["director"]["agent_id"]
-        assert a["administrator_agent_id"] != b["administrator_agent_id"]
+    assert len(rows) == 2
+    by_name = {r.name: r for r in rows}
+    assert "Director" in by_name
+    assert "Administrator" in by_name
+
+    director_row = by_name["Director"]
+    admin_row = by_name["Administrator"]
+    assert director_row.status == "active"
+    assert admin_row.status == "active"
+    assert director_row.agent_id == result["director"]["agent_id"]
+    assert admin_row.agent_id == result["administrator_agent_id"]
+    assert _is_administrator(admin_row.agent_card_json)
+    assert not _is_administrator(director_row.agent_card_json)
 
+
+def test_create_session_bootstrap__writes_one_placement_row_for_the_director_only(
+    broker_session, director_context
+):
+    result = _bootstrap(ctx=director_context)
+    director_id = result["director"]["agent_id"]
+
+    with broker_session() as s:
+        placements = s.query(AgentPlacement).all()
+
+    assert len(placements) == 1
+    placement = placements[0]
+    assert placement.agent_id == director_id
+    assert placement.director_agent_id is None
+    assert placement.tmux_session == director_context.session
+    assert placement.tmux_window_id == director_context.window_id
+    assert placement.tmux_pane_id == director_context.pane_id
+    assert placement.coding_agent == "unknown"
 
-class TestCreateSessionRollback:
-    """Any exception during the 5-step bootstrap rolls back the whole transaction."""
 
-    def test_rollback_when_placement_insert_fails_leaves_no_rows(
-        self, broker_session, director_context, monkeypatch
-    ):
-        """Inject an exception after step 2 (INSERT agents) by making the
-        ``AgentPlacement`` constructor raise. The ``with session.begin():``
-        wrapper must roll back the prior ``sessions`` and ``agents`` INSERTs.
-        """
+def test_create_session_bootstrap__sessions_director_agent_id_is_set_to_the_director(
+    broker_session, director_context
+):
+    result = _bootstrap(ctx=director_context)
+    sid = result["session_id"]
+    director_id = result["director"]["agent_id"]
 
-        class _BoomPlacement:
-            def __init__(self, *args, **kwargs):
-                raise RuntimeError("injected failure after INSERT agents")
-
-        # Patch the reference the broker module looks up during create_session.
-        monkeypatch.setattr(broker, "AgentPlacement", _BoomPlacement)
-
-        with pytest.raises(RuntimeError, match="injected failure"):
-            broker.create_session(label="rollback", director_context=director_context)
-
-        with broker_session() as s:
-            sessions = s.query(SessionModel).count()
-            agents = s.query(Agent).count()
-            placements = s.query(AgentPlacement).count()
-
-        assert sessions == 0
-        assert agents == 0
-        assert placements == 0
-
-
-class TestDeleteSessionCascade:
-    def test_sets_sessions_deleted_at_and_returns_count_including_director(
-        self, broker_session, director_context
-    ):
-        result = _bootstrap(ctx=director_context)
-        sid = result["session_id"]
-
-        ret = broker.delete_session(sid)
-
-        assert isinstance(ret, dict)
-        assert ret["deregistered_count"] == 2
-
-        with broker_session() as s:
-            row = s.query(SessionModel).filter(SessionModel.session_id == sid).one()
-        assert row.deleted_at is not None
-
-    def test_deregisters_all_active_agents_in_the_session(
-        self, broker_session, director_context
-    ):
-        result = _bootstrap(ctx=director_context)
-        sid = result["session_id"]
-
-        broker.delete_session(sid)
-
-        with broker_session() as s:
-            statuses = {
-                r.name: r.status
-                for r in s.query(Agent).filter(Agent.session_id == sid).all()
-            }
-        assert statuses["Director"] == "deregistered"
-        assert statuses["Administrator"] == "deregistered"
-
-    def test_deletes_placement_rows_in_the_session(
-        self, broker_session, director_context
-    ):
-        result = _bootstrap(ctx=director_context)
-        sid = result["session_id"]
-
-        with broker_session() as s:
-            assert s.query(AgentPlacement).count() == 1
-
-        broker.delete_session(sid)
-
-        with broker_session() as s:
-            assert s.query(AgentPlacement).count() == 0
-
-    def test_tasks_are_preserved_after_soft_delete(
-        self, broker_session, director_context
-    ):
-        result = _bootstrap(ctx=director_context)
-        sid = result["session_id"]
-        admin_id = result["administrator_agent_id"]
-        director_id = result["director"]["agent_id"]
-
-        sent = broker.send_message(sid, admin_id, director_id, "audit me")
-        task_id = sent["task"]["id"]
-
-        broker.delete_session(sid)
-
-        with broker_session() as s:
-            tasks = s.query(Task).all()
-        assert any(t.task_id == task_id for t in tasks)
-
-    def test_idempotent_rerun_returns_zero_deregistered(self, director_context):
-        result = _bootstrap(ctx=director_context)
-        sid = result["session_id"]
-
-        first = broker.delete_session(sid)
-        second = broker.delete_session(sid)
-
-        assert first["deregistered_count"] == 2
-        assert second["deregistered_count"] == 0
-
-    def test_unknown_session_raises_click_exception(self):
-        """Deleting a session that was never created raises not-found.
-
-        The broker raises ``click.ClickException`` (exit 1 when the CLI layer
-        catches it) rather than ``click.UsageError`` (exit 2 with a Usage:
-        banner). Design 0000026 pins the exit code to 1 — same as
-        ``session show`` — because "not found" is a runtime condition, not a
-        CLI usage error.
-        """
-        fake_sid = str(uuid.uuid4())
-        with pytest.raises(click.ClickException) as exc_info:
-            broker.delete_session(fake_sid)
-        msg = str(exc_info.value)
-        assert "not found" in msg.lower()
-        assert fake_sid in msg
-
-
-class TestRegisterAgentOnSoftDeletedSession:
-    """Registration into a soft-deleted session fails with a specific message."""
-
-    def test_rejects_soft_deleted_session_with_expected_error_string(
-        self, director_context
-    ):
-        result = _bootstrap(ctx=director_context)
-        sid = result["session_id"]
-        broker.delete_session(sid)
-
-        with pytest.raises(click.UsageError) as exc_info:
-            broker.register_agent(
-                session_id=sid,
-                name="late-comer",
-                description="registering after soft delete",
-            )
-        msg = str(exc_info.value)
-        # Design doc exact wording: "session X is deleted"
-        assert "is deleted" in msg
-        assert sid in msg
-        # Must NOT use the "not found" path — the row still exists.
-        assert "not found" not in msg.lower()
-
-    def test_unknown_session_still_says_not_found(self):
-        """Make sure the soft-delete guard did not replace the not-found path."""
-        with pytest.raises(click.UsageError) as exc_info:
-            broker.register_agent(
-                session_id=str(uuid.uuid4()),
-                name="stranger",
-                description="no such session",
-            )
-        assert "not found" in str(exc_info.value).lower()
-
-
-class TestListSessionsFiltersSoftDeleted:
-    def test_hides_soft_deleted_sessions(self, director_context):
-        alive = _bootstrap(label="alive", ctx=director_context)
-        dead = _bootstrap(label="dead", ctx=director_context)
-        broker.delete_session(dead["session_id"])
-
-        sessions = broker.list_sessions()
-        ids = {s["session_id"] for s in sessions}
-
-        assert alive["session_id"] in ids
-        assert dead["session_id"] not in ids
-
-    def test_get_session_still_returns_soft_deleted_row(self, director_context):
-        result = _bootstrap(label="dead-but-visible", ctx=director_context)
-        sid = result["session_id"]
-        broker.delete_session(sid)
-
-        row = broker.get_session(sid)
-        assert row is not None
-        assert row["deleted_at"] is not None
-
-
-class TestDeregisterAgentRootDirector:
-    def test_rejects_root_director_with_specific_error(self, director_context):
-        result = _bootstrap(ctx=director_context)
-        director_id = result["director"]["agent_id"]
-
-        with pytest.raises(click.UsageError) as exc_info:
-            broker.deregister_agent(director_id)
-
-        msg = str(exc_info.value)
-        assert "cannot deregister the root Director" in msg
-        assert "cafleet session delete" in msg
-
-    def test_state_unchanged_after_rejection(self, broker_session, director_context):
-        result = _bootstrap(ctx=director_context)
-        director_id = result["director"]["agent_id"]
-        sid = result["session_id"]
-
-        with pytest.raises(click.UsageError):
-            broker.deregister_agent(director_id)
-
-        with broker_session() as s:
-            d_row = s.query(Agent).filter(Agent.agent_id == director_id).one()
-            p_row = (
-                s.query(AgentPlacement)
-                .filter(AgentPlacement.agent_id == director_id)
-                .one()
-            )
-            sess_row = (
-                s.query(SessionModel).filter(SessionModel.session_id == sid).one()
-            )
-
-        assert d_row.status == "active"
-        assert d_row.deregistered_at is None
-        assert p_row.tmux_pane_id == director_context.pane_id
-        assert sess_row.director_agent_id == director_id
-
-    def test_non_root_director_agent_can_still_be_deregistered(self, director_context):
-        result = _bootstrap(ctx=director_context)
-        sid = result["session_id"]
-
-        member = broker.register_agent(
+    with broker_session() as s:
+        row = s.query(SessionModel).filter(SessionModel.session_id == sid).one()
+
+    assert row.director_agent_id == director_id
+
+
+def test_create_session_bootstrap__administrator_registered_at_equals_session_created_at(
+    broker_session, director_context
+):
+    result = _bootstrap(ctx=director_context)
+    sid = result["session_id"]
+    admin_id = result["administrator_agent_id"]
+
+    with broker_session() as s:
+        session_row = (
+            s.query(SessionModel).filter(SessionModel.session_id == sid).one()
+        )
+        admin_row = s.query(Agent).filter(Agent.agent_id == admin_id).one()
+
+    assert admin_row.registered_at == session_row.created_at
+
+
+def test_create_session_bootstrap__sessions_deleted_at_is_null_after_bootstrap(
+    broker_session, director_context
+):
+    result = _bootstrap(ctx=director_context)
+    with broker_session() as s:
+        row = (
+            s.query(SessionModel)
+            .filter(SessionModel.session_id == result["session_id"])
+            .one()
+        )
+    assert row.deleted_at is None
+
+
+def test_create_session_bootstrap__label_is_preserved(director_context):
+    result = _bootstrap(label="hello-world", ctx=director_context)
+    assert result["label"] == "hello-world"
+
+
+def test_create_session_bootstrap__label_may_be_none(director_context):
+    result = _bootstrap(label=None, ctx=director_context)
+    assert result["label"] is None
+
+
+def test_create_session_bootstrap__each_call_mints_unique_ids(director_context):
+    a = _bootstrap(ctx=director_context)
+    b = _bootstrap(ctx=director_context)
+    assert a["session_id"] != b["session_id"]
+    assert a["director"]["agent_id"] != b["director"]["agent_id"]
+    assert a["administrator_agent_id"] != b["administrator_agent_id"]
+
+
+# --- create_session_rollback: any exception during the 5-step bootstrap rolls
+# back the whole transaction. ---
+
+
+def test_create_session_rollback__rollback_when_placement_insert_fails_leaves_no_rows(
+    broker_session, director_context, monkeypatch
+):
+    """Inject an exception after step 2 (INSERT agents) by making the
+    ``AgentPlacement`` constructor raise. The ``with session.begin():``
+    wrapper must roll back the prior ``sessions`` and ``agents`` INSERTs.
+    """
+
+    class _BoomPlacement:
+        def __init__(self, *args, **kwargs):
+            raise RuntimeError("injected failure after INSERT agents")
+
+    # Patch the reference the broker module looks up during create_session.
+    monkeypatch.setattr(broker, "AgentPlacement", _BoomPlacement)
+
+    with pytest.raises(RuntimeError, match="injected failure"):
+        broker.create_session(label="rollback", director_context=director_context)
+
+    with broker_session() as s:
+        sessions = s.query(SessionModel).count()
+        agents = s.query(Agent).count()
+        placements = s.query(AgentPlacement).count()
+
+    assert sessions == 0
+    assert agents == 0
+    assert placements == 0
+
+
+def test_delete_session_cascade__sets_sessions_deleted_at_and_returns_count_including_director(
+    broker_session, director_context
+):
+    result = _bootstrap(ctx=director_context)
+    sid = result["session_id"]
+
+    ret = broker.delete_session(sid)
+
+    assert isinstance(ret, dict)
+    assert ret["deregistered_count"] == 2
+
+    with broker_session() as s:
+        row = s.query(SessionModel).filter(SessionModel.session_id == sid).one()
+    assert row.deleted_at is not None
+
+
+def test_delete_session_cascade__deregisters_all_active_agents_in_the_session(
+    broker_session, director_context
+):
+    result = _bootstrap(ctx=director_context)
+    sid = result["session_id"]
+
+    broker.delete_session(sid)
+
+    with broker_session() as s:
+        statuses = {
+            r.name: r.status
+            for r in s.query(Agent).filter(Agent.session_id == sid).all()
+        }
+    assert statuses["Director"] == "deregistered"
+    assert statuses["Administrator"] == "deregistered"
+
+
+def test_delete_session_cascade__deletes_placement_rows_in_the_session(
+    broker_session, director_context
+):
+    result = _bootstrap(ctx=director_context)
+    sid = result["session_id"]
+
+    with broker_session() as s:
+        assert s.query(AgentPlacement).count() == 1
+
+    broker.delete_session(sid)
+
+    with broker_session() as s:
+        assert s.query(AgentPlacement).count() == 0
+
+
+def test_delete_session_cascade__tasks_are_preserved_after_soft_delete(
+    broker_session, director_context
+):
+    result = _bootstrap(ctx=director_context)
+    sid = result["session_id"]
+    admin_id = result["administrator_agent_id"]
+    director_id = result["director"]["agent_id"]
+
+    sent = broker.send_message(sid, admin_id, director_id, "audit me")
+    task_id = sent["task"]["id"]
+
+    broker.delete_session(sid)
+
+    with broker_session() as s:
+        tasks = s.query(Task).all()
+    assert any(t.task_id == task_id for t in tasks)
+
+
+def test_delete_session_cascade__idempotent_rerun_returns_zero_deregistered(director_context):
+    result = _bootstrap(ctx=director_context)
+    sid = result["session_id"]
+
+    first = broker.delete_session(sid)
+    second = broker.delete_session(sid)
+
+    assert first["deregistered_count"] == 2
+    assert second["deregistered_count"] == 0
+
+
+def test_delete_session_cascade__unknown_session_raises_click_exception():
+    """Deleting a session that was never created raises not-found.
+
+    The broker raises ``click.ClickException`` (exit 1 when the CLI layer
+    catches it) rather than ``click.UsageError`` (exit 2 with a Usage:
+    banner). Design 0000026 pins the exit code to 1 — same as
+    ``session show`` — because "not found" is a runtime condition, not a
+    CLI usage error.
+    """
+    fake_sid = str(uuid.uuid4())
+    with pytest.raises(click.ClickException) as exc_info:
+        broker.delete_session(fake_sid)
+    msg = str(exc_info.value)
+    assert "not found" in msg.lower()
+    assert fake_sid in msg
+
+
+# --- register_agent_on_soft_deleted_session: registration into a soft-deleted
+# session fails with a specific message. ---
+
+
+def test_register_agent_on_soft_deleted_session__rejects_soft_deleted_session_with_expected_error_string(
+    director_context,
+):
+    result = _bootstrap(ctx=director_context)
+    sid = result["session_id"]
+    broker.delete_session(sid)
+
+    with pytest.raises(click.UsageError) as exc_info:
+        broker.register_agent(
             session_id=sid,
-            name="regular-member",
-            description="regular member",
+            name="late-comer",
+            description="registering after soft delete",
+        )
+    msg = str(exc_info.value)
+    # Design doc exact wording: "session X is deleted"
+    assert "is deleted" in msg
+    assert sid in msg
+    # Must NOT use the "not found" path — the row still exists.
+    assert "not found" not in msg.lower()
+
+
+def test_register_agent_on_soft_deleted_session__unknown_session_still_says_not_found():
+    """Make sure the soft-delete guard did not replace the not-found path."""
+    with pytest.raises(click.UsageError) as exc_info:
+        broker.register_agent(
+            session_id=str(uuid.uuid4()),
+            name="stranger",
+            description="no such session",
+        )
+    assert "not found" in str(exc_info.value).lower()
+
+
+def test_list_sessions_filters_soft_deleted__hides_soft_deleted_sessions(director_context):
+    alive = _bootstrap(label="alive", ctx=director_context)
+    dead = _bootstrap(label="dead", ctx=director_context)
+    broker.delete_session(dead["session_id"])
+
+    sessions = broker.list_sessions()
+    ids = {s["session_id"] for s in sessions}
+
+    assert alive["session_id"] in ids
+    assert dead["session_id"] not in ids
+
+
+def test_list_sessions_filters_soft_deleted__get_session_still_returns_soft_deleted_row(
+    director_context,
+):
+    result = _bootstrap(label="dead-but-visible", ctx=director_context)
+    sid = result["session_id"]
+    broker.delete_session(sid)
+
+    row = broker.get_session(sid)
+    assert row is not None
+    assert row["deleted_at"] is not None
+
+
+def test_deregister_agent_root_director__rejects_root_director_with_specific_error(director_context):
+    result = _bootstrap(ctx=director_context)
+    director_id = result["director"]["agent_id"]
+
+    with pytest.raises(click.UsageError) as exc_info:
+        broker.deregister_agent(director_id)
+
+    msg = str(exc_info.value)
+    assert "cannot deregister the root Director" in msg
+    assert "cafleet session delete" in msg
+
+
+def test_deregister_agent_root_director__state_unchanged_after_rejection(broker_session, director_context):
+    result = _bootstrap(ctx=director_context)
+    director_id = result["director"]["agent_id"]
+    sid = result["session_id"]
+
+    with pytest.raises(click.UsageError):
+        broker.deregister_agent(director_id)
+
+    with broker_session() as s:
+        d_row = s.query(Agent).filter(Agent.agent_id == director_id).one()
+        p_row = (
+            s.query(AgentPlacement)
+            .filter(AgentPlacement.agent_id == director_id)
+            .one()
+        )
+        sess_row = (
+            s.query(SessionModel).filter(SessionModel.session_id == sid).one()
         )
 
-        assert broker.deregister_agent(member["agent_id"]) is True
+    assert d_row.status == "active"
+    assert d_row.deregistered_at is None
+    assert p_row.tmux_pane_id == director_context.pane_id
+    assert sess_row.director_agent_id == director_id
 
 
-class TestMemberToDirectorNotification:
-    """After bootstrap, sending to the root Director triggers a tmux push."""
+def test_deregister_agent_root_director__non_root_director_agent_can_still_be_deregistered(director_context):
+    result = _bootstrap(ctx=director_context)
+    sid = result["session_id"]
 
-    def test_send_message_invokes_send_poll_trigger_with_director_pane(
-        self, director_context, monkeypatch
-    ):
-        mock_trigger = Mock(return_value=True)
-        monkeypatch.setattr("cafleet.tmux.send_poll_trigger", mock_trigger)
+    member = broker.register_agent(
+        session_id=sid,
+        name="regular-member",
+        description="regular member",
+    )
 
-        result = broker.create_session(
-            label="notify", director_context=director_context
-        )
-        sid = result["session_id"]
-        root_director_id = result["director"]["agent_id"]
+    assert broker.deregister_agent(member["agent_id"]) is True
 
-        member = broker.register_agent(
-            session_id=sid,
-            name="member",
-            description="member under the root Director",
-            placement={
-                "director_agent_id": root_director_id,
-                "tmux_session": "main",
-                "tmux_window_id": "@1",
-                "tmux_pane_id": "%1",
-                "coding_agent": "claude",
-            },
-        )
 
-        response = broker.send_message(
-            sid, member["agent_id"], to=root_director_id, text="hi director"
-        )
+# --- member_to_director_notification: after bootstrap, sending to the root
+# Director triggers a tmux push. ---
 
-        assert response["notification_sent"] is True
-        assert mock_trigger.call_count == 1
-        kwargs = mock_trigger.call_args.kwargs
-        assert kwargs["target_pane_id"] == director_context.pane_id
-        assert kwargs["session_id"] == sid
-        assert kwargs["agent_id"] == root_director_id
+
+def test_member_to_director_notification__send_message_invokes_send_poll_trigger_with_director_pane(
+    director_context, monkeypatch
+):
+    mock_trigger = Mock(return_value=True)
+    monkeypatch.setattr("cafleet.tmux.send_poll_trigger", mock_trigger)
+
+    result = broker.create_session(
+        label="notify", director_context=director_context
+    )
+    sid = result["session_id"]
+    root_director_id = result["director"]["agent_id"]
+
+    member = broker.register_agent(
+        session_id=sid,
+        name="member",
+        description="member under the root Director",
+        placement={
+            "director_agent_id": root_director_id,
+            "tmux_session": "main",
+            "tmux_window_id": "@1",
+            "tmux_pane_id": "%1",
+            "coding_agent": "claude",
+        },
+    )
+
+    response = broker.send_message(
+        sid, member["agent_id"], to=root_director_id, text="hi director"
+    )
+
+    assert response["notification_sent"] is True
+    assert mock_trigger.call_count == 1
+    kwargs = mock_trigger.call_args.kwargs
+    assert kwargs["target_pane_id"] == director_context.pane_id
+    assert kwargs["session_id"] == sid
+    assert kwargs["agent_id"] == root_director_id

--- a/cafleet/tests/test_session_bootstrap.py
+++ b/cafleet/tests/test_session_bootstrap.py
@@ -57,7 +57,9 @@ def _bootstrap(label: str | None = None, ctx: DirectorContext | None = None) -> 
 # Director + placement + Admin. ---
 
 
-def test_create_session_bootstrap__returns_nested_dict_with_required_top_level_keys(director_context):
+def test_create_session_bootstrap__returns_nested_dict_with_required_top_level_keys(
+    director_context,
+):
     result = _bootstrap(label="bootstrap-1", ctx=director_context)
     assert isinstance(result, dict)
     for key in (
@@ -70,14 +72,18 @@ def test_create_session_bootstrap__returns_nested_dict_with_required_top_level_k
         assert key in result, f"missing top-level key {key!r} in {result!r}"
 
 
-def test_create_session_bootstrap__director_sub_dict_has_required_keys(director_context):
+def test_create_session_bootstrap__director_sub_dict_has_required_keys(
+    director_context,
+):
     result = _bootstrap(ctx=director_context)
     director = result["director"]
     for key in ("agent_id", "name", "description", "registered_at", "placement"):
         assert key in director, f"missing director key {key!r} in {director!r}"
 
 
-def test_create_session_bootstrap__director_name_and_description_are_hardcoded(director_context):
+def test_create_session_bootstrap__director_name_and_description_are_hardcoded(
+    director_context,
+):
     result = _bootstrap(ctx=director_context)
     assert result["director"]["name"] == "Director"
     assert result["director"]["description"] == "Root Director for this session"
@@ -96,7 +102,9 @@ def test_create_session_bootstrap__placement_sub_dict_matches_director_context_a
     assert "created_at" in placement
 
 
-def test_create_session_bootstrap__writes_exactly_one_session_row(broker_session, director_context):
+def test_create_session_bootstrap__writes_exactly_one_session_row(
+    broker_session, director_context
+):
     result = _bootstrap(ctx=director_context)
     with broker_session() as s:
         rows = s.query(SessionModel).all()
@@ -169,9 +177,7 @@ def test_create_session_bootstrap__administrator_registered_at_equals_session_cr
     admin_id = result["administrator_agent_id"]
 
     with broker_session() as s:
-        session_row = (
-            s.query(SessionModel).filter(SessionModel.session_id == sid).one()
-        )
+        session_row = s.query(SessionModel).filter(SessionModel.session_id == sid).one()
         admin_row = s.query(Agent).filter(Agent.agent_id == admin_id).one()
 
     assert admin_row.registered_at == session_row.created_at
@@ -306,7 +312,9 @@ def test_delete_session_cascade__tasks_are_preserved_after_soft_delete(
     assert any(t.task_id == task_id for t in tasks)
 
 
-def test_delete_session_cascade__idempotent_rerun_returns_zero_deregistered(director_context):
+def test_delete_session_cascade__idempotent_rerun_returns_zero_deregistered(
+    director_context,
+):
     result = _bootstrap(ctx=director_context)
     sid = result["session_id"]
 
@@ -370,7 +378,9 @@ def test_register_agent_on_soft_deleted_session__unknown_session_still_says_not_
     assert "not found" in str(exc_info.value).lower()
 
 
-def test_list_sessions_filters_soft_deleted__hides_soft_deleted_sessions(director_context):
+def test_list_sessions_filters_soft_deleted__hides_soft_deleted_sessions(
+    director_context,
+):
     alive = _bootstrap(label="alive", ctx=director_context)
     dead = _bootstrap(label="dead", ctx=director_context)
     broker.delete_session(dead["session_id"])
@@ -394,7 +404,9 @@ def test_list_sessions_filters_soft_deleted__get_session_still_returns_soft_dele
     assert row["deleted_at"] is not None
 
 
-def test_deregister_agent_root_director__rejects_root_director_with_specific_error(director_context):
+def test_deregister_agent_root_director__rejects_root_director_with_specific_error(
+    director_context,
+):
     result = _bootstrap(ctx=director_context)
     director_id = result["director"]["agent_id"]
 
@@ -406,7 +418,9 @@ def test_deregister_agent_root_director__rejects_root_director_with_specific_err
     assert "cafleet session delete" in msg
 
 
-def test_deregister_agent_root_director__state_unchanged_after_rejection(broker_session, director_context):
+def test_deregister_agent_root_director__state_unchanged_after_rejection(
+    broker_session, director_context
+):
     result = _bootstrap(ctx=director_context)
     director_id = result["director"]["agent_id"]
     sid = result["session_id"]
@@ -417,13 +431,9 @@ def test_deregister_agent_root_director__state_unchanged_after_rejection(broker_
     with broker_session() as s:
         d_row = s.query(Agent).filter(Agent.agent_id == director_id).one()
         p_row = (
-            s.query(AgentPlacement)
-            .filter(AgentPlacement.agent_id == director_id)
-            .one()
+            s.query(AgentPlacement).filter(AgentPlacement.agent_id == director_id).one()
         )
-        sess_row = (
-            s.query(SessionModel).filter(SessionModel.session_id == sid).one()
-        )
+        sess_row = s.query(SessionModel).filter(SessionModel.session_id == sid).one()
 
     assert d_row.status == "active"
     assert d_row.deregistered_at is None
@@ -431,7 +441,9 @@ def test_deregister_agent_root_director__state_unchanged_after_rejection(broker_
     assert sess_row.director_agent_id == director_id
 
 
-def test_deregister_agent_root_director__non_root_director_agent_can_still_be_deregistered(director_context):
+def test_deregister_agent_root_director__non_root_director_agent_can_still_be_deregistered(
+    director_context,
+):
     result = _bootstrap(ctx=director_context)
     sid = result["session_id"]
 
@@ -454,9 +466,7 @@ def test_member_to_director_notification__send_message_invokes_send_poll_trigger
     mock_trigger = Mock(return_value=True)
     monkeypatch.setattr("cafleet.tmux.send_poll_trigger", mock_trigger)
 
-    result = broker.create_session(
-        label="notify", director_context=director_context
-    )
+    result = broker.create_session(label="notify", director_context=director_context)
     sid = result["session_id"]
     root_director_id = result["director"]["agent_id"]
 

--- a/cafleet/tests/test_session_cli.py
+++ b/cafleet/tests/test_session_cli.py
@@ -205,7 +205,9 @@ def test_session_create__each_create_mints_unique_id(tmp_path, monkeypatch):
     assert len(rows) == 2
 
 
-def test_session_create__json_output_includes_administrator_agent_id(tmp_path, monkeypatch):
+def test_session_create__json_output_includes_administrator_agent_id(
+    tmp_path, monkeypatch
+):
     db_file = tmp_path / "registry.db"
     monkeypatch.setattr(
         config.settings,
@@ -223,7 +225,9 @@ def test_session_create__json_output_includes_administrator_agent_id(tmp_path, m
     uuid.UUID(data["administrator_agent_id"])
 
 
-def test_session_create__json_administrator_agent_id_matches_db_row(tmp_path, monkeypatch):
+def test_session_create__json_administrator_agent_id_matches_db_row(
+    tmp_path, monkeypatch
+):
     db_file = tmp_path / "registry.db"
     monkeypatch.setattr(
         config.settings,
@@ -438,7 +442,9 @@ def test_session_show__missing_session_exits_nonzero(tmp_path, monkeypatch):
     assert "not found" in output_lower
 
 
-def test_session_show__soft_deleted_session_surfaces_deleted_at_line(tmp_path, monkeypatch):
+def test_session_show__soft_deleted_session_surfaces_deleted_at_line(
+    tmp_path, monkeypatch
+):
     """Design 0000026: ``get_session`` intentionally returns soft-deleted
     rows (exposing ``deleted_at`` for audit), but pre-fix the text output
     dropped that field, so a soft-deleted session was visually identical
@@ -476,7 +482,9 @@ def test_session_show__soft_deleted_session_surfaces_deleted_at_line(tmp_path, m
     assert "2026-04-16T10:00:00+00:00" in result.output
 
 
-def test_session_show__active_session_does_not_print_deleted_at_line(tmp_path, monkeypatch):
+def test_session_show__active_session_does_not_print_deleted_at_line(
+    tmp_path, monkeypatch
+):
     """Symmetric check: an active (``deleted_at IS NULL``) session must
     NOT show a ``deleted_at:`` line — otherwise users would see a blank
     or misleading field on every healthy session.
@@ -539,7 +547,9 @@ def test_session_delete__delete_nonexistent_session(tmp_path, monkeypatch):
     assert result.exception is None or isinstance(result.exception, SystemExit)
 
 
-def test_session_delete__delete_session_with_active_agents_succeeds(tmp_path, monkeypatch):
+def test_session_delete__delete_session_with_active_agents_succeeds(
+    tmp_path, monkeypatch
+):
     """Session with active agents soft-deletes successfully and flips them
     to ``deregistered``.
 
@@ -568,7 +578,9 @@ def test_session_delete__delete_session_with_active_agents_succeeds(tmp_path, mo
     assert _session_deleted_at(db_file, sid) is not None
 
 
-def test_session_delete__delete_session_with_deregistered_agents_succeeds(tmp_path, monkeypatch):
+def test_session_delete__delete_session_with_deregistered_agents_succeeds(
+    tmp_path, monkeypatch
+):
     db_file = tmp_path / "registry.db"
     monkeypatch.setattr(
         config.settings,

--- a/cafleet/tests/test_session_cli.py
+++ b/cafleet/tests/test_session_cli.py
@@ -96,527 +96,538 @@ def _session_deleted_at(db_path, session_id: str) -> str | None:
     return None if row is None else row[0]
 
 
-class TestSessionCreate:
-    def test_creates_session_with_uuid(self, tmp_path, monkeypatch):
-        db_file = tmp_path / "registry.db"
-        monkeypatch.setattr(
-            config.settings,
-            "database_url",
-            f"sqlite+aiosqlite:///{db_file}",
-        )
-        runner = CliRunner()
-        _init_db(runner)
+def test_session_create__creates_session_with_uuid(tmp_path, monkeypatch):
+    db_file = tmp_path / "registry.db"
+    monkeypatch.setattr(
+        config.settings,
+        "database_url",
+        f"sqlite+aiosqlite:///{db_file}",
+    )
+    runner = CliRunner()
+    _init_db(runner)
 
-        result = runner.invoke(cli, ["session", "create"])
+    result = runner.invoke(cli, ["session", "create"])
 
-        assert result.exit_code == 0, result.output
-        output = result.output.strip()
-        found_uuid = None
-        for word in output.split():
-            try:
-                uuid.UUID(word)
-                found_uuid = word
-                break
-            except ValueError:
-                continue
-        assert found_uuid is not None
-
-        rows = _session_rows(db_file)
-        session_ids = [r[0] for r in rows]
-        assert found_uuid in session_ids
-
-    def test_creates_session_with_label(self, tmp_path, monkeypatch):
-        db_file = tmp_path / "registry.db"
-        monkeypatch.setattr(
-            config.settings,
-            "database_url",
-            f"sqlite+aiosqlite:///{db_file}",
-        )
-        runner = CliRunner()
-        _init_db(runner)
-
-        result = runner.invoke(cli, ["session", "create", "--label", "PR-42 review"])
-
-        assert result.exit_code == 0, result.output
-
-        rows = _session_rows(db_file)
-        assert len(rows) == 1
-        assert rows[0][1] == "PR-42 review"
-
-    def test_creates_session_without_label(self, tmp_path, monkeypatch):
-        db_file = tmp_path / "registry.db"
-        monkeypatch.setattr(
-            config.settings,
-            "database_url",
-            f"sqlite+aiosqlite:///{db_file}",
-        )
-        runner = CliRunner()
-        _init_db(runner)
-
-        result = runner.invoke(cli, ["session", "create"])
-        assert result.exit_code == 0
-
-        rows = _session_rows(db_file)
-        assert len(rows) == 1
-        assert rows[0][1] is None
-
-    def test_creates_session_json_output(self, tmp_path, monkeypatch):
-        db_file = tmp_path / "registry.db"
-        monkeypatch.setattr(
-            config.settings,
-            "database_url",
-            f"sqlite+aiosqlite:///{db_file}",
-        )
-        runner = CliRunner()
-        _init_db(runner)
-
-        result = runner.invoke(cli, ["session", "create", "--label", "test", "--json"])
-
-        assert result.exit_code == 0, result.output
-        data = json.loads(result.output)
-        assert "session_id" in data
-        uuid.UUID(data["session_id"])
-        assert data["label"] == "test"
-
-    def test_each_create_mints_unique_id(self, tmp_path, monkeypatch):
-        db_file = tmp_path / "registry.db"
-        monkeypatch.setattr(
-            config.settings,
-            "database_url",
-            f"sqlite+aiosqlite:///{db_file}",
-        )
-        runner = CliRunner()
-        _init_db(runner)
-
-        r1 = runner.invoke(cli, ["session", "create", "--json"])
-        r2 = runner.invoke(cli, ["session", "create", "--json"])
-
-        assert r1.exit_code == 0
-        assert r2.exit_code == 0
-
-        id1 = json.loads(r1.output)["session_id"]
-        id2 = json.loads(r2.output)["session_id"]
-        assert id1 != id2
-
-        rows = _session_rows(db_file)
-        assert len(rows) == 2
-
-    def test_json_output_includes_administrator_agent_id(self, tmp_path, monkeypatch):
-        db_file = tmp_path / "registry.db"
-        monkeypatch.setattr(
-            config.settings,
-            "database_url",
-            f"sqlite+aiosqlite:///{db_file}",
-        )
-        runner = CliRunner()
-        _init_db(runner)
-
-        result = runner.invoke(cli, ["session", "create", "--json"])
-
-        assert result.exit_code == 0, result.output
-        data = json.loads(result.output)
-        assert "administrator_agent_id" in data
-        uuid.UUID(data["administrator_agent_id"])
-
-    def test_json_administrator_agent_id_matches_db_row(self, tmp_path, monkeypatch):
-        db_file = tmp_path / "registry.db"
-        monkeypatch.setattr(
-            config.settings,
-            "database_url",
-            f"sqlite+aiosqlite:///{db_file}",
-        )
-        runner = CliRunner()
-        _init_db(runner)
-
-        result = runner.invoke(cli, ["session", "create", "--json"])
-        assert result.exit_code == 0
-        data = json.loads(result.output)
-        sid = data["session_id"]
-        admin_id = data["administrator_agent_id"]
-
-        conn = sqlite3.connect(str(db_file))
+    assert result.exit_code == 0, result.output
+    output = result.output.strip()
+    found_uuid = None
+    for word in output.split():
         try:
-            rows = conn.execute(
-                "SELECT agent_id, session_id, name, status, agent_card_json "
-                "FROM agents WHERE agent_id = ?",
-                (admin_id,),
-            ).fetchall()
-        finally:
-            conn.close()
+            uuid.UUID(word)
+            found_uuid = word
+            break
+        except ValueError:
+            continue
+    assert found_uuid is not None
 
-        assert len(rows) == 1
-        _row_agent_id, row_session_id, row_name, row_status, row_card_json = rows[0]
-        assert row_session_id == sid
-        assert row_name == "Administrator"
-        assert row_status == "active"
-        card = json.loads(row_card_json)
-        assert card["cafleet"]["kind"] == "builtin-administrator"
-
-    # NOTE: the former ``test_non_json_output_unchanged_single_uuid_line``
-    # (design 0000025 §B guard that the text path prints exactly one line)
-    # is deliberately removed here. Design 0000026 §CLI-surface supersedes
-    # that contract with a 7-line text shape (session_id, director
-    # agent_id, label, created_at, director_name, pane, administrator).
-    # The equivalent assertions for the NEW shape live in
-    # ``test_cli_session_bootstrap.py::TestSessionCreateTextOutput``.
+    rows = _session_rows(db_file)
+    session_ids = [r[0] for r in rows]
+    assert found_uuid in session_ids
 
 
-class TestSessionList:
-    def test_lists_empty(self, tmp_path, monkeypatch):
-        db_file = tmp_path / "registry.db"
-        monkeypatch.setattr(
-            config.settings,
-            "database_url",
-            f"sqlite+aiosqlite:///{db_file}",
+def test_session_create__creates_session_with_label(tmp_path, monkeypatch):
+    db_file = tmp_path / "registry.db"
+    monkeypatch.setattr(
+        config.settings,
+        "database_url",
+        f"sqlite+aiosqlite:///{db_file}",
+    )
+    runner = CliRunner()
+    _init_db(runner)
+
+    result = runner.invoke(cli, ["session", "create", "--label", "PR-42 review"])
+
+    assert result.exit_code == 0, result.output
+
+    rows = _session_rows(db_file)
+    assert len(rows) == 1
+    assert rows[0][1] == "PR-42 review"
+
+
+def test_session_create__creates_session_without_label(tmp_path, monkeypatch):
+    db_file = tmp_path / "registry.db"
+    monkeypatch.setattr(
+        config.settings,
+        "database_url",
+        f"sqlite+aiosqlite:///{db_file}",
+    )
+    runner = CliRunner()
+    _init_db(runner)
+
+    result = runner.invoke(cli, ["session", "create"])
+    assert result.exit_code == 0
+
+    rows = _session_rows(db_file)
+    assert len(rows) == 1
+    assert rows[0][1] is None
+
+
+def test_session_create__creates_session_json_output(tmp_path, monkeypatch):
+    db_file = tmp_path / "registry.db"
+    monkeypatch.setattr(
+        config.settings,
+        "database_url",
+        f"sqlite+aiosqlite:///{db_file}",
+    )
+    runner = CliRunner()
+    _init_db(runner)
+
+    result = runner.invoke(cli, ["session", "create", "--label", "test", "--json"])
+
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    assert "session_id" in data
+    uuid.UUID(data["session_id"])
+    assert data["label"] == "test"
+
+
+def test_session_create__each_create_mints_unique_id(tmp_path, monkeypatch):
+    db_file = tmp_path / "registry.db"
+    monkeypatch.setattr(
+        config.settings,
+        "database_url",
+        f"sqlite+aiosqlite:///{db_file}",
+    )
+    runner = CliRunner()
+    _init_db(runner)
+
+    r1 = runner.invoke(cli, ["session", "create", "--json"])
+    r2 = runner.invoke(cli, ["session", "create", "--json"])
+
+    assert r1.exit_code == 0
+    assert r2.exit_code == 0
+
+    id1 = json.loads(r1.output)["session_id"]
+    id2 = json.loads(r2.output)["session_id"]
+    assert id1 != id2
+
+    rows = _session_rows(db_file)
+    assert len(rows) == 2
+
+
+def test_session_create__json_output_includes_administrator_agent_id(tmp_path, monkeypatch):
+    db_file = tmp_path / "registry.db"
+    monkeypatch.setattr(
+        config.settings,
+        "database_url",
+        f"sqlite+aiosqlite:///{db_file}",
+    )
+    runner = CliRunner()
+    _init_db(runner)
+
+    result = runner.invoke(cli, ["session", "create", "--json"])
+
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    assert "administrator_agent_id" in data
+    uuid.UUID(data["administrator_agent_id"])
+
+
+def test_session_create__json_administrator_agent_id_matches_db_row(tmp_path, monkeypatch):
+    db_file = tmp_path / "registry.db"
+    monkeypatch.setattr(
+        config.settings,
+        "database_url",
+        f"sqlite+aiosqlite:///{db_file}",
+    )
+    runner = CliRunner()
+    _init_db(runner)
+
+    result = runner.invoke(cli, ["session", "create", "--json"])
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    sid = data["session_id"]
+    admin_id = data["administrator_agent_id"]
+
+    conn = sqlite3.connect(str(db_file))
+    try:
+        rows = conn.execute(
+            "SELECT agent_id, session_id, name, status, agent_card_json "
+            "FROM agents WHERE agent_id = ?",
+            (admin_id,),
+        ).fetchall()
+    finally:
+        conn.close()
+
+    assert len(rows) == 1
+    _row_agent_id, row_session_id, row_name, row_status, row_card_json = rows[0]
+    assert row_session_id == sid
+    assert row_name == "Administrator"
+    assert row_status == "active"
+    card = json.loads(row_card_json)
+    assert card["cafleet"]["kind"] == "builtin-administrator"
+
+
+# NOTE: the former ``test_non_json_output_unchanged_single_uuid_line``
+# (design 0000025 §B guard that the text path prints exactly one line)
+# is deliberately removed here. Design 0000026 §CLI-surface supersedes
+# that contract with a 7-line text shape (session_id, director
+# agent_id, label, created_at, director_name, pane, administrator).
+# The equivalent assertions for the NEW shape live in
+# ``test_cli_session_bootstrap.py::test_session_create_text_output__*``.
+
+
+def test_session_list__lists_empty(tmp_path, monkeypatch):
+    db_file = tmp_path / "registry.db"
+    monkeypatch.setattr(
+        config.settings,
+        "database_url",
+        f"sqlite+aiosqlite:///{db_file}",
+    )
+    runner = CliRunner()
+    _init_db(runner)
+
+    result = runner.invoke(cli, ["session", "list"])
+
+    assert result.exit_code == 0, result.output
+
+
+def test_session_list__lists_sessions_with_agent_count(tmp_path, monkeypatch):
+    db_file = tmp_path / "registry.db"
+    monkeypatch.setattr(
+        config.settings,
+        "database_url",
+        f"sqlite+aiosqlite:///{db_file}",
+    )
+    runner = CliRunner()
+    _init_db(runner)
+
+    sid = str(uuid.uuid4())
+    _seed_session(db_file, sid, label="test-session")
+    _seed_agent(db_file, str(uuid.uuid4()), sid, status="active")
+    _seed_agent(db_file, str(uuid.uuid4()), sid, status="active")
+    _seed_agent(db_file, str(uuid.uuid4()), sid, status="deregistered")
+
+    result = runner.invoke(cli, ["session", "list"])
+
+    assert result.exit_code == 0
+    assert sid in result.output
+    assert "test-session" in result.output
+
+
+def test_session_list__lists_json_output(tmp_path, monkeypatch):
+    db_file = tmp_path / "registry.db"
+    monkeypatch.setattr(
+        config.settings,
+        "database_url",
+        f"sqlite+aiosqlite:///{db_file}",
+    )
+    runner = CliRunner()
+    _init_db(runner)
+
+    sid = str(uuid.uuid4())
+    _seed_session(db_file, sid, label="json-test")
+    _seed_agent(db_file, str(uuid.uuid4()), sid, status="active")
+
+    result = runner.invoke(cli, ["session", "list", "--json"])
+
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert isinstance(data, list)
+    assert len(data) == 1
+    assert data[0]["session_id"] == sid
+    assert data[0]["label"] == "json-test"
+    assert data[0]["agent_count"] == 1
+
+
+def test_session_list__lists_multiple_sessions(tmp_path, monkeypatch):
+    db_file = tmp_path / "registry.db"
+    monkeypatch.setattr(
+        config.settings,
+        "database_url",
+        f"sqlite+aiosqlite:///{db_file}",
+    )
+    runner = CliRunner()
+    _init_db(runner)
+
+    sid_a = str(uuid.uuid4())
+    sid_b = str(uuid.uuid4())
+    _seed_session(db_file, sid_a, label="session-a")
+    _seed_session(db_file, sid_b, label="session-b")
+
+    result = runner.invoke(cli, ["session", "list", "--json"])
+
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert len(data) == 2
+    ids = {d["session_id"] for d in data}
+    assert sid_a in ids
+    assert sid_b in ids
+
+
+def test_session_list__agent_count_only_active(tmp_path, monkeypatch):
+    db_file = tmp_path / "registry.db"
+    monkeypatch.setattr(
+        config.settings,
+        "database_url",
+        f"sqlite+aiosqlite:///{db_file}",
+    )
+    runner = CliRunner()
+    _init_db(runner)
+
+    sid = str(uuid.uuid4())
+    _seed_session(db_file, sid)
+    _seed_agent(db_file, str(uuid.uuid4()), sid, status="active")
+    _seed_agent(db_file, str(uuid.uuid4()), sid, status="deregistered")
+    _seed_agent(db_file, str(uuid.uuid4()), sid, status="deregistered")
+
+    result = runner.invoke(cli, ["session", "list", "--json"])
+
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert data[0]["agent_count"] == 1
+
+
+def test_session_show__shows_existing_session(tmp_path, monkeypatch):
+    db_file = tmp_path / "registry.db"
+    monkeypatch.setattr(
+        config.settings,
+        "database_url",
+        f"sqlite+aiosqlite:///{db_file}",
+    )
+    runner = CliRunner()
+    _init_db(runner)
+
+    sid = str(uuid.uuid4())
+    _seed_session(db_file, sid, label="show-test")
+
+    result = runner.invoke(cli, ["session", "show", sid])
+
+    assert result.exit_code == 0, result.output
+    assert sid in result.output
+    assert "show-test" in result.output
+
+
+def test_session_show__shows_json_output(tmp_path, monkeypatch):
+    db_file = tmp_path / "registry.db"
+    monkeypatch.setattr(
+        config.settings,
+        "database_url",
+        f"sqlite+aiosqlite:///{db_file}",
+    )
+    runner = CliRunner()
+    _init_db(runner)
+
+    sid = str(uuid.uuid4())
+    _seed_session(db_file, sid, label="json-show")
+
+    result = runner.invoke(cli, ["session", "show", sid, "--json"])
+
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert data["session_id"] == sid
+    assert data["label"] == "json-show"
+    assert "created_at" in data
+
+
+def test_session_show__missing_session_exits_nonzero(tmp_path, monkeypatch):
+    db_file = tmp_path / "registry.db"
+    monkeypatch.setattr(
+        config.settings,
+        "database_url",
+        f"sqlite+aiosqlite:///{db_file}",
+    )
+    runner = CliRunner()
+    _init_db(runner)
+
+    fake_id = str(uuid.uuid4())
+    result = runner.invoke(cli, ["session", "show", fake_id])
+
+    assert result.exit_code == 1, result.output
+    output_lower = result.output.lower()
+    assert "not found" in output_lower
+
+
+def test_session_show__soft_deleted_session_surfaces_deleted_at_line(tmp_path, monkeypatch):
+    """Design 0000026: ``get_session`` intentionally returns soft-deleted
+    rows (exposing ``deleted_at`` for audit), but pre-fix the text output
+    dropped that field, so a soft-deleted session was visually identical
+    to an active one. This regression guard pins the new behavior: when
+    ``deleted_at`` is non-NULL, text output includes a ``deleted_at:``
+    line so users can distinguish it without parsing JSON.
+    """
+    db_file = tmp_path / "registry.db"
+    monkeypatch.setattr(
+        config.settings,
+        "database_url",
+        f"sqlite+aiosqlite:///{db_file}",
+    )
+    runner = CliRunner()
+    _init_db(runner)
+
+    sid = str(uuid.uuid4())
+    _seed_session(db_file, sid, label="audit-me")
+    # Flip deleted_at directly; bypass the cascade so the rest of the DB
+    # stays untouched and we only pin the show-output behavior.
+    conn = sqlite3.connect(str(db_file))
+    try:
+        conn.execute(
+            "UPDATE sessions SET deleted_at = ? WHERE session_id = ?",
+            ("2026-04-16T10:00:00+00:00", sid),
         )
-        runner = CliRunner()
-        _init_db(runner)
+        conn.commit()
+    finally:
+        conn.close()
 
-        result = runner.invoke(cli, ["session", "list"])
+    result = runner.invoke(cli, ["session", "show", sid])
 
-        assert result.exit_code == 0, result.output
-
-    def test_lists_sessions_with_agent_count(self, tmp_path, monkeypatch):
-        db_file = tmp_path / "registry.db"
-        monkeypatch.setattr(
-            config.settings,
-            "database_url",
-            f"sqlite+aiosqlite:///{db_file}",
-        )
-        runner = CliRunner()
-        _init_db(runner)
-
-        sid = str(uuid.uuid4())
-        _seed_session(db_file, sid, label="test-session")
-        _seed_agent(db_file, str(uuid.uuid4()), sid, status="active")
-        _seed_agent(db_file, str(uuid.uuid4()), sid, status="active")
-        _seed_agent(db_file, str(uuid.uuid4()), sid, status="deregistered")
-
-        result = runner.invoke(cli, ["session", "list"])
-
-        assert result.exit_code == 0
-        assert sid in result.output
-        assert "test-session" in result.output
-
-    def test_lists_json_output(self, tmp_path, monkeypatch):
-        db_file = tmp_path / "registry.db"
-        monkeypatch.setattr(
-            config.settings,
-            "database_url",
-            f"sqlite+aiosqlite:///{db_file}",
-        )
-        runner = CliRunner()
-        _init_db(runner)
-
-        sid = str(uuid.uuid4())
-        _seed_session(db_file, sid, label="json-test")
-        _seed_agent(db_file, str(uuid.uuid4()), sid, status="active")
-
-        result = runner.invoke(cli, ["session", "list", "--json"])
-
-        assert result.exit_code == 0
-        data = json.loads(result.output)
-        assert isinstance(data, list)
-        assert len(data) == 1
-        assert data[0]["session_id"] == sid
-        assert data[0]["label"] == "json-test"
-        assert data[0]["agent_count"] == 1
-
-    def test_lists_multiple_sessions(self, tmp_path, monkeypatch):
-        db_file = tmp_path / "registry.db"
-        monkeypatch.setattr(
-            config.settings,
-            "database_url",
-            f"sqlite+aiosqlite:///{db_file}",
-        )
-        runner = CliRunner()
-        _init_db(runner)
-
-        sid_a = str(uuid.uuid4())
-        sid_b = str(uuid.uuid4())
-        _seed_session(db_file, sid_a, label="session-a")
-        _seed_session(db_file, sid_b, label="session-b")
-
-        result = runner.invoke(cli, ["session", "list", "--json"])
-
-        assert result.exit_code == 0
-        data = json.loads(result.output)
-        assert len(data) == 2
-        ids = {d["session_id"] for d in data}
-        assert sid_a in ids
-        assert sid_b in ids
-
-    def test_agent_count_only_active(self, tmp_path, monkeypatch):
-        db_file = tmp_path / "registry.db"
-        monkeypatch.setattr(
-            config.settings,
-            "database_url",
-            f"sqlite+aiosqlite:///{db_file}",
-        )
-        runner = CliRunner()
-        _init_db(runner)
-
-        sid = str(uuid.uuid4())
-        _seed_session(db_file, sid)
-        _seed_agent(db_file, str(uuid.uuid4()), sid, status="active")
-        _seed_agent(db_file, str(uuid.uuid4()), sid, status="deregistered")
-        _seed_agent(db_file, str(uuid.uuid4()), sid, status="deregistered")
-
-        result = runner.invoke(cli, ["session", "list", "--json"])
-
-        assert result.exit_code == 0
-        data = json.loads(result.output)
-        assert data[0]["agent_count"] == 1
+    assert result.exit_code == 0, result.output
+    assert "deleted_at:" in result.output
+    assert "2026-04-16T10:00:00+00:00" in result.output
 
 
-class TestSessionShow:
-    def test_shows_existing_session(self, tmp_path, monkeypatch):
-        db_file = tmp_path / "registry.db"
-        monkeypatch.setattr(
-            config.settings,
-            "database_url",
-            f"sqlite+aiosqlite:///{db_file}",
-        )
-        runner = CliRunner()
-        _init_db(runner)
+def test_session_show__active_session_does_not_print_deleted_at_line(tmp_path, monkeypatch):
+    """Symmetric check: an active (``deleted_at IS NULL``) session must
+    NOT show a ``deleted_at:`` line — otherwise users would see a blank
+    or misleading field on every healthy session.
+    """
+    db_file = tmp_path / "registry.db"
+    monkeypatch.setattr(
+        config.settings,
+        "database_url",
+        f"sqlite+aiosqlite:///{db_file}",
+    )
+    runner = CliRunner()
+    _init_db(runner)
 
-        sid = str(uuid.uuid4())
-        _seed_session(db_file, sid, label="show-test")
+    sid = str(uuid.uuid4())
+    _seed_session(db_file, sid, label="live-session")
 
-        result = runner.invoke(cli, ["session", "show", sid])
+    result = runner.invoke(cli, ["session", "show", sid])
 
-        assert result.exit_code == 0, result.output
-        assert sid in result.output
-        assert "show-test" in result.output
-
-    def test_shows_json_output(self, tmp_path, monkeypatch):
-        db_file = tmp_path / "registry.db"
-        monkeypatch.setattr(
-            config.settings,
-            "database_url",
-            f"sqlite+aiosqlite:///{db_file}",
-        )
-        runner = CliRunner()
-        _init_db(runner)
-
-        sid = str(uuid.uuid4())
-        _seed_session(db_file, sid, label="json-show")
-
-        result = runner.invoke(cli, ["session", "show", sid, "--json"])
-
-        assert result.exit_code == 0
-        data = json.loads(result.output)
-        assert data["session_id"] == sid
-        assert data["label"] == "json-show"
-        assert "created_at" in data
-
-    def test_missing_session_exits_nonzero(self, tmp_path, monkeypatch):
-        db_file = tmp_path / "registry.db"
-        monkeypatch.setattr(
-            config.settings,
-            "database_url",
-            f"sqlite+aiosqlite:///{db_file}",
-        )
-        runner = CliRunner()
-        _init_db(runner)
-
-        fake_id = str(uuid.uuid4())
-        result = runner.invoke(cli, ["session", "show", fake_id])
-
-        assert result.exit_code == 1, result.output
-        output_lower = result.output.lower()
-        assert "not found" in output_lower
-
-    def test_soft_deleted_session_surfaces_deleted_at_line(self, tmp_path, monkeypatch):
-        """Design 0000026: ``get_session`` intentionally returns soft-deleted
-        rows (exposing ``deleted_at`` for audit), but pre-fix the text output
-        dropped that field, so a soft-deleted session was visually identical
-        to an active one. This regression guard pins the new behavior: when
-        ``deleted_at`` is non-NULL, text output includes a ``deleted_at:``
-        line so users can distinguish it without parsing JSON.
-        """
-        db_file = tmp_path / "registry.db"
-        monkeypatch.setattr(
-            config.settings,
-            "database_url",
-            f"sqlite+aiosqlite:///{db_file}",
-        )
-        runner = CliRunner()
-        _init_db(runner)
-
-        sid = str(uuid.uuid4())
-        _seed_session(db_file, sid, label="audit-me")
-        # Flip deleted_at directly; bypass the cascade so the rest of the DB
-        # stays untouched and we only pin the show-output behavior.
-        conn = sqlite3.connect(str(db_file))
-        try:
-            conn.execute(
-                "UPDATE sessions SET deleted_at = ? WHERE session_id = ?",
-                ("2026-04-16T10:00:00+00:00", sid),
-            )
-            conn.commit()
-        finally:
-            conn.close()
-
-        result = runner.invoke(cli, ["session", "show", sid])
-
-        assert result.exit_code == 0, result.output
-        assert "deleted_at:" in result.output
-        assert "2026-04-16T10:00:00+00:00" in result.output
-
-    def test_active_session_does_not_print_deleted_at_line(self, tmp_path, monkeypatch):
-        """Symmetric check: an active (``deleted_at IS NULL``) session must
-        NOT show a ``deleted_at:`` line — otherwise users would see a blank
-        or misleading field on every healthy session.
-        """
-        db_file = tmp_path / "registry.db"
-        monkeypatch.setattr(
-            config.settings,
-            "database_url",
-            f"sqlite+aiosqlite:///{db_file}",
-        )
-        runner = CliRunner()
-        _init_db(runner)
-
-        sid = str(uuid.uuid4())
-        _seed_session(db_file, sid, label="live-session")
-
-        result = runner.invoke(cli, ["session", "show", sid])
-
-        assert result.exit_code == 0, result.output
-        assert "deleted_at" not in result.output
+    assert result.exit_code == 0, result.output
+    assert "deleted_at" not in result.output
 
 
-class TestSessionDelete:
-    def test_deletes_session(self, tmp_path, monkeypatch):
-        db_file = tmp_path / "registry.db"
-        monkeypatch.setattr(
-            config.settings,
-            "database_url",
-            f"sqlite+aiosqlite:///{db_file}",
-        )
-        runner = CliRunner()
-        _init_db(runner)
+def test_session_delete__deletes_session(tmp_path, monkeypatch):
+    db_file = tmp_path / "registry.db"
+    monkeypatch.setattr(
+        config.settings,
+        "database_url",
+        f"sqlite+aiosqlite:///{db_file}",
+    )
+    runner = CliRunner()
+    _init_db(runner)
 
-        sid = str(uuid.uuid4())
-        _seed_session(db_file, sid)
+    sid = str(uuid.uuid4())
+    _seed_session(db_file, sid)
 
-        result = runner.invoke(cli, ["session", "delete", sid])
+    result = runner.invoke(cli, ["session", "delete", sid])
 
-        assert result.exit_code == 0, result.output
-        # Soft delete: row stays but deleted_at is set, list_sessions hides it.
-        rows = _session_rows(db_file)
-        session_ids = [r[0] for r in rows]
-        assert sid in session_ids
-        assert _session_deleted_at(db_file, sid) is not None
-        assert "deleted" in result.output.lower()
-
-    def test_delete_nonexistent_session(self, tmp_path, monkeypatch):
-        db_file = tmp_path / "registry.db"
-        monkeypatch.setattr(
-            config.settings,
-            "database_url",
-            f"sqlite+aiosqlite:///{db_file}",
-        )
-        runner = CliRunner()
-        _init_db(runner)
-
-        fake_id = str(uuid.uuid4())
-        result = runner.invoke(cli, ["session", "delete", fake_id])
-
-        assert result.exception is None or isinstance(result.exception, SystemExit)
-
-    def test_delete_session_with_active_agents_succeeds(self, tmp_path, monkeypatch):
-        """Session with active agents soft-deletes successfully and flips them
-        to ``deregistered``.
-
-        Design 0000026: ``session delete`` is a soft delete that deregisters
-        every active agent in the session (including the root Director and
-        the Administrator) in the same transaction. The session row stays
-        but gains a ``deleted_at`` timestamp.
-        """
-        db_file = tmp_path / "registry.db"
-        monkeypatch.setattr(
-            config.settings,
-            "database_url",
-            f"sqlite+aiosqlite:///{db_file}",
-        )
-        runner = CliRunner()
-        _init_db(runner)
-
-        sid = str(uuid.uuid4())
-        _seed_session(db_file, sid)
-        _seed_agent(db_file, str(uuid.uuid4()), sid, status="active")
-        _seed_agent(db_file, str(uuid.uuid4()), sid, status="active")
-
-        result = runner.invoke(cli, ["session", "delete", sid])
-
-        assert result.exit_code == 0, result.output
-        assert _session_deleted_at(db_file, sid) is not None
-
-    def test_delete_session_with_deregistered_agents_succeeds(
-        self, tmp_path, monkeypatch
-    ):
-        db_file = tmp_path / "registry.db"
-        monkeypatch.setattr(
-            config.settings,
-            "database_url",
-            f"sqlite+aiosqlite:///{db_file}",
-        )
-        runner = CliRunner()
-        _init_db(runner)
-
-        sid = str(uuid.uuid4())
-        _seed_session(db_file, sid)
-        _seed_agent(db_file, str(uuid.uuid4()), sid, status="deregistered")
-
-        result = runner.invoke(cli, ["session", "delete", sid])
-
-        assert result.exit_code == 0, result.output
-        assert _session_deleted_at(db_file, sid) is not None
+    assert result.exit_code == 0, result.output
+    # Soft delete: row stays but deleted_at is set, list_sessions hides it.
+    rows = _session_rows(db_file)
+    session_ids = [r[0] for r in rows]
+    assert sid in session_ids
+    assert _session_deleted_at(db_file, sid) is not None
+    assert "deleted" in result.output.lower()
 
 
-class TestDbInitNoAutoSession:
-    def test_db_init_creates_no_sessions(self, tmp_path, monkeypatch):
-        db_file = tmp_path / "registry.db"
-        monkeypatch.setattr(
-            config.settings,
-            "database_url",
-            f"sqlite+aiosqlite:///{db_file}",
-        )
-        runner = CliRunner()
-        _init_db(runner)
+def test_session_delete__delete_nonexistent_session(tmp_path, monkeypatch):
+    db_file = tmp_path / "registry.db"
+    monkeypatch.setattr(
+        config.settings,
+        "database_url",
+        f"sqlite+aiosqlite:///{db_file}",
+    )
+    runner = CliRunner()
+    _init_db(runner)
 
-        rows = _session_rows(db_file)
-        assert len(rows) == 0
+    fake_id = str(uuid.uuid4())
+    result = runner.invoke(cli, ["session", "delete", fake_id])
+
+    assert result.exception is None or isinstance(result.exception, SystemExit)
 
 
-class TestSessionGroupStructure:
-    def test_session_group_exists(self, tmp_path, monkeypatch):
-        db_file = tmp_path / "registry.db"
-        monkeypatch.setattr(
-            config.settings,
-            "database_url",
-            f"sqlite+aiosqlite:///{db_file}",
-        )
-        runner = CliRunner()
-        result = runner.invoke(cli, ["session", "--help"])
+def test_session_delete__delete_session_with_active_agents_succeeds(tmp_path, monkeypatch):
+    """Session with active agents soft-deletes successfully and flips them
+    to ``deregistered``.
 
-        assert result.exit_code == 0, result.output
-        output_lower = result.output.lower()
-        assert "create" in output_lower
-        assert "list" in output_lower
-        assert "show" in output_lower
-        assert "delete" in output_lower
+    Design 0000026: ``session delete`` is a soft delete that deregisters
+    every active agent in the session (including the root Director and
+    the Administrator) in the same transaction. The session row stays
+    but gains a ``deleted_at`` timestamp.
+    """
+    db_file = tmp_path / "registry.db"
+    monkeypatch.setattr(
+        config.settings,
+        "database_url",
+        f"sqlite+aiosqlite:///{db_file}",
+    )
+    runner = CliRunner()
+    _init_db(runner)
 
-    def test_session_is_not_under_db(self, tmp_path, monkeypatch):
-        db_file = tmp_path / "registry.db"
-        monkeypatch.setattr(
-            config.settings,
-            "database_url",
-            f"sqlite+aiosqlite:///{db_file}",
-        )
-        runner = CliRunner()
-        result = runner.invoke(cli, ["db", "session", "create"])
+    sid = str(uuid.uuid4())
+    _seed_session(db_file, sid)
+    _seed_agent(db_file, str(uuid.uuid4()), sid, status="active")
+    _seed_agent(db_file, str(uuid.uuid4()), sid, status="active")
 
-        assert result.exit_code == 2, result.output
+    result = runner.invoke(cli, ["session", "delete", sid])
+
+    assert result.exit_code == 0, result.output
+    assert _session_deleted_at(db_file, sid) is not None
+
+
+def test_session_delete__delete_session_with_deregistered_agents_succeeds(tmp_path, monkeypatch):
+    db_file = tmp_path / "registry.db"
+    monkeypatch.setattr(
+        config.settings,
+        "database_url",
+        f"sqlite+aiosqlite:///{db_file}",
+    )
+    runner = CliRunner()
+    _init_db(runner)
+
+    sid = str(uuid.uuid4())
+    _seed_session(db_file, sid)
+    _seed_agent(db_file, str(uuid.uuid4()), sid, status="deregistered")
+
+    result = runner.invoke(cli, ["session", "delete", sid])
+
+    assert result.exit_code == 0, result.output
+    assert _session_deleted_at(db_file, sid) is not None
+
+
+def test_db_init_no_auto_session__db_init_creates_no_sessions(tmp_path, monkeypatch):
+    db_file = tmp_path / "registry.db"
+    monkeypatch.setattr(
+        config.settings,
+        "database_url",
+        f"sqlite+aiosqlite:///{db_file}",
+    )
+    runner = CliRunner()
+    _init_db(runner)
+
+    rows = _session_rows(db_file)
+    assert len(rows) == 0
+
+
+def test_session_group_structure__session_group_exists(tmp_path, monkeypatch):
+    db_file = tmp_path / "registry.db"
+    monkeypatch.setattr(
+        config.settings,
+        "database_url",
+        f"sqlite+aiosqlite:///{db_file}",
+    )
+    runner = CliRunner()
+    result = runner.invoke(cli, ["session", "--help"])
+
+    assert result.exit_code == 0, result.output
+    output_lower = result.output.lower()
+    assert "create" in output_lower
+    assert "list" in output_lower
+    assert "show" in output_lower
+    assert "delete" in output_lower
+
+
+def test_session_group_structure__session_is_not_under_db(tmp_path, monkeypatch):
+    db_file = tmp_path / "registry.db"
+    monkeypatch.setattr(
+        config.settings,
+        "database_url",
+        f"sqlite+aiosqlite:///{db_file}",
+    )
+    runner = CliRunner()
+    result = runner.invoke(cli, ["db", "session", "create"])
+
+    assert result.exit_code == 2, result.output

--- a/cafleet/tests/test_tmux.py
+++ b/cafleet/tests/test_tmux.py
@@ -5,423 +5,430 @@ import pytest
 from cafleet import tmux
 
 
-class TestEnsureTmuxAvailable:
-    def test_errors_when_tmux_missing(self, monkeypatch):
-        monkeypatch.setattr("shutil.which", lambda _: None)
-        monkeypatch.setenv("TMUX", "/tmp/tmux-1000/default,12345,0")
-        with pytest.raises(tmux.TmuxError, match="tmux binary not found on PATH"):
-            tmux.ensure_tmux_available()
-
-    def test_errors_when_tmux_env_unset(self, monkeypatch):
-        monkeypatch.setattr("shutil.which", lambda _: "/usr/bin/tmux")
-        monkeypatch.delenv("TMUX", raising=False)
-        with pytest.raises(tmux.TmuxError, match="must be run inside a tmux session"):
-            tmux.ensure_tmux_available()
+def test_ensure_tmux_available__errors_when_tmux_missing(monkeypatch):
+    monkeypatch.setattr("shutil.which", lambda _: None)
+    monkeypatch.setenv("TMUX", "/tmp/tmux-1000/default,12345,0")
+    with pytest.raises(tmux.TmuxError, match="tmux binary not found on PATH"):
+        tmux.ensure_tmux_available()
 
 
-class TestDirectorContext:
-    def test_parses_display_message(self, monkeypatch):
-        monkeypatch.setenv("TMUX_PANE", "%0")
-
-        def mock_run(args):
-            assert args == [
-                "tmux",
-                "display-message",
-                "-p",
-                "-t",
-                "%0",
-                "#{session_name}|#{window_id}|#{pane_id}",
-            ]
-            return "main|@3|%0\n"
-
-        monkeypatch.setattr(tmux, "_run", mock_run)
-        ctx = tmux.director_context()
-        assert ctx.session == "main"
-        assert ctx.window_id == "@3"
-        assert ctx.pane_id == "%0"
-
-    def test_errors_when_tmux_pane_unset(self, monkeypatch):
-        monkeypatch.delenv("TMUX_PANE", raising=False)
-        with pytest.raises(tmux.TmuxError, match="TMUX_PANE is not set"):
-            tmux.director_context()
+def test_ensure_tmux_available__errors_when_tmux_env_unset(monkeypatch):
+    monkeypatch.setattr("shutil.which", lambda _: "/usr/bin/tmux")
+    monkeypatch.delenv("TMUX", raising=False)
+    with pytest.raises(tmux.TmuxError, match="must be run inside a tmux session"):
+        tmux.ensure_tmux_available()
 
 
-class TestSplitWindow:
-    def test_returns_captured_pane_id(self, monkeypatch):
-        def mock_run(args):
-            assert args[0:3] == ["tmux", "split-window", "-t"]
-            assert "@3" in args
-            assert "-P" in args
-            assert "-F" in args
-            assert "#{pane_id}" in args
-            assert "-e" in args
-            return "%7\n"
+def test_director_context__parses_display_message(monkeypatch):
+    monkeypatch.setenv("TMUX_PANE", "%0")
 
-        monkeypatch.setattr(tmux, "_run", mock_run)
-        pane_id = tmux.split_window(
-            target_window_id="@3",
-            env={
-                "CAFLEET_DATABASE_URL": "sqlite+aiosqlite:////tmp/registry.db",
-            },
-            command=["claude", "Hello world"],
-        )
-        assert pane_id == "%7"
-
-    def test_command_appended_directly_to_args(self, monkeypatch):
-        captured_args = []
-
-        def mock_run(args):
-            captured_args.extend(args)
-            return "%8\n"
-
-        monkeypatch.setattr(tmux, "_run", mock_run)
-        tmux.split_window(
-            target_window_id="@5",
-            env={},
-            command=["my-binary", "--flag", "value", "prompt text"],
-        )
-        assert captured_args[-4:] == ["my-binary", "--flag", "value", "prompt text"]
-
-    def test_claude_style_command(self, monkeypatch):
-        captured_args = []
-
-        def mock_run(args):
-            captured_args.extend(args)
-            return "%9\n"
-
-        monkeypatch.setattr(tmux, "_run", mock_run)
-        tmux.split_window(
-            target_window_id="@3",
-            env={},
-            command=[
-                "claude",
-                (
-                    "Load Skill(cafleet). Your agent_id is "
-                    "7ba91234-5678-90ab-cdef-112233445566."
-                ),
-            ],
-        )
-        assert captured_args[-2] == "claude"
-        assert "Load Skill(cafleet)" in captured_args[-1]
-
-    def test_env_vars_forwarded_as_flags(self, monkeypatch):
-        """Only CAFLEET_DATABASE_URL is forwarded as -e KEY=VAL when set.
-
-        Design doc 0000023: session_id and agent_id are now passed as literal
-        CLI flags via the prompt text, not via tmux env inheritance. The only
-        env var that member-create forwards is CAFLEET_DATABASE_URL so the
-        spawned agent can reach the same SQLite file.
-        """
-        captured_args = []
-
-        def mock_run(args):
-            captured_args.extend(args)
-            return "%11\n"
-
-        monkeypatch.setattr(tmux, "_run", mock_run)
-        tmux.split_window(
-            target_window_id="@3",
-            env={
-                "CAFLEET_DATABASE_URL": "sqlite+aiosqlite:////tmp/registry.db",
-            },
-            command=["claude", "prompt"],
-        )
-        env_pairs = []
-        for i, a in enumerate(captured_args):
-            if a == "-e" and i + 1 < len(captured_args):
-                env_pairs.append(captured_args[i + 1])
-        assert "CAFLEET_DATABASE_URL=sqlite+aiosqlite:////tmp/registry.db" in env_pairs
-        for pair in env_pairs:
-            assert not pair.startswith("CAFLEET_SESSION_ID=")
-            assert not pair.startswith("CAFLEET_AGENT_ID=")
-            assert not pair.startswith("CAFLEET_URL=")
-
-    def test_empty_env_emits_no_e_flags(self, monkeypatch):
-        captured_args = []
-
-        def mock_run(args):
-            captured_args.extend(args)
-            return "%12\n"
-
-        monkeypatch.setattr(tmux, "_run", mock_run)
-        tmux.split_window(
-            target_window_id="@3",
-            env={},
-            command=["claude", "prompt"],
-        )
-        assert "-e" not in captured_args
-
-
-class TestSendExit:
-    def test_raises_tmuxerror_on_failure(self, monkeypatch):
-        def mock_run(args):
-            raise tmux.TmuxError("tmux command failed: server exited unexpectedly")
-
-        monkeypatch.setattr(tmux, "_run", mock_run)
-        with pytest.raises(tmux.TmuxError, match="server exited unexpectedly"):
-            tmux.send_exit(target_pane_id="%7")
-
-    def test_ignore_missing_swallows_pane_gone(self, monkeypatch):
-        def mock_run(args):
-            raise tmux.TmuxError(
-                "tmux command failed: tmux send-keys -t %99 /exit Enter\n"
-                "stderr: can't find pane: %99"
-            )
-
-        monkeypatch.setattr(tmux, "_run", mock_run)
-        tmux.send_exit(target_pane_id="%99", ignore_missing=True)
-
-    def test_ignore_missing_does_not_swallow_other_errors(self, monkeypatch):
-        def mock_run(args):
-            raise tmux.TmuxError("tmux command failed: server crashed")
-
-        monkeypatch.setattr(tmux, "_run", mock_run)
-        with pytest.raises(tmux.TmuxError, match="server crashed"):
-            tmux.send_exit(target_pane_id="%7", ignore_missing=True)
-
-
-class TestCapturePane:
-    def test_invokes_correct_args(self, monkeypatch):
-        captured_args = []
-
-        def mock_run(args):
-            captured_args.extend(args)
-            return "line 1\nline 2\n"
-
-        monkeypatch.setattr(tmux, "_run", mock_run)
-        result = tmux.capture_pane(target_pane_id="%7", lines=80)
-        assert captured_args == ["tmux", "capture-pane", "-p", "-t", "%7", "-S", "-80"]
-        assert result == "line 1\nline 2\n"
-
-    def test_raises_on_missing_pane(self, monkeypatch):
-        def mock_run(args):
-            raise tmux.TmuxError(
-                "tmux command failed: tmux capture-pane -p -t %99 -S -80\n"
-                "stderr: can't find pane: %99"
-            )
-
-        monkeypatch.setattr(tmux, "_run", mock_run)
-        with pytest.raises(tmux.TmuxError, match="can't find pane"):
-            tmux.capture_pane(target_pane_id="%99", lines=80)
-
-    def test_rejects_non_positive_lines(self, monkeypatch):
-        with pytest.raises(tmux.TmuxError, match="lines must be positive, got 0"):
-            tmux.capture_pane(target_pane_id="%7", lines=0)
-        with pytest.raises(tmux.TmuxError, match="lines must be positive, got -1"):
-            tmux.capture_pane(target_pane_id="%7", lines=-1)
-
-
-class TestSendPollTrigger:
-    def test_success_returns_true(self, monkeypatch):
-        """``--session-id`` is a root-group global option and MUST come
-        before the subcommand; ``--agent-id`` is a per-subcommand option
-        and MUST come after ``message poll``. This ordering is what click's
-        parser actually accepts and is the literal string the recipient's
-        Bash tool receives.
-        """
-        monkeypatch.setattr("shutil.which", lambda _: "/usr/bin/tmux")
-        captured_args = []
-
-        def mock_run(args, **kwargs):
-            captured_args.extend(args)
-            return ""
-
-        monkeypatch.setattr(tmux, "_run", mock_run)
-        result = tmux.send_poll_trigger(
-            target_pane_id="%7",
-            session_id="sess-001",
-            agent_id="agent-001",
-        )
-        assert result is True
-        assert captured_args == [
+    def mock_run(args):
+        assert args == [
             "tmux",
-            "send-keys",
+            "display-message",
+            "-p",
             "-t",
-            "%7",
-            "-l",
-            "cafleet --session-id sess-001 message poll --agent-id agent-001",
-            "tmux",
-            "send-keys",
-            "-t",
-            "%7",
-            "Enter",
+            "%0",
+            "#{session_name}|#{window_id}|#{pane_id}",
         ]
+        return "main|@3|%0\n"
 
-    def test_pane_not_found_returns_false(self, monkeypatch):
-        monkeypatch.setattr("shutil.which", lambda _: "/usr/bin/tmux")
-
-        def mock_run(args, **kwargs):
-            raise tmux.TmuxError(
-                "tmux command failed: tmux send-keys -t %99\n"
-                "stderr: can't find pane: %99"
-            )
-
-        monkeypatch.setattr(tmux, "_run", mock_run)
-        result = tmux.send_poll_trigger(
-            target_pane_id="%99",
-            session_id="sess-001",
-            agent_id="agent-001",
-        )
-        assert result is False
-
-    def test_tmux_binary_missing_returns_false(self, monkeypatch):
-        monkeypatch.setattr("shutil.which", lambda _: None)
-        run_called = False
-
-        def mock_run(args):
-            nonlocal run_called
-            run_called = True
-            return ""
-
-        monkeypatch.setattr(tmux, "_run", mock_run)
-        result = tmux.send_poll_trigger(
-            target_pane_id="%7",
-            session_id="sess-001",
-            agent_id="agent-001",
-        )
-        assert result is False
-        assert not run_called
-
-    def test_never_raises_on_tmux_error(self, monkeypatch):
-        monkeypatch.setattr("shutil.which", lambda _: "/usr/bin/tmux")
-
-        def mock_run(args, **kwargs):
-            raise tmux.TmuxError("tmux command failed: server exited unexpectedly")
-
-        monkeypatch.setattr(tmux, "_run", mock_run)
-        result = tmux.send_poll_trigger(
-            target_pane_id="%7",
-            session_id="sess-001",
-            agent_id="agent-001",
-        )
-        assert result is False
+    monkeypatch.setattr(tmux, "_run", mock_run)
+    ctx = tmux.director_context()
+    assert ctx.session == "main"
+    assert ctx.window_id == "@3"
+    assert ctx.pane_id == "%0"
 
 
-class TestSendPollTriggerKeystroke:
-    """Regression guard for the literal keystroke shape pushed by
-    ``send_poll_trigger``.
+def test_director_context__errors_when_tmux_pane_unset(monkeypatch):
+    monkeypatch.delenv("TMUX_PANE", raising=False)
+    with pytest.raises(tmux.TmuxError, match="TMUX_PANE is not set"):
+        tmux.director_context()
 
-    The keystroke is the bare cafleet command and MUST carry
-    ``message poll --agent-id <a>``. The recipient's Bash tool is
-    enabled under ``--permission-mode dontAsk``, so the harness runs
-    the keystroke as a normal Bash invocation.
 
-    The two ``send-keys`` calls are inspected separately:
+def test_split_window__returns_captured_pane_id(monkeypatch):
+    def mock_run(args):
+        assert args[0:3] == ["tmux", "split-window", "-t"]
+        assert "@3" in args
+        assert "-P" in args
+        assert "-F" in args
+        assert "#{pane_id}" in args
+        assert "-e" in args
+        return "%7\n"
 
-    - call 0: ``["tmux", "send-keys", "-t", <pane>, "-l", <keystroke>]``
-    - call 1: ``["tmux", "send-keys", "-t", <pane>, "Enter"]``
+    monkeypatch.setattr(tmux, "_run", mock_run)
+    pane_id = tmux.split_window(
+        target_window_id="@3",
+        env={
+            "CAFLEET_DATABASE_URL": "sqlite+aiosqlite:////tmp/registry.db",
+        },
+        command=["claude", "Hello world"],
+    )
+    assert pane_id == "%7"
+
+
+def test_split_window__command_appended_directly_to_args(monkeypatch):
+    captured_args = []
+
+    def mock_run(args):
+        captured_args.extend(args)
+        return "%8\n"
+
+    monkeypatch.setattr(tmux, "_run", mock_run)
+    tmux.split_window(
+        target_window_id="@5",
+        env={},
+        command=["my-binary", "--flag", "value", "prompt text"],
+    )
+    assert captured_args[-4:] == ["my-binary", "--flag", "value", "prompt text"]
+
+
+def test_split_window__claude_style_command(monkeypatch):
+    captured_args = []
+
+    def mock_run(args):
+        captured_args.extend(args)
+        return "%9\n"
+
+    monkeypatch.setattr(tmux, "_run", mock_run)
+    tmux.split_window(
+        target_window_id="@3",
+        env={},
+        command=[
+            "claude",
+            (
+                "Load Skill(cafleet). Your agent_id is "
+                "7ba91234-5678-90ab-cdef-112233445566."
+            ),
+        ],
+    )
+    assert captured_args[-2] == "claude"
+    assert "Load Skill(cafleet)" in captured_args[-1]
+
+
+def test_split_window__env_vars_forwarded_as_flags(monkeypatch):
+    """Only CAFLEET_DATABASE_URL is forwarded as -e KEY=VAL when set.
+
+    Design doc 0000023: session_id and agent_id are now passed as literal
+    CLI flags via the prompt text, not via tmux env inheritance. The only
+    env var that member-create forwards is CAFLEET_DATABASE_URL so the
+    spawned agent can reach the same SQLite file.
     """
+    captured_args = []
 
-    def test_keystroke_starts_with_bare_cafleet(self, monkeypatch):
-        monkeypatch.setattr("shutil.which", lambda _: "/usr/bin/tmux")
-        captured: list[list[str]] = []
+    def mock_run(args):
+        captured_args.extend(args)
+        return "%11\n"
 
-        def mock_run(args, **_kwargs):
-            captured.append(list(args))
-            return ""
+    monkeypatch.setattr(tmux, "_run", mock_run)
+    tmux.split_window(
+        target_window_id="@3",
+        env={
+            "CAFLEET_DATABASE_URL": "sqlite+aiosqlite:////tmp/registry.db",
+        },
+        command=["claude", "prompt"],
+    )
+    env_pairs = []
+    for i, a in enumerate(captured_args):
+        if a == "-e" and i + 1 < len(captured_args):
+            env_pairs.append(captured_args[i + 1])
+    assert "CAFLEET_DATABASE_URL=sqlite+aiosqlite:////tmp/registry.db" in env_pairs
+    for pair in env_pairs:
+        assert not pair.startswith("CAFLEET_SESSION_ID=")
+        assert not pair.startswith("CAFLEET_AGENT_ID=")
+        assert not pair.startswith("CAFLEET_URL=")
 
-        monkeypatch.setattr(tmux, "_run", mock_run)
-        ok = tmux.send_poll_trigger(
-            target_pane_id="%5",
-            session_id="550e8400-e29b-41d4-a716-446655440000",
-            agent_id="7ba91234-5678-90ab-cdef-112233445566",
+
+def test_split_window__empty_env_emits_no_e_flags(monkeypatch):
+    captured_args = []
+
+    def mock_run(args):
+        captured_args.extend(args)
+        return "%12\n"
+
+    monkeypatch.setattr(tmux, "_run", mock_run)
+    tmux.split_window(
+        target_window_id="@3",
+        env={},
+        command=["claude", "prompt"],
+    )
+    assert "-e" not in captured_args
+
+
+def test_send_exit__raises_tmuxerror_on_failure(monkeypatch):
+    def mock_run(args):
+        raise tmux.TmuxError("tmux command failed: server exited unexpectedly")
+
+    monkeypatch.setattr(tmux, "_run", mock_run)
+    with pytest.raises(tmux.TmuxError, match="server exited unexpectedly"):
+        tmux.send_exit(target_pane_id="%7")
+
+
+def test_send_exit__ignore_missing_swallows_pane_gone(monkeypatch):
+    def mock_run(args):
+        raise tmux.TmuxError(
+            "tmux command failed: tmux send-keys -t %99 /exit Enter\n"
+            "stderr: can't find pane: %99"
         )
-        assert ok is True
-        assert len(captured) == 2
 
-        keystroke = captured[0][-1]
-        assert keystroke.startswith("cafleet --session-id "), (
-            "send_poll_trigger keystroke must start with `cafleet --session-id `; "
-            f"got: {keystroke!r}"
+    monkeypatch.setattr(tmux, "_run", mock_run)
+    tmux.send_exit(target_pane_id="%99", ignore_missing=True)
+
+
+def test_send_exit__ignore_missing_does_not_swallow_other_errors(monkeypatch):
+    def mock_run(args):
+        raise tmux.TmuxError("tmux command failed: server crashed")
+
+    monkeypatch.setattr(tmux, "_run", mock_run)
+    with pytest.raises(tmux.TmuxError, match="server crashed"):
+        tmux.send_exit(target_pane_id="%7", ignore_missing=True)
+
+
+def test_capture_pane__invokes_correct_args(monkeypatch):
+    captured_args = []
+
+    def mock_run(args):
+        captured_args.extend(args)
+        return "line 1\nline 2\n"
+
+    monkeypatch.setattr(tmux, "_run", mock_run)
+    result = tmux.capture_pane(target_pane_id="%7", lines=80)
+    assert captured_args == ["tmux", "capture-pane", "-p", "-t", "%7", "-S", "-80"]
+    assert result == "line 1\nline 2\n"
+
+
+def test_capture_pane__raises_on_missing_pane(monkeypatch):
+    def mock_run(args):
+        raise tmux.TmuxError(
+            "tmux command failed: tmux capture-pane -p -t %99 -S -80\n"
+            "stderr: can't find pane: %99"
         )
-        assert "message poll --agent-id" in keystroke, (
-            f"keystroke must carry `message poll --agent-id`; got: {keystroke!r}"
+
+    monkeypatch.setattr(tmux, "_run", mock_run)
+    with pytest.raises(tmux.TmuxError, match="can't find pane"):
+        tmux.capture_pane(target_pane_id="%99", lines=80)
+
+
+def test_capture_pane__rejects_non_positive_lines(monkeypatch):
+    with pytest.raises(tmux.TmuxError, match="lines must be positive, got 0"):
+        tmux.capture_pane(target_pane_id="%7", lines=0)
+    with pytest.raises(tmux.TmuxError, match="lines must be positive, got -1"):
+        tmux.capture_pane(target_pane_id="%7", lines=-1)
+
+
+def test_send_poll_trigger__success_returns_true(monkeypatch):
+    """``--session-id`` is a root-group global option and MUST come
+    before the subcommand; ``--agent-id`` is a per-subcommand option
+    and MUST come after ``message poll``. This ordering is what click's
+    parser actually accepts and is the literal string the recipient's
+    Bash tool receives.
+    """
+    monkeypatch.setattr("shutil.which", lambda _: "/usr/bin/tmux")
+    captured_args = []
+
+    def mock_run(args, **kwargs):
+        captured_args.extend(args)
+        return ""
+
+    monkeypatch.setattr(tmux, "_run", mock_run)
+    result = tmux.send_poll_trigger(
+        target_pane_id="%7",
+        session_id="sess-001",
+        agent_id="agent-001",
+    )
+    assert result is True
+    assert captured_args == [
+        "tmux",
+        "send-keys",
+        "-t",
+        "%7",
+        "-l",
+        "cafleet --session-id sess-001 message poll --agent-id agent-001",
+        "tmux",
+        "send-keys",
+        "-t",
+        "%7",
+        "Enter",
+    ]
+
+
+def test_send_poll_trigger__pane_not_found_returns_false(monkeypatch):
+    monkeypatch.setattr("shutil.which", lambda _: "/usr/bin/tmux")
+
+    def mock_run(args, **kwargs):
+        raise tmux.TmuxError(
+            "tmux command failed: tmux send-keys -t %99\n"
+            "stderr: can't find pane: %99"
         )
 
-        assert captured[1] == ["tmux", "send-keys", "-t", "%5", "Enter"]
+    monkeypatch.setattr(tmux, "_run", mock_run)
+    result = tmux.send_poll_trigger(
+        target_pane_id="%99",
+        session_id="sess-001",
+        agent_id="agent-001",
+    )
+    assert result is False
 
 
-class TestPaneExists:
-    def test_returns_true_when_pane_present_in_list(self, monkeypatch):
-        captured_args = []
+def test_send_poll_trigger__tmux_binary_missing_returns_false(monkeypatch):
+    monkeypatch.setattr("shutil.which", lambda _: None)
+    run_called = False
 
-        def mock_run(args):
-            captured_args.extend(args)
-            return "%0\n%3\n%7\n%9\n"
+    def mock_run(args):
+        nonlocal run_called
+        run_called = True
+        return ""
 
-        monkeypatch.setattr(tmux, "_run", mock_run)
-        assert tmux.pane_exists(target_pane_id="%7") is True
-        assert captured_args == [
-            "tmux",
-            "list-panes",
-            "-a",
-            "-F",
-            "#{pane_id}",
-        ]
-
-    def test_returns_false_when_pane_absent(self, monkeypatch):
-        def mock_run(args):
-            return "%0\n%3\n%9\n"
-
-        monkeypatch.setattr(tmux, "_run", mock_run)
-        assert tmux.pane_exists(target_pane_id="%7") is False
-
-    def test_propagates_unrelated_tmux_error(self, monkeypatch):
-        def mock_run(args):
-            raise tmux.TmuxError(
-                "tmux command failed: tmux list-panes -a -F #{pane_id}\n"
-                "stderr: no server running on /tmp/tmux-1000/default"
-            )
-
-        monkeypatch.setattr(tmux, "_run", mock_run)
-        with pytest.raises(tmux.TmuxError, match="no server running"):
-            tmux.pane_exists(target_pane_id="%7")
+    monkeypatch.setattr(tmux, "_run", mock_run)
+    result = tmux.send_poll_trigger(
+        target_pane_id="%7",
+        session_id="sess-001",
+        agent_id="agent-001",
+    )
+    assert result is False
+    assert not run_called
 
 
-class TestKillPane:
-    def test_invokes_correct_args(self, monkeypatch):
-        captured_args = []
+def test_send_poll_trigger__never_raises_on_tmux_error(monkeypatch):
+    monkeypatch.setattr("shutil.which", lambda _: "/usr/bin/tmux")
 
-        def mock_run(args):
-            captured_args.extend(args)
-            return ""
+    def mock_run(args, **kwargs):
+        raise tmux.TmuxError("tmux command failed: server exited unexpectedly")
 
-        monkeypatch.setattr(tmux, "_run", mock_run)
-        result = tmux.kill_pane(target_pane_id="%7")
-        assert result is None
-        assert captured_args == ["tmux", "kill-pane", "-t", "%7"]
+    monkeypatch.setattr(tmux, "_run", mock_run)
+    result = tmux.send_poll_trigger(
+        target_pane_id="%7",
+        session_id="sess-001",
+        agent_id="agent-001",
+    )
+    assert result is False
 
-    def test_ignore_missing_swallows_pane_gone(self, monkeypatch):
-        def mock_run(args):
-            raise tmux.TmuxError(
-                "tmux command failed: tmux kill-pane -t %99\n"
-                "stderr: can't find pane: %99"
-            )
 
-        monkeypatch.setattr(tmux, "_run", mock_run)
-        tmux.kill_pane(target_pane_id="%99", ignore_missing=True)
+# --- send_poll_trigger_keystroke: regression guard for the literal keystroke
+# shape pushed by ``send_poll_trigger``. The keystroke is the bare cafleet
+# command and MUST carry ``message poll --agent-id <a>``. The recipient's Bash
+# tool is enabled under ``--permission-mode dontAsk``, so the harness runs the
+# keystroke as a normal Bash invocation.
+#
+# The two ``send-keys`` calls are inspected separately:
+# - call 0: ``["tmux", "send-keys", "-t", <pane>, "-l", <keystroke>]``
+# - call 1: ``["tmux", "send-keys", "-t", <pane>, "Enter"]``
+# ---
 
-    def test_ignore_missing_does_not_swallow_other_errors(self, monkeypatch):
-        def mock_run(args):
-            raise tmux.TmuxError(
-                "tmux command failed: tmux kill-pane -t %7\n"
-                "stderr: server exited unexpectedly"
-            )
 
-        monkeypatch.setattr(tmux, "_run", mock_run)
-        with pytest.raises(tmux.TmuxError, match="server exited unexpectedly"):
-            tmux.kill_pane(target_pane_id="%7", ignore_missing=True)
+def test_send_poll_trigger_keystroke__keystroke_starts_with_bare_cafleet(monkeypatch):
+    monkeypatch.setattr("shutil.which", lambda _: "/usr/bin/tmux")
+    captured: list[list[str]] = []
 
-    def test_default_raises_even_for_pane_gone(self, monkeypatch):
-        def mock_run(args):
-            raise tmux.TmuxError(
-                "tmux command failed: tmux kill-pane -t %99\n"
-                "stderr: can't find pane: %99"
-            )
+    def mock_run(args, **_kwargs):
+        captured.append(list(args))
+        return ""
 
-        monkeypatch.setattr(tmux, "_run", mock_run)
-        with pytest.raises(tmux.TmuxError, match="can't find pane"):
-            tmux.kill_pane(target_pane_id="%99")
+    monkeypatch.setattr(tmux, "_run", mock_run)
+    ok = tmux.send_poll_trigger(
+        target_pane_id="%5",
+        session_id="550e8400-e29b-41d4-a716-446655440000",
+        agent_id="7ba91234-5678-90ab-cdef-112233445566",
+    )
+    assert ok is True
+    assert len(captured) == 2
+
+    keystroke = captured[0][-1]
+    assert keystroke.startswith("cafleet --session-id "), (
+        "send_poll_trigger keystroke must start with `cafleet --session-id `; "
+        f"got: {keystroke!r}"
+    )
+    assert "message poll --agent-id" in keystroke, (
+        f"keystroke must carry `message poll --agent-id`; got: {keystroke!r}"
+    )
+
+    assert captured[1] == ["tmux", "send-keys", "-t", "%5", "Enter"]
+
+
+def test_pane_exists__returns_true_when_pane_present_in_list(monkeypatch):
+    captured_args = []
+
+    def mock_run(args):
+        captured_args.extend(args)
+        return "%0\n%3\n%7\n%9\n"
+
+    monkeypatch.setattr(tmux, "_run", mock_run)
+    assert tmux.pane_exists(target_pane_id="%7") is True
+    assert captured_args == [
+        "tmux",
+        "list-panes",
+        "-a",
+        "-F",
+        "#{pane_id}",
+    ]
+
+
+def test_pane_exists__returns_false_when_pane_absent(monkeypatch):
+    def mock_run(args):
+        return "%0\n%3\n%9\n"
+
+    monkeypatch.setattr(tmux, "_run", mock_run)
+    assert tmux.pane_exists(target_pane_id="%7") is False
+
+
+def test_pane_exists__propagates_unrelated_tmux_error(monkeypatch):
+    def mock_run(args):
+        raise tmux.TmuxError(
+            "tmux command failed: tmux list-panes -a -F #{pane_id}\n"
+            "stderr: no server running on /tmp/tmux-1000/default"
+        )
+
+    monkeypatch.setattr(tmux, "_run", mock_run)
+    with pytest.raises(tmux.TmuxError, match="no server running"):
+        tmux.pane_exists(target_pane_id="%7")
+
+
+def test_kill_pane__invokes_correct_args(monkeypatch):
+    captured_args = []
+
+    def mock_run(args):
+        captured_args.extend(args)
+        return ""
+
+    monkeypatch.setattr(tmux, "_run", mock_run)
+    result = tmux.kill_pane(target_pane_id="%7")
+    assert result is None
+    assert captured_args == ["tmux", "kill-pane", "-t", "%7"]
+
+
+def test_kill_pane__ignore_missing_swallows_pane_gone(monkeypatch):
+    def mock_run(args):
+        raise tmux.TmuxError(
+            "tmux command failed: tmux kill-pane -t %99\n"
+            "stderr: can't find pane: %99"
+        )
+
+    monkeypatch.setattr(tmux, "_run", mock_run)
+    tmux.kill_pane(target_pane_id="%99", ignore_missing=True)
+
+
+def test_kill_pane__ignore_missing_does_not_swallow_other_errors(monkeypatch):
+    def mock_run(args):
+        raise tmux.TmuxError(
+            "tmux command failed: tmux kill-pane -t %7\n"
+            "stderr: server exited unexpectedly"
+        )
+
+    monkeypatch.setattr(tmux, "_run", mock_run)
+    with pytest.raises(tmux.TmuxError, match="server exited unexpectedly"):
+        tmux.kill_pane(target_pane_id="%7", ignore_missing=True)
+
+
+def test_kill_pane__default_raises_even_for_pane_gone(monkeypatch):
+    def mock_run(args):
+        raise tmux.TmuxError(
+            "tmux command failed: tmux kill-pane -t %99\n"
+            "stderr: can't find pane: %99"
+        )
+
+    monkeypatch.setattr(tmux, "_run", mock_run)
+    with pytest.raises(tmux.TmuxError, match="can't find pane"):
+        tmux.kill_pane(target_pane_id="%99")
 
 
 class _FakeClock:
@@ -442,189 +449,195 @@ class _FakeClock:
         self.now += secs
 
 
-class TestWaitForPaneGone:
-    def test_returns_true_immediately_when_pane_already_gone(self, monkeypatch):
-        clock = _FakeClock()
-        monkeypatch.setattr("time.monotonic", clock.monotonic)
-        monkeypatch.setattr("time.sleep", clock.sleep)
+def test_wait_for_pane_gone__returns_true_immediately_when_pane_already_gone(monkeypatch):
+    clock = _FakeClock()
+    monkeypatch.setattr("time.monotonic", clock.monotonic)
+    monkeypatch.setattr("time.sleep", clock.sleep)
 
-        poll_calls: list[str] = []
+    poll_calls: list[str] = []
 
-        def fake_pane_exists(*, target_pane_id):
-            poll_calls.append(target_pane_id)
-            return False
+    def fake_pane_exists(*, target_pane_id):
+        poll_calls.append(target_pane_id)
+        return False
 
-        monkeypatch.setattr(tmux, "pane_exists", fake_pane_exists)
+    monkeypatch.setattr(tmux, "pane_exists", fake_pane_exists)
 
-        result = tmux.wait_for_pane_gone(target_pane_id="%7", timeout=2.0, interval=0.5)
-        assert result is True
-        assert poll_calls == ["%7"]
-        assert clock.sleep_calls == []
-
-    def test_returns_true_when_pane_disappears_mid_wait(self, monkeypatch):
-        clock = _FakeClock()
-        monkeypatch.setattr("time.monotonic", clock.monotonic)
-        monkeypatch.setattr("time.sleep", clock.sleep)
-
-        results = iter([True, True, False])
-        poll_calls: list[str] = []
-
-        def fake_pane_exists(*, target_pane_id):
-            poll_calls.append(target_pane_id)
-            return next(results)
-
-        monkeypatch.setattr(tmux, "pane_exists", fake_pane_exists)
-
-        result = tmux.wait_for_pane_gone(target_pane_id="%7", timeout=2.0, interval=0.5)
-        assert result is True
-        assert poll_calls == ["%7", "%7", "%7"]
-        assert clock.sleep_calls == [0.5, 0.5]
-        assert clock.now < 1.0 + 1e-9
-
-    def test_returns_false_after_timeout(self, monkeypatch):
-        clock = _FakeClock()
-        monkeypatch.setattr("time.monotonic", clock.monotonic)
-        monkeypatch.setattr("time.sleep", clock.sleep)
-
-        poll_calls: list[str] = []
-
-        def fake_pane_exists(*, target_pane_id):
-            poll_calls.append(target_pane_id)
-            return True
-
-        monkeypatch.setattr(tmux, "pane_exists", fake_pane_exists)
-
-        result = tmux.wait_for_pane_gone(target_pane_id="%7", timeout=2.0, interval=0.5)
-        assert result is False
-        assert len(poll_calls) == 5
-        assert clock.sleep_calls == [0.5, 0.5, 0.5, 0.5]
-
-    def test_propagates_tmux_error_from_pane_exists(self, monkeypatch):
-        clock = _FakeClock()
-        monkeypatch.setattr("time.monotonic", clock.monotonic)
-        monkeypatch.setattr("time.sleep", clock.sleep)
-
-        call_count = {"n": 0}
-
-        def fake_pane_exists(*, target_pane_id):
-            call_count["n"] += 1
-            if call_count["n"] >= 2:
-                raise tmux.TmuxError("tmux command failed: server exited unexpectedly")
-            return True
-
-        monkeypatch.setattr(tmux, "pane_exists", fake_pane_exists)
-
-        with pytest.raises(tmux.TmuxError, match="server exited unexpectedly"):
-            tmux.wait_for_pane_gone(target_pane_id="%7", timeout=2.0, interval=0.5)
-        assert call_count["n"] == 2
+    result = tmux.wait_for_pane_gone(target_pane_id="%7", timeout=2.0, interval=0.5)
+    assert result is True
+    assert poll_calls == ["%7"]
+    assert clock.sleep_calls == []
 
 
-class TestSendBashCommand:
-    """Round-8 ``tmux.send_bash_command`` helper.
+def test_wait_for_pane_gone__returns_true_when_pane_disappears_mid_wait(monkeypatch):
+    clock = _FakeClock()
+    monkeypatch.setattr("time.monotonic", clock.monotonic)
+    monkeypatch.setattr("time.sleep", clock.sleep)
 
-    Bash routing uses Claude Code's ``!`` keystroke convention: the keystroke
-    ``! <command>`` followed by ``Enter`` enters Bash-input mode in the
-    member's pane and runs ``<command>``. Unlike ``send_freetext_and_submit``,
-    there is NO leading ``4`` keystroke (no AskUserQuestion gate), so the
-    helper issues exactly two ``send-keys`` invocations.
-    """
+    results = iter([True, True, False])
+    poll_calls: list[str] = []
 
-    def test_sends_keystrokes_in_two_calls(self, monkeypatch):
-        captured_calls: list[list[str]] = []
+    def fake_pane_exists(*, target_pane_id):
+        poll_calls.append(target_pane_id)
+        return next(results)
 
-        def mock_run(args, **_kwargs):
-            captured_calls.append(list(args))
-            return ""
+    monkeypatch.setattr(tmux, "pane_exists", fake_pane_exists)
 
-        monkeypatch.setattr(tmux, "_run", mock_run)
-        tmux.send_bash_command(target_pane_id="%5", command="git log -1 --oneline")
-        assert len(captured_calls) == 2
-        assert captured_calls[0] == [
-            "tmux",
-            "send-keys",
-            "-t",
-            "%5",
-            "-l",
-            "! git log -1 --oneline",
-        ]
-        assert captured_calls[1] == [
-            "tmux",
-            "send-keys",
-            "-t",
-            "%5",
-            "Enter",
-        ]
+    result = tmux.wait_for_pane_gone(target_pane_id="%7", timeout=2.0, interval=0.5)
+    assert result is True
+    assert poll_calls == ["%7", "%7", "%7"]
+    assert clock.sleep_calls == [0.5, 0.5]
+    assert clock.now < 1.0 + 1e-9
 
-    @pytest.mark.parametrize(
-        "bad_command",
-        [
-            "line1\nline2",
-            "trailing\n",
-            "\nleading",
-            "carriage\rreturn",
-            "mixed\r\nCRLF",
-        ],
-    )
-    def test_rejects_newlines(self, monkeypatch, bad_command):
-        run_calls: list[list[str]] = []
 
-        def mock_run(args, **_kwargs):
-            run_calls.append(list(args))
-            return ""
+def test_wait_for_pane_gone__returns_false_after_timeout(monkeypatch):
+    clock = _FakeClock()
+    monkeypatch.setattr("time.monotonic", clock.monotonic)
+    monkeypatch.setattr("time.sleep", clock.sleep)
 
-        monkeypatch.setattr(tmux, "_run", mock_run)
-        with pytest.raises(tmux.TmuxError, match="(?i)newline"):
-            tmux.send_bash_command(target_pane_id="%5", command=bad_command)
-        assert run_calls == []
+    poll_calls: list[str] = []
 
-    def test_rejects_empty_command(self, monkeypatch):
-        run_calls: list[list[str]] = []
+    def fake_pane_exists(*, target_pane_id):
+        poll_calls.append(target_pane_id)
+        return True
 
-        def mock_run(args, **_kwargs):
-            run_calls.append(list(args))
-            return ""
+    monkeypatch.setattr(tmux, "pane_exists", fake_pane_exists)
 
-        monkeypatch.setattr(tmux, "_run", mock_run)
-        with pytest.raises(
-            tmux.TmuxError,
-            match="send_bash_command: command may not be empty",
-        ):
-            tmux.send_bash_command(target_pane_id="%5", command="")
-        assert run_calls == []
+    result = tmux.wait_for_pane_gone(target_pane_id="%7", timeout=2.0, interval=0.5)
+    assert result is False
+    assert len(poll_calls) == 5
+    assert clock.sleep_calls == [0.5, 0.5, 0.5, 0.5]
 
-    @pytest.mark.parametrize(
-        "whitespace_command",
-        [" ", "   ", "\t", " \t ", "\t\t"],
-    )
-    def test_rejects_whitespace_only_command(self, monkeypatch, whitespace_command):
-        run_calls: list[list[str]] = []
 
-        def mock_run(args, **_kwargs):
-            run_calls.append(list(args))
-            return ""
+def test_wait_for_pane_gone__propagates_tmux_error_from_pane_exists(monkeypatch):
+    clock = _FakeClock()
+    monkeypatch.setattr("time.monotonic", clock.monotonic)
+    monkeypatch.setattr("time.sleep", clock.sleep)
 
-        monkeypatch.setattr(tmux, "_run", mock_run)
-        with pytest.raises(
-            tmux.TmuxError,
-            match="send_bash_command: command may not be empty",
-        ):
-            tmux.send_bash_command(target_pane_id="%5", command=whitespace_command)
-        assert run_calls == []
+    call_count = {"n": 0}
 
-    def test_strips_surrounding_whitespace_from_command(self, monkeypatch):
-        captured_calls: list[list[str]] = []
+    def fake_pane_exists(*, target_pane_id):
+        call_count["n"] += 1
+        if call_count["n"] >= 2:
+            raise tmux.TmuxError("tmux command failed: server exited unexpectedly")
+        return True
 
-        def mock_run(args, **_kwargs):
-            captured_calls.append(list(args))
-            return ""
+    monkeypatch.setattr(tmux, "pane_exists", fake_pane_exists)
 
-        monkeypatch.setattr(tmux, "_run", mock_run)
-        tmux.send_bash_command(target_pane_id="%5", command="  git status  ")
-        assert captured_calls[0] == [
-            "tmux",
-            "send-keys",
-            "-t",
-            "%5",
-            "-l",
-            "! git status",
-        ]
+    with pytest.raises(tmux.TmuxError, match="server exited unexpectedly"):
+        tmux.wait_for_pane_gone(target_pane_id="%7", timeout=2.0, interval=0.5)
+    assert call_count["n"] == 2
+
+
+# --- send_bash_command: round-8 ``tmux.send_bash_command`` helper.
+#
+# Bash routing uses Claude Code's ``!`` keystroke convention: the keystroke
+# ``! <command>`` followed by ``Enter`` enters Bash-input mode in the
+# member's pane and runs ``<command>``. Unlike ``send_freetext_and_submit``,
+# there is NO leading ``4`` keystroke (no AskUserQuestion gate), so the
+# helper issues exactly two ``send-keys`` invocations.
+# ---
+
+
+def test_send_bash_command__sends_keystrokes_in_two_calls(monkeypatch):
+    captured_calls: list[list[str]] = []
+
+    def mock_run(args, **_kwargs):
+        captured_calls.append(list(args))
+        return ""
+
+    monkeypatch.setattr(tmux, "_run", mock_run)
+    tmux.send_bash_command(target_pane_id="%5", command="git log -1 --oneline")
+    assert len(captured_calls) == 2
+    assert captured_calls[0] == [
+        "tmux",
+        "send-keys",
+        "-t",
+        "%5",
+        "-l",
+        "! git log -1 --oneline",
+    ]
+    assert captured_calls[1] == [
+        "tmux",
+        "send-keys",
+        "-t",
+        "%5",
+        "Enter",
+    ]
+
+
+@pytest.mark.parametrize(
+    "bad_command",
+    [
+        "line1\nline2",
+        "trailing\n",
+        "\nleading",
+        "carriage\rreturn",
+        "mixed\r\nCRLF",
+    ],
+)
+def test_send_bash_command__rejects_newlines(monkeypatch, bad_command):
+    run_calls: list[list[str]] = []
+
+    def mock_run(args, **_kwargs):
+        run_calls.append(list(args))
+        return ""
+
+    monkeypatch.setattr(tmux, "_run", mock_run)
+    with pytest.raises(tmux.TmuxError, match="(?i)newline"):
+        tmux.send_bash_command(target_pane_id="%5", command=bad_command)
+    assert run_calls == []
+
+
+def test_send_bash_command__rejects_empty_command(monkeypatch):
+    run_calls: list[list[str]] = []
+
+    def mock_run(args, **_kwargs):
+        run_calls.append(list(args))
+        return ""
+
+    monkeypatch.setattr(tmux, "_run", mock_run)
+    with pytest.raises(
+        tmux.TmuxError,
+        match="send_bash_command: command may not be empty",
+    ):
+        tmux.send_bash_command(target_pane_id="%5", command="")
+    assert run_calls == []
+
+
+@pytest.mark.parametrize(
+    "whitespace_command",
+    [" ", "   ", "\t", " \t ", "\t\t"],
+)
+def test_send_bash_command__rejects_whitespace_only_command(monkeypatch, whitespace_command):
+    run_calls: list[list[str]] = []
+
+    def mock_run(args, **_kwargs):
+        run_calls.append(list(args))
+        return ""
+
+    monkeypatch.setattr(tmux, "_run", mock_run)
+    with pytest.raises(
+        tmux.TmuxError,
+        match="send_bash_command: command may not be empty",
+    ):
+        tmux.send_bash_command(target_pane_id="%5", command=whitespace_command)
+    assert run_calls == []
+
+
+def test_send_bash_command__strips_surrounding_whitespace_from_command(monkeypatch):
+    captured_calls: list[list[str]] = []
+
+    def mock_run(args, **_kwargs):
+        captured_calls.append(list(args))
+        return ""
+
+    monkeypatch.setattr(tmux, "_run", mock_run)
+    tmux.send_bash_command(target_pane_id="%5", command="  git status  ")
+    assert captured_calls[0] == [
+        "tmux",
+        "send-keys",
+        "-t",
+        "%5",
+        "-l",
+        "! git status",
+    ]

--- a/cafleet/tests/test_tmux.py
+++ b/cafleet/tests/test_tmux.py
@@ -257,8 +257,7 @@ def test_send_poll_trigger__pane_not_found_returns_false(monkeypatch):
 
     def mock_run(args, **kwargs):
         raise tmux.TmuxError(
-            "tmux command failed: tmux send-keys -t %99\n"
-            "stderr: can't find pane: %99"
+            "tmux command failed: tmux send-keys -t %99\nstderr: can't find pane: %99"
         )
 
     monkeypatch.setattr(tmux, "_run", mock_run)
@@ -399,8 +398,7 @@ def test_kill_pane__invokes_correct_args(monkeypatch):
 def test_kill_pane__ignore_missing_swallows_pane_gone(monkeypatch):
     def mock_run(args):
         raise tmux.TmuxError(
-            "tmux command failed: tmux kill-pane -t %99\n"
-            "stderr: can't find pane: %99"
+            "tmux command failed: tmux kill-pane -t %99\nstderr: can't find pane: %99"
         )
 
     monkeypatch.setattr(tmux, "_run", mock_run)
@@ -422,8 +420,7 @@ def test_kill_pane__ignore_missing_does_not_swallow_other_errors(monkeypatch):
 def test_kill_pane__default_raises_even_for_pane_gone(monkeypatch):
     def mock_run(args):
         raise tmux.TmuxError(
-            "tmux command failed: tmux kill-pane -t %99\n"
-            "stderr: can't find pane: %99"
+            "tmux command failed: tmux kill-pane -t %99\nstderr: can't find pane: %99"
         )
 
     monkeypatch.setattr(tmux, "_run", mock_run)
@@ -449,7 +446,9 @@ class _FakeClock:
         self.now += secs
 
 
-def test_wait_for_pane_gone__returns_true_immediately_when_pane_already_gone(monkeypatch):
+def test_wait_for_pane_gone__returns_true_immediately_when_pane_already_gone(
+    monkeypatch,
+):
     clock = _FakeClock()
     monkeypatch.setattr("time.monotonic", clock.monotonic)
     monkeypatch.setattr("time.sleep", clock.sleep)
@@ -608,7 +607,9 @@ def test_send_bash_command__rejects_empty_command(monkeypatch):
     "whitespace_command",
     [" ", "   ", "\t", " \t ", "\t\t"],
 )
-def test_send_bash_command__rejects_whitespace_only_command(monkeypatch, whitespace_command):
+def test_send_bash_command__rejects_whitespace_only_command(
+    monkeypatch, whitespace_command
+):
     run_calls: list[list[str]] = []
 
     def mock_run(args, **_kwargs):

--- a/cafleet/tests/test_tmux_send_helpers.py
+++ b/cafleet/tests/test_tmux_send_helpers.py
@@ -15,128 +15,138 @@ def run_recorder(monkeypatch):
     return calls
 
 
-class TestTmuxHelpers:
-    @pytest.mark.parametrize("digit", [1, 2, 3])
-    def test_send_choice_key_records_exact_argv(self, run_recorder, digit):
-        tmux.send_choice_key(target_pane_id="%7", digit=digit)
-        assert len(run_recorder) == 1
-        assert run_recorder[0]["args"] == [
-            "tmux",
-            "send-keys",
-            "-t",
-            "%7",
-            str(digit),
-        ]
+@pytest.mark.parametrize("digit", [1, 2, 3])
+def test_tmux_helpers__send_choice_key_records_exact_argv(run_recorder, digit):
+    tmux.send_choice_key(target_pane_id="%7", digit=digit)
+    assert len(run_recorder) == 1
+    assert run_recorder[0]["args"] == [
+        "tmux",
+        "send-keys",
+        "-t",
+        "%7",
+        str(digit),
+    ]
 
-    def test_send_choice_key_does_not_append_enter(self, run_recorder):
-        tmux.send_choice_key(target_pane_id="%7", digit=1)
-        assert "Enter" not in run_recorder[0]["args"]
 
-    @pytest.mark.parametrize("bad_digit", [0, 4, 5, -1, 10])
-    def test_send_choice_key_rejects_out_of_range(self, run_recorder, bad_digit):
-        with pytest.raises(tmux.TmuxError, match="must be"):
-            tmux.send_choice_key(target_pane_id="%7", digit=bad_digit)
-        assert len(run_recorder) == 0
+def test_tmux_helpers__send_choice_key_does_not_append_enter(run_recorder):
+    tmux.send_choice_key(target_pane_id="%7", digit=1)
+    assert "Enter" not in run_recorder[0]["args"]
 
-    def test_send_choice_key_different_pane_id(self, run_recorder):
-        tmux.send_choice_key(target_pane_id="%99", digit=2)
-        assert run_recorder[0]["args"] == [
-            "tmux",
-            "send-keys",
-            "-t",
-            "%99",
-            "2",
-        ]
 
-    def test_send_freetext_and_submit_three_calls_in_order(self, run_recorder):
-        tmux.send_freetext_and_submit(target_pane_id="%7", text="hello")
-        assert len(run_recorder) == 3
-        assert run_recorder[0]["args"] == ["tmux", "send-keys", "-t", "%7", "4"]
-        assert run_recorder[1]["args"] == [
-            "tmux",
-            "send-keys",
-            "-t",
-            "%7",
-            "-l",
-            "hello",
-        ]
-        assert run_recorder[2]["args"] == [
-            "tmux",
-            "send-keys",
-            "-t",
-            "%7",
-            "Enter",
-        ]
+@pytest.mark.parametrize("bad_digit", [0, 4, 5, -1, 10])
+def test_tmux_helpers__send_choice_key_rejects_out_of_range(run_recorder, bad_digit):
+    with pytest.raises(tmux.TmuxError, match="must be"):
+        tmux.send_choice_key(target_pane_id="%7", digit=bad_digit)
+    assert len(run_recorder) == 0
 
-    def test_send_freetext_and_submit_uses_literal_flag_for_text(self, run_recorder):
-        tmux.send_freetext_and_submit(target_pane_id="%7", text="hello")
-        second = run_recorder[1]["args"]
-        assert "-l" in second
-        l_index = second.index("-l")
-        assert second[l_index + 1] == "hello"
 
-    def test_send_freetext_and_submit_empty_string_accepted(self, run_recorder):
-        tmux.send_freetext_and_submit(target_pane_id="%7", text="")
-        assert len(run_recorder) == 3
-        assert run_recorder[1]["args"] == [
-            "tmux",
-            "send-keys",
-            "-t",
-            "%7",
-            "-l",
-            "",
-        ]
+def test_tmux_helpers__send_choice_key_different_pane_id(run_recorder):
+    tmux.send_choice_key(target_pane_id="%99", digit=2)
+    assert run_recorder[0]["args"] == [
+        "tmux",
+        "send-keys",
+        "-t",
+        "%99",
+        "2",
+    ]
 
-    @pytest.mark.parametrize(
-        "bad_text",
-        [
-            "line1\nline2",
-            "\n",
-            "\r",
-            "leading\ntext",
-            "trailing\n",
-            "mixed\r\nCRLF",
-        ],
-    )
-    def test_send_freetext_and_submit_rejects_newlines(self, run_recorder, bad_text):
-        with pytest.raises(tmux.TmuxError, match="(?i)newline"):
-            tmux.send_freetext_and_submit(target_pane_id="%7", text=bad_text)
-        assert len(run_recorder) == 0
 
-    def test_send_freetext_and_submit_shell_meta_passes_through_to_run(
-        self, run_recorder
-    ):
-        payload = "$(echo pwn) `bt` $VAR ; && | > < rm -rf /"
-        tmux.send_freetext_and_submit(target_pane_id="%7", text=payload)
-        assert run_recorder[1]["args"] == [
-            "tmux",
-            "send-keys",
-            "-t",
-            "%7",
-            "-l",
-            payload,
-        ]
+def test_tmux_helpers__send_freetext_and_submit_three_calls_in_order(run_recorder):
+    tmux.send_freetext_and_submit(target_pane_id="%7", text="hello")
+    assert len(run_recorder) == 3
+    assert run_recorder[0]["args"] == ["tmux", "send-keys", "-t", "%7", "4"]
+    assert run_recorder[1]["args"] == [
+        "tmux",
+        "send-keys",
+        "-t",
+        "%7",
+        "-l",
+        "hello",
+    ]
+    assert run_recorder[2]["args"] == [
+        "tmux",
+        "send-keys",
+        "-t",
+        "%7",
+        "Enter",
+    ]
 
-    def test_send_freetext_and_submit_multibyte_passes_through(self, run_recorder):
-        payload = "日本語 テスト ✓ 🚀"
-        tmux.send_freetext_and_submit(target_pane_id="%7", text=payload)
-        assert run_recorder[1]["args"][-1] == payload
 
-    def test_send_freetext_and_submit_key_name_lookalike_passes_through(
-        self, run_recorder
-    ):
-        payload = "Enter C-c Esc"
-        tmux.send_freetext_and_submit(target_pane_id="%7", text=payload)
-        assert run_recorder[1]["args"] == [
-            "tmux",
-            "send-keys",
-            "-t",
-            "%7",
-            "-l",
-            payload,
-        ]
+def test_tmux_helpers__send_freetext_and_submit_uses_literal_flag_for_text(run_recorder):
+    tmux.send_freetext_and_submit(target_pane_id="%7", text="hello")
+    second = run_recorder[1]["args"]
+    assert "-l" in second
+    l_index = second.index("-l")
+    assert second[l_index + 1] == "hello"
 
-    def test_send_freetext_and_submit_different_pane_id(self, run_recorder):
-        tmux.send_freetext_and_submit(target_pane_id="%42", text="x")
-        for call in run_recorder:
-            assert "%42" in call["args"]
+
+def test_tmux_helpers__send_freetext_and_submit_empty_string_accepted(run_recorder):
+    tmux.send_freetext_and_submit(target_pane_id="%7", text="")
+    assert len(run_recorder) == 3
+    assert run_recorder[1]["args"] == [
+        "tmux",
+        "send-keys",
+        "-t",
+        "%7",
+        "-l",
+        "",
+    ]
+
+
+@pytest.mark.parametrize(
+    "bad_text",
+    [
+        "line1\nline2",
+        "\n",
+        "\r",
+        "leading\ntext",
+        "trailing\n",
+        "mixed\r\nCRLF",
+    ],
+)
+def test_tmux_helpers__send_freetext_and_submit_rejects_newlines(run_recorder, bad_text):
+    with pytest.raises(tmux.TmuxError, match="(?i)newline"):
+        tmux.send_freetext_and_submit(target_pane_id="%7", text=bad_text)
+    assert len(run_recorder) == 0
+
+
+def test_tmux_helpers__send_freetext_and_submit_shell_meta_passes_through_to_run(
+    run_recorder,
+):
+    payload = "$(echo pwn) `bt` $VAR ; && | > < rm -rf /"
+    tmux.send_freetext_and_submit(target_pane_id="%7", text=payload)
+    assert run_recorder[1]["args"] == [
+        "tmux",
+        "send-keys",
+        "-t",
+        "%7",
+        "-l",
+        payload,
+    ]
+
+
+def test_tmux_helpers__send_freetext_and_submit_multibyte_passes_through(run_recorder):
+    payload = "日本語 テスト ✓ 🚀"
+    tmux.send_freetext_and_submit(target_pane_id="%7", text=payload)
+    assert run_recorder[1]["args"][-1] == payload
+
+
+def test_tmux_helpers__send_freetext_and_submit_key_name_lookalike_passes_through(
+    run_recorder,
+):
+    payload = "Enter C-c Esc"
+    tmux.send_freetext_and_submit(target_pane_id="%7", text=payload)
+    assert run_recorder[1]["args"] == [
+        "tmux",
+        "send-keys",
+        "-t",
+        "%7",
+        "-l",
+        payload,
+    ]
+
+
+def test_tmux_helpers__send_freetext_and_submit_different_pane_id(run_recorder):
+    tmux.send_freetext_and_submit(target_pane_id="%42", text="x")
+    for call in run_recorder:
+        assert "%42" in call["args"]

--- a/cafleet/tests/test_tmux_send_helpers.py
+++ b/cafleet/tests/test_tmux_send_helpers.py
@@ -72,7 +72,9 @@ def test_tmux_helpers__send_freetext_and_submit_three_calls_in_order(run_recorde
     ]
 
 
-def test_tmux_helpers__send_freetext_and_submit_uses_literal_flag_for_text(run_recorder):
+def test_tmux_helpers__send_freetext_and_submit_uses_literal_flag_for_text(
+    run_recorder,
+):
     tmux.send_freetext_and_submit(target_pane_id="%7", text="hello")
     second = run_recorder[1]["args"]
     assert "-l" in second
@@ -104,7 +106,9 @@ def test_tmux_helpers__send_freetext_and_submit_empty_string_accepted(run_record
         "mixed\r\nCRLF",
     ],
 )
-def test_tmux_helpers__send_freetext_and_submit_rejects_newlines(run_recorder, bad_text):
+def test_tmux_helpers__send_freetext_and_submit_rejects_newlines(
+    run_recorder, bad_text
+):
     with pytest.raises(tmux.TmuxError, match="(?i)newline"):
         tmux.send_freetext_and_submit(target_pane_id="%7", text=bad_text)
     assert len(run_recorder) == 0

--- a/cafleet/tests/test_webui_api_format.py
+++ b/cafleet/tests/test_webui_api_format.py
@@ -68,208 +68,201 @@ def _two_agents() -> tuple[str, str, str]:
     return sid, a["agent_id"], b["agent_id"]
 
 
-class TestFormatMessagesEmpty:
-    def test_empty_rows_returns_empty_and_skips_lookup(self, monkeypatch):
-        calls = []
+def test_format_messages_empty__empty_rows_returns_empty_and_skips_lookup(monkeypatch):
+    calls = []
 
-        def fake_get_agent_names(ids):
-            calls.append(list(ids))
-            return {}
+    def fake_get_agent_names(ids):
+        calls.append(list(ids))
+        return {}
 
-        monkeypatch.setattr(webui_api.broker, "get_agent_names", fake_get_agent_names)
+    monkeypatch.setattr(webui_api.broker, "get_agent_names", fake_get_agent_names)
 
-        accessor_calls = []
+    accessor_calls = []
 
-        def accessor(row):
-            accessor_calls.append(row)
-            return {}
+    def accessor(row):
+        accessor_calls.append(row)
+        return {}
 
-        result = _format_messages([], accessor)
-        assert result == []
-        assert calls == []
-        assert accessor_calls == []
-
-
-class TestFormatMessagesBatchesLookup:
-    def test_calls_accessor_per_row_and_batches_agent_lookup(self, monkeypatch):
-        rows = [
-            {"row_index": 0, "from": "a1", "to": "a2"},
-            {"row_index": 1, "from": "a1", "to": "a3"},
-        ]
-
-        accessor_inputs = []
-
-        def accessor(row):
-            accessor_inputs.append(row)
-            return {
-                "task_id": f"task-{row['row_index']}",
-                "from_id": row["from"],
-                "to_id": row["to"],
-                "type_": "message",
-                "status": "input_required",
-                "created_at": "2026-04-30T00:00:00+00:00",
-                "status_timestamp": "2026-04-30T00:00:00+00:00",
-                "origin_task_id": None,
-                "body": f"body-{row['row_index']}",
-            }
-
-        get_agent_names_calls = []
-
-        def fake_get_agent_names(ids):
-            get_agent_names_calls.append(set(ids))
-            return {"a1": "alpha", "a2": "beta", "a3": "gamma"}
-
-        monkeypatch.setattr(webui_api.broker, "get_agent_names", fake_get_agent_names)
-
-        result = _format_messages(rows, accessor)
-
-        assert accessor_inputs == rows
-        assert len(get_agent_names_calls) == 1
-        assert get_agent_names_calls[0] == {"a1", "a2", "a3"}
-        assert len(result) == 2
-        assert result[0]["from_agent_name"] == "alpha"
-        assert result[0]["to_agent_name"] == "beta"
-        assert result[1]["to_agent_name"] == "gamma"
+    result = _format_messages([], accessor)
+    assert result == []
+    assert calls == []
+    assert accessor_calls == []
 
 
-class TestFormatMessagesShape:
-    def test_output_dict_shape_matches_contract(self, monkeypatch):
-        rows = [{"x": 1}]
+def test_format_messages_batches_lookup__calls_accessor_per_row_and_batches_agent_lookup(monkeypatch):
+    rows = [
+        {"row_index": 0, "from": "a1", "to": "a2"},
+        {"row_index": 1, "from": "a1", "to": "a3"},
+    ]
 
-        def accessor(row):
-            return {
-                "task_id": "t1",
-                "from_id": "a1",
-                "to_id": "a2",
-                "type_": "message",
-                "status": "input_required",
-                "created_at": "2026-04-30T00:00:00+00:00",
-                "status_timestamp": "2026-04-30T00:00:00+00:00",
-                "origin_task_id": None,
-                "body": "hello",
-            }
+    accessor_inputs = []
 
-        monkeypatch.setattr(
-            webui_api.broker,
-            "get_agent_names",
-            lambda _ids: {"a1": "alpha", "a2": "beta"},
-        )
-
-        result = _format_messages(rows, accessor)
-        assert len(result) == 1
-        assert set(result[0].keys()) == _EXPECTED_KEYS
-
-
-class TestRawTaskAccessor:
-    def test_extracts_from_broker_inbox_row_shape(self):
-        row = {
-            "task_id": "tid-1",
-            "from_agent_id": "a1",
-            "to_agent_id": "a2",
-            "type": "unicast",
-            "status_state": "input_required",
-            "created_at": "2026-04-30T01:00:00+00:00",
-            "status_timestamp": "2026-04-30T02:00:00+00:00",
+    def accessor(row):
+        accessor_inputs.append(row)
+        return {
+            "task_id": f"task-{row['row_index']}",
+            "from_id": row["from"],
+            "to_id": row["to"],
+            "type_": "message",
+            "status": "input_required",
+            "created_at": "2026-04-30T00:00:00+00:00",
+            "status_timestamp": "2026-04-30T00:00:00+00:00",
             "origin_task_id": None,
-            "task_json": (
-                '{"id":"tid-1","artifacts":[{"parts":[{"text":"hello world"}]}]}'
-            ),
+            "body": f"body-{row['row_index']}",
         }
 
-        result = _raw_task_accessor(row)
+    get_agent_names_calls = []
 
-        assert result["task_id"] == "tid-1"
-        assert result["from_id"] == "a1"
-        assert result["to_id"] == "a2"
-        assert result["type_"] == "unicast"
-        assert result["status"] == "input_required"
-        assert result["created_at"] == "2026-04-30T01:00:00+00:00"
-        assert result["status_timestamp"] == "2026-04-30T02:00:00+00:00"
-        assert result["origin_task_id"] is None
-        assert result["body"] == "hello world"
+    def fake_get_agent_names(ids):
+        get_agent_names_calls.append(set(ids))
+        return {"a1": "alpha", "a2": "beta", "a3": "gamma"}
+
+    monkeypatch.setattr(webui_api.broker, "get_agent_names", fake_get_agent_names)
+
+    result = _format_messages(rows, accessor)
+
+    assert accessor_inputs == rows
+    assert len(get_agent_names_calls) == 1
+    assert get_agent_names_calls[0] == {"a1", "a2", "a3"}
+    assert len(result) == 2
+    assert result[0]["from_agent_name"] == "alpha"
+    assert result[0]["to_agent_name"] == "beta"
+    assert result[1]["to_agent_name"] == "gamma"
 
 
-class TestTimelineEntryAccessor:
-    def test_extracts_from_broker_list_timeline_entry_shape(self):
-        entry = {
-            "task": {
-                "id": "tid-2",
-                "status": {
-                    "state": "completed",
-                    "timestamp": "2026-04-30T03:00:00+00:00",
-                },
-                "metadata": {
-                    "fromAgentId": "b1",
-                    "toAgentId": "b2",
-                    "type": "unicast",
-                },
-                "artifacts": [{"parts": [{"text": "timeline body"}]}],
+def test_format_messages_shape__output_dict_shape_matches_contract(monkeypatch):
+    rows = [{"x": 1}]
+
+    def accessor(row):
+        return {
+            "task_id": "t1",
+            "from_id": "a1",
+            "to_id": "a2",
+            "type_": "message",
+            "status": "input_required",
+            "created_at": "2026-04-30T00:00:00+00:00",
+            "status_timestamp": "2026-04-30T00:00:00+00:00",
+            "origin_task_id": None,
+            "body": "hello",
+        }
+
+    monkeypatch.setattr(
+        webui_api.broker,
+        "get_agent_names",
+        lambda _ids: {"a1": "alpha", "a2": "beta"},
+    )
+
+    result = _format_messages(rows, accessor)
+    assert len(result) == 1
+    assert set(result[0].keys()) == _EXPECTED_KEYS
+
+
+def test_raw_task_accessor__extracts_from_broker_inbox_row_shape():
+    row = {
+        "task_id": "tid-1",
+        "from_agent_id": "a1",
+        "to_agent_id": "a2",
+        "type": "unicast",
+        "status_state": "input_required",
+        "created_at": "2026-04-30T01:00:00+00:00",
+        "status_timestamp": "2026-04-30T02:00:00+00:00",
+        "origin_task_id": None,
+        "task_json": (
+            '{"id":"tid-1","artifacts":[{"parts":[{"text":"hello world"}]}]}'
+        ),
+    }
+
+    result = _raw_task_accessor(row)
+
+    assert result["task_id"] == "tid-1"
+    assert result["from_id"] == "a1"
+    assert result["to_id"] == "a2"
+    assert result["type_"] == "unicast"
+    assert result["status"] == "input_required"
+    assert result["created_at"] == "2026-04-30T01:00:00+00:00"
+    assert result["status_timestamp"] == "2026-04-30T02:00:00+00:00"
+    assert result["origin_task_id"] is None
+    assert result["body"] == "hello world"
+
+
+def test_timeline_entry_accessor__extracts_from_broker_list_timeline_entry_shape():
+    entry = {
+        "task": {
+            "id": "tid-2",
+            "status": {
+                "state": "completed",
+                "timestamp": "2026-04-30T03:00:00+00:00",
             },
-            "created_at": "2026-04-30T03:30:00+00:00",
-            "origin_task_id": "origin-1",
-        }
+            "metadata": {
+                "fromAgentId": "b1",
+                "toAgentId": "b2",
+                "type": "unicast",
+            },
+            "artifacts": [{"parts": [{"text": "timeline body"}]}],
+        },
+        "created_at": "2026-04-30T03:30:00+00:00",
+        "origin_task_id": "origin-1",
+    }
 
-        result = _timeline_entry_accessor(entry)
+    result = _timeline_entry_accessor(entry)
 
-        assert result["task_id"] == "tid-2"
-        assert result["from_id"] == "b1"
-        assert result["to_id"] == "b2"
-        assert result["type_"] == "unicast"
-        assert result["status"] == "completed"
-        assert result["created_at"] == "2026-04-30T03:30:00+00:00"
-        assert result["status_timestamp"] == "2026-04-30T03:00:00+00:00"
-        assert result["origin_task_id"] == "origin-1"
-        assert result["body"] == "timeline body"
-
-
-class TestFormatMessagesEndToEndRawTaskAccessor:
-    def test_inbox_rows_through_format_messages_match_contract(self):
-        sid, sender, recipient = _two_agents()
-        broker.send_message(sid, sender, recipient, "snapshot body")
-
-        rows = broker.list_inbox(recipient)
-        result = _format_messages(rows, _raw_task_accessor)
-
-        assert len(result) == 1
-        msg = result[0]
-        assert set(msg.keys()) == _EXPECTED_KEYS
-        assert msg["from_agent_id"] == sender
-        assert msg["from_agent_name"] == "alpha"
-        assert msg["to_agent_id"] == recipient
-        assert msg["to_agent_name"] == "beta"
-        assert msg["type"] == "unicast"
-        assert msg["status"] == "input_required"
-        assert msg["body"] == "snapshot body"
-        assert msg["origin_task_id"] is None
-        assert isinstance(msg["task_id"], str)
-        assert msg["task_id"]
-        assert isinstance(msg["created_at"], str)
-        assert msg["created_at"]
-        assert isinstance(msg["status_timestamp"], str)
-        assert msg["status_timestamp"]
+    assert result["task_id"] == "tid-2"
+    assert result["from_id"] == "b1"
+    assert result["to_id"] == "b2"
+    assert result["type_"] == "unicast"
+    assert result["status"] == "completed"
+    assert result["created_at"] == "2026-04-30T03:30:00+00:00"
+    assert result["status_timestamp"] == "2026-04-30T03:00:00+00:00"
+    assert result["origin_task_id"] == "origin-1"
+    assert result["body"] == "timeline body"
 
 
-class TestFormatMessagesEndToEndTimelineEntryAccessor:
-    def test_timeline_entries_through_format_messages_match_contract(self):
-        sid, sender, recipient = _two_agents()
-        broker.send_message(sid, sender, recipient, "timeline snapshot")
+def test_format_messages_end_to_end_raw_task_accessor__inbox_rows_through_format_messages_match_contract():
+    sid, sender, recipient = _two_agents()
+    broker.send_message(sid, sender, recipient, "snapshot body")
 
-        entries = broker.list_timeline(sid)
-        result = _format_messages(entries, _timeline_entry_accessor)
+    rows = broker.list_inbox(recipient)
+    result = _format_messages(rows, _raw_task_accessor)
 
-        assert len(result) == 1
-        msg = result[0]
-        assert set(msg.keys()) == _EXPECTED_KEYS
-        assert msg["from_agent_id"] == sender
-        assert msg["from_agent_name"] == "alpha"
-        assert msg["to_agent_id"] == recipient
-        assert msg["to_agent_name"] == "beta"
-        assert msg["type"] == "unicast"
-        assert msg["status"] == "input_required"
-        assert msg["body"] == "timeline snapshot"
-        assert isinstance(msg["task_id"], str)
-        assert msg["task_id"]
-        assert isinstance(msg["created_at"], str)
-        assert msg["created_at"]
-        assert isinstance(msg["status_timestamp"], str)
-        assert msg["status_timestamp"]
+    assert len(result) == 1
+    msg = result[0]
+    assert set(msg.keys()) == _EXPECTED_KEYS
+    assert msg["from_agent_id"] == sender
+    assert msg["from_agent_name"] == "alpha"
+    assert msg["to_agent_id"] == recipient
+    assert msg["to_agent_name"] == "beta"
+    assert msg["type"] == "unicast"
+    assert msg["status"] == "input_required"
+    assert msg["body"] == "snapshot body"
+    assert msg["origin_task_id"] is None
+    assert isinstance(msg["task_id"], str)
+    assert msg["task_id"]
+    assert isinstance(msg["created_at"], str)
+    assert msg["created_at"]
+    assert isinstance(msg["status_timestamp"], str)
+    assert msg["status_timestamp"]
+
+
+def test_format_messages_end_to_end_timeline_entry_accessor__timeline_entries_through_format_messages_match_contract():
+    sid, sender, recipient = _two_agents()
+    broker.send_message(sid, sender, recipient, "timeline snapshot")
+
+    entries = broker.list_timeline(sid)
+    result = _format_messages(entries, _timeline_entry_accessor)
+
+    assert len(result) == 1
+    msg = result[0]
+    assert set(msg.keys()) == _EXPECTED_KEYS
+    assert msg["from_agent_id"] == sender
+    assert msg["from_agent_name"] == "alpha"
+    assert msg["to_agent_id"] == recipient
+    assert msg["to_agent_name"] == "beta"
+    assert msg["type"] == "unicast"
+    assert msg["status"] == "input_required"
+    assert msg["body"] == "timeline snapshot"
+    assert isinstance(msg["task_id"], str)
+    assert msg["task_id"]
+    assert isinstance(msg["created_at"], str)
+    assert msg["created_at"]
+    assert isinstance(msg["status_timestamp"], str)
+    assert msg["status_timestamp"]

--- a/cafleet/tests/test_webui_api_format.py
+++ b/cafleet/tests/test_webui_api_format.py
@@ -89,7 +89,9 @@ def test_format_messages_empty__empty_rows_returns_empty_and_skips_lookup(monkey
     assert accessor_calls == []
 
 
-def test_format_messages_batches_lookup__calls_accessor_per_row_and_batches_agent_lookup(monkeypatch):
+def test_format_messages_batches_lookup__calls_accessor_per_row_and_batches_agent_lookup(
+    monkeypatch,
+):
     rows = [
         {"row_index": 0, "from": "a1", "to": "a2"},
         {"row_index": 1, "from": "a1", "to": "a3"},

--- a/design-docs/0000044-pytest-functional-style/design-doc.md
+++ b/design-docs/0000044-pytest-functional-style/design-doc.md
@@ -1,0 +1,232 @@
+# Refactor Test Suite to Functional Pytest Style
+
+**Status**: Approved
+**Progress**: 3/44 tasks complete
+**Last Updated**: 2026-05-01
+
+## Overview
+
+The cafleet test suite currently uses pytest class-style flavor (`class Test...:` containers grouping `test_*` methods). This design refactors every class-style file under `cafleet/tests/` to plain top-level `test_*` functions. The change is mechanical — same test count, same assertions, same fixtures, same coverage — and produces a flatter, more idiomatic pytest layout.
+
+## Success Criteria
+
+- [ ] `git grep "^class Test"` inside `cafleet/tests/` returns no matches
+- [ ] `pytest --collect-only -q` reports the **same number of tests** as the pre-refactor baseline
+- [ ] `mise //cafleet:test` passes
+- [ ] `mise //cafleet:lint` passes
+- [ ] `mise //cafleet:format` reports no changes
+- [ ] `mise //cafleet:typecheck` passes
+- [ ] No new tests are added; the existing suite is the oracle
+
+---
+
+## Background
+
+The CAFleet test suite has 32 `test_*.py` files under `cafleet/tests/` (plus `conftest.py` and `__init__.py`, neither in scope for renaming). 28 of those 32 files currently use class-style organization with about 120 `class Test*` containers; the remaining 4 (`test_alembic_smoke.py`, `test_cli_version.py`, `test_db_init.py`, `test_db_pragmas.py`) are already function-style and stay untouched. The class-style containers are **purely organizational** — none of them use class-scoped fixtures, none inherit from a base class, none define `setup_method` / `teardown_method` / `setup_class` / `teardown_class`, and none share state across methods via `self` (with one exception, two files use class-level constants accessed via `self`, see Specification §C). All fixtures are defined at module level or in `conftest.py`.
+
+The `[tool.pytest.ini_options]` table in `cafleet/pyproject.toml` is empty, so pytest's default collection rules apply (`Test*` classes and `test_*` functions). Removing the `Test*` containers does not alter collection because top-level `test_*` functions are also collected by default.
+
+The §A recipe assumes there are no class-scoped marks (`@pytest.mark.parametrize` or other `@pytest.mark.*`) sitting directly on the class declarations. This is verifiable today via `git grep -nE "^@pytest\.mark\." cafleet/tests/`, which returns zero matches. Existing `@pytest.mark.parametrize` decorators all sit on individual methods inside classes (see §A step 5).
+
+Functional style is the more common modern convention in pytest projects: less ceremony, fewer indentation levels, no `self` argument noise, and no organizational hierarchy that pytest does not actually use beyond test ID generation.
+
+---
+
+## Specification
+
+### A. Conversion recipe (per class)
+
+For each `class TestSomeThing:` in a test file:
+
+1. Convert the class name `TestSomeThing` to a snake_case prefix: `some_thing` (drop the leading `Test`, then PEP 8 lowercase with underscore boundaries between camel-case words).
+2. For every method `def test_method_name(self, ...args):` inside the class, emit a top-level function `def test_some_thing__method_name(...args):` — note the **double underscore** between class context and original method name.
+3. Drop the `self` parameter from every method's signature.
+4. Replace any `self.X` reference in the method body with the module-level binding `X` (see §C for class-attribute promotion rules).
+5. Move `@pytest.mark.parametrize(...)` decorators that sit on a method directly onto the resulting top-level function. No semantics change because the suite has no class-scoped parametrization (no `pytest.mark.parametrize` decorators on classes themselves).
+6. Preserve the original method order inside each file. Class boundaries become blank lines between function groups; an inline comment `# --- some_thing ---` MAY be added for readability when a file contains many groups, but is not required.
+7. Delete the now-empty `class TestSomeThing:` line.
+
+The class docstring (if any) MUST be either dropped (if it merely restates the class name) or relocated as a module-level section comment above the resulting function group.
+
+### B. Naming convention — examples
+
+| Class definition | Method | Resulting top-level function |
+|---|---|---|
+| `class TestSendMessage:` | `def test_persists_row(self): ...` | `def test_send_message__persists_row(): ...` |
+| `class TestBroadcastAdministratorExclusion:` | `def test_skips_admin(self, runner): ...` | `def test_broadcast_administrator_exclusion__skips_admin(runner): ...` |
+| `class TestMigration0002Upgrade:` | `def test_inserts_session_row(self): ...` | `def test_migration_0002_upgrade__inserts_session_row(): ...` |
+| `class TestDoctorJsonOutput:` | `def test_emits_pane_id(self, monkeypatch): ...` | `def test_doctor_json_output__emits_pane_id(monkeypatch): ...` |
+
+The double underscore separator (`__`) is used uniformly so that the `pytest -k` selector and pytest test ID stay self-describing.
+
+### C. Class attributes / helper classes
+
+Two files use class-level constants accessed via `self`. Both promote to module-level constants with the **same name**:
+
+| File | Current | Converted |
+|---|---|---|
+| `test_cli_claude_helpers.py` | `class TestClaudePromptTemplate: _STANDARD_KWARGS = {...}` accessed via `self._STANDARD_KWARGS` | Top-level `_STANDARD_KWARGS = {...}` placed immediately above the function group, accessed bare |
+| `test_server_cli.py` | `class TestWebUIDistWarning: _WARNING_PREFIX = "..."` accessed via `self._WARNING_PREFIX` | Top-level `_WARNING_PREFIX = "..."` placed immediately above the function group, accessed bare |
+
+Helper classes that are NOT pytest test classes (no `Test` prefix) MUST be left untouched. Specifically `class _FakeClock:` in `cafleet/tests/test_tmux.py` is a stateful test helper; preserve its definition and all `self.now` / `self.sleep_calls` usage exactly as-is.
+
+### D. What is NOT changed
+
+- Module-level fixtures (every fixture in this suite already lives at module level or in `conftest.py`).
+- The single autouse fixture `_silence_real_tmux_subprocess` in `cafleet/tests/conftest.py`.
+- Test logic: no assertion text, no monkeypatch target, no parametrize value, no fixture argument is altered.
+- Test file count, test file names, and the `cafleet/tests/` directory layout — no files are split, renamed, or merged. Mechanical conversion is the default for every file. Splitting an oversize file is **out of scope** for this refactor; a separate cleanup pass can address it later if desired.
+- Pytest collection IDs change shape (from `tests/test_x.py::TestFoo::test_bar` to `tests/test_x.py::test_foo__test_bar`), but the suite has no consumers pinning on those IDs and no migration note is required.
+
+### E. Files in scope
+
+28 files under `cafleet/tests/`, listed in the implementation step that owns them. Already-functional files (`test_alembic_smoke.py`, `test_cli_version.py`, `test_db_init.py`, `test_db_pragmas.py`) are out of scope.
+
+### F. Worked example
+
+Before (`cafleet/tests/test_cli_doctor.py`, abbreviated):
+
+```python
+class TestDoctorTextOutput:
+    def test_emits_pane_block(self, runner_with_tmux_env):
+        result = runner_with_tmux_env.invoke(cli, ["doctor"])
+        assert result.exit_code == 0
+        assert "tmux:" in result.output
+
+
+class TestDoctorJsonOutput:
+    def test_emits_pane_id(self, runner_with_tmux_env):
+        result = runner_with_tmux_env.invoke(cli, ["--json", "doctor"])
+        assert result.exit_code == 0
+```
+
+After:
+
+```python
+def test_doctor_text_output__emits_pane_block(runner_with_tmux_env):
+    result = runner_with_tmux_env.invoke(cli, ["doctor"])
+    assert result.exit_code == 0
+    assert "tmux:" in result.output
+
+
+def test_doctor_json_output__emits_pane_id(runner_with_tmux_env):
+    result = runner_with_tmux_env.invoke(cli, ["--json", "doctor"])
+    assert result.exit_code == 0
+```
+
+### G. Opt-in cleanup evaluation
+
+The user authorization permits opportunistic cleanup beyond the mechanical conversion: splitting overgrown test files into per-concern files, and merging near-duplicate test groups into `@pytest.mark.parametrize`. To keep this refactor reviewable, both forms of cleanup require a **named criterion**, evaluated up-front against every in-scope file, before any conversion work begins.
+
+#### G.1 File-split criterion
+
+A class-style file is a split candidate iff **all three** conditions hold:
+
+1. The file exceeds 800 source lines.
+2. It contains 8 or more `class Test*` containers.
+3. The classes group into 3 or more orthogonal subjects, each with a coherent name independent of the others, such that splitting yields per-subject files that each tell a self-contained story.
+
+Failing any one disqualifies the file. The 800-line threshold is deliberately conservative: a 600-line file that happens to have 9 classes is still cohesive enough to read end-to-end, and splitting trades the navigation cost of "find the class" for the navigation cost of "find the file."
+
+#### G.2 Parametrize-merge criterion
+
+A group of adjacent test functions is a merge candidate iff **all three** conditions hold:
+
+1. There are 3 or more such functions.
+2. Their bodies differ only in input value(s) and expected output(s) — same setup, same assertion shape, same monkeypatch targets.
+3. The individual function names are not load-bearing prose (i.e., they do not document a distinct intent that would be lost as a parametrize id).
+
+#### G.3 Evaluation result
+
+The Drafter inventoried every in-scope file under §E. **No file meets the §G.1 split criterion** and **no test group meets the §G.2 parametrize-merge criterion** under conservative reading. The largest files by class count are `test_tmux.py` (12 classes) and `test_broker_registry.py` (11 classes); both stay below the 800-line threshold and their class groupings already align with single subjects (tmux primitive operations; registry CRUD operations) that read coherently as one file each. Existing `@pytest.mark.parametrize` decorators already cover the obvious table-driven groups (digit ranges, newline variants, etc.).
+
+Therefore this design proceeds with **mechanical conversion only**. A separate cleanup pass remains the right vehicle if the suite later grows past the §G.1 / §G.2 thresholds.
+
+---
+
+## Implementation
+
+> Task format: `- [x] Done task <!-- completed: 2026-02-13T14:30 -->`
+> When completing a task, check the box and record the timestamp in the same edit.
+
+### Step 1: Establish baseline
+
+- [x] Run `mise //cafleet:test` from the project root and confirm a green baseline. <!-- completed: 2026-05-01T12:00 -->
+- [x] Capture the pre-refactor test count via `mise //cafleet:test -- --collect-only -q` (mise forwards arguments after `--` to the underlying `uv run python -m pytest`) and record the count in this design doc immediately below this checklist as `Baseline test count: N`. <!-- completed: 2026-05-01T12:00 -->
+- [x] Confirm the §A step 5 invariant by running `git grep -nE "^@pytest\.mark\." cafleet/tests/` and verifying the result is empty (no class-scoped marks). <!-- completed: 2026-05-01T12:00 -->
+
+Baseline test count: 557
+
+### Step 2: Refactor broker-layer tests
+
+Apply the §A recipe to:
+
+- [ ] `cafleet/tests/test_broker_administrator.py` — 5 classes <!-- completed: -->
+- [ ] `cafleet/tests/test_broker_messaging.py` — 7 classes <!-- completed: -->
+- [ ] `cafleet/tests/test_broker_registry.py` — 11 classes <!-- completed: -->
+- [ ] `cafleet/tests/test_broker_webui.py` — 8 classes <!-- completed: -->
+- [ ] After this step, run `mise //cafleet:test` and confirm green. <!-- completed: -->
+
+### Step 3: Refactor CLI agent / message / generic tests
+
+- [ ] `cafleet/tests/test_cli_agent.py` — 1 class <!-- completed: -->
+- [ ] `cafleet/tests/test_cli_claude_helpers.py` — 3 classes; promote `_STANDARD_KWARGS` to module-level (§C) <!-- completed: -->
+- [ ] `cafleet/tests/test_cli_client_command.py` — 4 classes <!-- completed: -->
+- [ ] `cafleet/tests/test_cli_doctor.py` — 4 classes <!-- completed: -->
+- [ ] `cafleet/tests/test_cli_message.py` — 4 classes <!-- completed: -->
+- [ ] `cafleet/tests/test_cli_message_truncation.py` — 4 classes <!-- completed: -->
+- [ ] After this step, run `mise //cafleet:test` and confirm green. <!-- completed: -->
+
+### Step 4: Refactor CLI member-family tests
+
+- [ ] `cafleet/tests/test_cli_member.py` — 7 classes <!-- completed: -->
+- [ ] `cafleet/tests/test_cli_member_delete.py` — 8 classes <!-- completed: -->
+- [ ] `cafleet/tests/test_cli_member_exec.py` — 4 classes <!-- completed: -->
+- [ ] `cafleet/tests/test_cli_member_ping.py` — 5 classes <!-- completed: -->
+- [ ] `cafleet/tests/test_cli_member_send_input.py` — 8 classes <!-- completed: -->
+- [ ] After this step, run `mise //cafleet:test` and confirm green. <!-- completed: -->
+
+### Step 5: Refactor session + bootstrap tests
+
+- [ ] `cafleet/tests/test_cli_session_bootstrap.py` — 5 classes <!-- completed: -->
+- [ ] `cafleet/tests/test_cli_session_flag.py` — 5 classes <!-- completed: -->
+- [ ] `cafleet/tests/test_session_bootstrap.py` — 7 classes <!-- completed: -->
+- [ ] `cafleet/tests/test_session_cli.py` — 6 classes <!-- completed: -->
+- [ ] After this step, run `mise //cafleet:test` and confirm green. <!-- completed: -->
+
+### Step 6: Refactor alembic migration tests
+
+- [ ] `cafleet/tests/test_alembic_0002_upgrade.py` — 2 classes <!-- completed: -->
+- [ ] `cafleet/tests/test_alembic_0006_upgrade.py` — 3 classes <!-- completed: -->
+- [ ] `cafleet/tests/test_alembic_0008_upgrade.py` — 3 classes <!-- completed: -->
+- [ ] After this step, run `mise //cafleet:test` and confirm green. <!-- completed: -->
+
+### Step 7: Refactor remaining tests
+
+- [ ] `cafleet/tests/test_output.py` — 4 classes <!-- completed: -->
+- [ ] `cafleet/tests/test_output_indexed_list.py` — 1 class <!-- completed: -->
+- [ ] `cafleet/tests/test_server_cli.py` — 5 classes; promote `_WARNING_PREFIX` to module-level (§C) <!-- completed: -->
+- [ ] `cafleet/tests/test_tmux.py` — 12 `Test*` classes; **preserve `class _FakeClock`** untouched (§C) <!-- completed: -->
+- [ ] `cafleet/tests/test_tmux_send_helpers.py` — 1 class <!-- completed: -->
+- [ ] `cafleet/tests/test_webui_api_format.py` — 7 classes <!-- completed: -->
+- [ ] After this step, run `mise //cafleet:test` and confirm green. <!-- completed: -->
+
+### Step 8: Final verification
+
+- [ ] `git grep "^class Test" cafleet/tests/` returns no matches. <!-- completed: -->
+- [ ] `class _FakeClock` still present in `cafleet/tests/test_tmux.py` (helper class is preserved). <!-- completed: -->
+- [ ] `mise //cafleet:test -- --collect-only -q` count matches the Step 1 baseline test count exactly. <!-- completed: -->
+- [ ] `mise //cafleet:test` passes. <!-- completed: -->
+- [ ] `mise //cafleet:lint` passes. <!-- completed: -->
+- [ ] `mise //cafleet:format` reports no changes (run as a check; no files should be modified). <!-- completed: -->
+- [ ] `mise //cafleet:typecheck` passes. <!-- completed: -->
+
+---
+
+## Changelog
+
+| Date | Changes |
+|------|---------|
+| 2026-05-01 | Initial draft |
+| 2026-05-01 | Reviewer round 1: corrected file count to 32 (28 class-style + 4 already-functional); added §G opt-in cleanup criteria with explicit "no candidates" evaluation; fixed progress denominator to match checkbox count; replaced bypass `uv run pytest --collect-only` with mise-routed `mise //cafleet:test -- --collect-only -q`; added §A step 5 verification grep into Step 1 |
+| 2026-05-01 | Approved by user — Status flipped Draft → Approved |

--- a/design-docs/0000044-pytest-functional-style/design-doc.md
+++ b/design-docs/0000044-pytest-functional-style/design-doc.md
@@ -1,6 +1,6 @@
 # Refactor Test Suite to Functional Pytest Style
 
-**Status**: Approved
+**Status**: Complete
 **Progress**: 44/44 tasks complete
 **Last Updated**: 2026-05-01
 
@@ -230,3 +230,4 @@ Apply the §A recipe to:
 | 2026-05-01 | Initial draft |
 | 2026-05-01 | Reviewer round 1: corrected file count to 32 (28 class-style + 4 already-functional); added §G opt-in cleanup criteria with explicit "no candidates" evaluation; fixed progress denominator to match checkbox count; replaced bypass `uv run pytest --collect-only` with mise-routed `mise //cafleet:test -- --collect-only -q`; added §A step 5 verification grep into Step 1 |
 | 2026-05-01 | Approved by user — Status flipped Draft → Approved |
+| 2026-05-01 | Implementation complete. All 8 steps green, 557 tests pass, Success Criteria satisfied, ruff lint + format + ty typecheck all clean. Copilot review cycles: round 1 surfaced 3 nits (2 design-doc clarifications about pre/post-refactor invariants, 1 source-rename `test_broker_host_default__broker_port_default_is_8000` → `test_broker_port_default__is_8000`); round 1 fix-push prompted 1 follow-up nit (symmetric rename of `cafleet_env_var_is_read` → `cafleet_broker_port_env_var_is_read` to mirror the host sister test); round 2 fix-push received 0 new Copilot comments. PR #47 finalized with user approval — Status flipped Approved → Complete. |

--- a/design-docs/0000044-pytest-functional-style/design-doc.md
+++ b/design-docs/0000044-pytest-functional-style/design-doc.md
@@ -1,7 +1,7 @@
 # Refactor Test Suite to Functional Pytest Style
 
 **Status**: Approved
-**Progress**: 15/44 tasks complete
+**Progress**: 21/44 tasks complete
 **Last Updated**: 2026-05-01
 
 ## Overview
@@ -179,12 +179,12 @@ Apply the §A recipe to:
 
 ### Step 4: Refactor CLI member-family tests
 
-- [ ] `cafleet/tests/test_cli_member.py` — 7 classes <!-- completed: -->
-- [ ] `cafleet/tests/test_cli_member_delete.py` — 8 classes <!-- completed: -->
-- [ ] `cafleet/tests/test_cli_member_exec.py` — 4 classes <!-- completed: -->
-- [ ] `cafleet/tests/test_cli_member_ping.py` — 5 classes <!-- completed: -->
-- [ ] `cafleet/tests/test_cli_member_send_input.py` — 8 classes <!-- completed: -->
-- [ ] After this step, run `mise //cafleet:test` and confirm green. <!-- completed: -->
+- [x] `cafleet/tests/test_cli_member.py` — 7 classes <!-- completed: 2026-05-01T13:30 -->
+- [x] `cafleet/tests/test_cli_member_delete.py` — 8 classes <!-- completed: 2026-05-01T13:30 -->
+- [x] `cafleet/tests/test_cli_member_exec.py` — 4 classes <!-- completed: 2026-05-01T13:30 -->
+- [x] `cafleet/tests/test_cli_member_ping.py` — 5 classes <!-- completed: 2026-05-01T13:30 -->
+- [x] `cafleet/tests/test_cli_member_send_input.py` — 8 classes <!-- completed: 2026-05-01T13:30 -->
+- [x] After this step, run `mise //cafleet:test` and confirm green. <!-- completed: 2026-05-01T13:30 -->
 
 ### Step 5: Refactor session + bootstrap tests
 

--- a/design-docs/0000044-pytest-functional-style/design-doc.md
+++ b/design-docs/0000044-pytest-functional-style/design-doc.md
@@ -1,7 +1,7 @@
 # Refactor Test Suite to Functional Pytest Style
 
 **Status**: Approved
-**Progress**: 37/44 tasks complete
+**Progress**: 44/44 tasks complete
 **Last Updated**: 2026-05-01
 
 ## Overview
@@ -213,13 +213,13 @@ Apply the §A recipe to:
 
 ### Step 8: Final verification
 
-- [ ] `git grep "^class Test" cafleet/tests/` returns no matches. <!-- completed: -->
-- [ ] `class _FakeClock` still present in `cafleet/tests/test_tmux.py` (helper class is preserved). <!-- completed: -->
-- [ ] `mise //cafleet:test -- --collect-only -q` count matches the Step 1 baseline test count exactly. <!-- completed: -->
-- [ ] `mise //cafleet:test` passes. <!-- completed: -->
-- [ ] `mise //cafleet:lint` passes. <!-- completed: -->
-- [ ] `mise //cafleet:format` reports no changes (run as a check; no files should be modified). <!-- completed: -->
-- [ ] `mise //cafleet:typecheck` passes. <!-- completed: -->
+- [x] `git grep "^class Test" cafleet/tests/` returns no matches. <!-- completed: 2026-05-01 -->
+- [x] `class _FakeClock` still present in `cafleet/tests/test_tmux.py` (helper class is preserved). <!-- completed: 2026-05-01 -->
+- [x] `mise //cafleet:test -- --collect-only -q` count matches the Step 1 baseline test count exactly. <!-- completed: 2026-05-01 -->
+- [x] `mise //cafleet:test` passes. <!-- completed: 2026-05-01 -->
+- [x] `mise //cafleet:lint` passes. <!-- completed: 2026-05-01 -->
+- [x] `mise //cafleet:format` reports no changes (run as a check; no files should be modified). <!-- completed: 2026-05-01 -->
+- [x] `mise //cafleet:typecheck` passes. <!-- completed: 2026-05-01 -->
 
 ---
 

--- a/design-docs/0000044-pytest-functional-style/design-doc.md
+++ b/design-docs/0000044-pytest-functional-style/design-doc.md
@@ -1,7 +1,7 @@
 # Refactor Test Suite to Functional Pytest Style
 
 **Status**: Approved
-**Progress**: 8/44 tasks complete
+**Progress**: 15/44 tasks complete
 **Last Updated**: 2026-05-01
 
 ## Overview
@@ -169,13 +169,13 @@ Apply the §A recipe to:
 
 ### Step 3: Refactor CLI agent / message / generic tests
 
-- [ ] `cafleet/tests/test_cli_agent.py` — 1 class <!-- completed: -->
-- [ ] `cafleet/tests/test_cli_claude_helpers.py` — 3 classes; promote `_STANDARD_KWARGS` to module-level (§C) <!-- completed: -->
-- [ ] `cafleet/tests/test_cli_client_command.py` — 4 classes <!-- completed: -->
-- [ ] `cafleet/tests/test_cli_doctor.py` — 4 classes <!-- completed: -->
-- [ ] `cafleet/tests/test_cli_message.py` — 4 classes <!-- completed: -->
-- [ ] `cafleet/tests/test_cli_message_truncation.py` — 4 classes <!-- completed: -->
-- [ ] After this step, run `mise //cafleet:test` and confirm green. <!-- completed: -->
+- [x] `cafleet/tests/test_cli_agent.py` — 1 class <!-- completed: 2026-05-01T13:00 -->
+- [x] `cafleet/tests/test_cli_claude_helpers.py` — 3 classes; promote `_STANDARD_KWARGS` to module-level (§C) <!-- completed: 2026-05-01T13:00 -->
+- [x] `cafleet/tests/test_cli_client_command.py` — 4 classes <!-- completed: 2026-05-01T13:00 -->
+- [x] `cafleet/tests/test_cli_doctor.py` — 4 classes <!-- completed: 2026-05-01T13:00 -->
+- [x] `cafleet/tests/test_cli_message.py` — 4 classes <!-- completed: 2026-05-01T13:00 -->
+- [x] `cafleet/tests/test_cli_message_truncation.py` — 4 classes <!-- completed: 2026-05-01T13:00 -->
+- [x] After this step, run `mise //cafleet:test` and confirm green. <!-- completed: 2026-05-01T13:00 -->
 
 ### Step 4: Refactor CLI member-family tests
 

--- a/design-docs/0000044-pytest-functional-style/design-doc.md
+++ b/design-docs/0000044-pytest-functional-style/design-doc.md
@@ -1,7 +1,7 @@
 # Refactor Test Suite to Functional Pytest Style
 
 **Status**: Approved
-**Progress**: 3/44 tasks complete
+**Progress**: 8/44 tasks complete
 **Last Updated**: 2026-05-01
 
 ## Overview
@@ -161,11 +161,11 @@ Baseline test count: 557
 
 Apply the §A recipe to:
 
-- [ ] `cafleet/tests/test_broker_administrator.py` — 5 classes <!-- completed: -->
-- [ ] `cafleet/tests/test_broker_messaging.py` — 7 classes <!-- completed: -->
-- [ ] `cafleet/tests/test_broker_registry.py` — 11 classes <!-- completed: -->
-- [ ] `cafleet/tests/test_broker_webui.py` — 8 classes <!-- completed: -->
-- [ ] After this step, run `mise //cafleet:test` and confirm green. <!-- completed: -->
+- [x] `cafleet/tests/test_broker_administrator.py` — 5 classes <!-- completed: 2026-05-01T12:30 -->
+- [x] `cafleet/tests/test_broker_messaging.py` — 7 classes <!-- completed: 2026-05-01T12:30 -->
+- [x] `cafleet/tests/test_broker_registry.py` — 11 classes <!-- completed: 2026-05-01T12:30 -->
+- [x] `cafleet/tests/test_broker_webui.py` — 8 classes <!-- completed: 2026-05-01T12:30 -->
+- [x] After this step, run `mise //cafleet:test` and confirm green. <!-- completed: 2026-05-01T12:30 -->
 
 ### Step 3: Refactor CLI agent / message / generic tests
 

--- a/design-docs/0000044-pytest-functional-style/design-doc.md
+++ b/design-docs/0000044-pytest-functional-style/design-doc.md
@@ -1,7 +1,7 @@
 # Refactor Test Suite to Functional Pytest Style
 
 **Status**: Approved
-**Progress**: 21/44 tasks complete
+**Progress**: 26/44 tasks complete
 **Last Updated**: 2026-05-01
 
 ## Overview
@@ -188,11 +188,11 @@ Apply the §A recipe to:
 
 ### Step 5: Refactor session + bootstrap tests
 
-- [ ] `cafleet/tests/test_cli_session_bootstrap.py` — 5 classes <!-- completed: -->
-- [ ] `cafleet/tests/test_cli_session_flag.py` — 5 classes <!-- completed: -->
-- [ ] `cafleet/tests/test_session_bootstrap.py` — 7 classes <!-- completed: -->
-- [ ] `cafleet/tests/test_session_cli.py` — 6 classes <!-- completed: -->
-- [ ] After this step, run `mise //cafleet:test` and confirm green. <!-- completed: -->
+- [x] `cafleet/tests/test_cli_session_bootstrap.py` — 5 classes <!-- completed: 2026-05-01T14:00 -->
+- [x] `cafleet/tests/test_cli_session_flag.py` — 5 classes <!-- completed: 2026-05-01T14:00 -->
+- [x] `cafleet/tests/test_session_bootstrap.py` — 7 classes <!-- completed: 2026-05-01T14:00 -->
+- [x] `cafleet/tests/test_session_cli.py` — 6 classes <!-- completed: 2026-05-01T14:00 -->
+- [x] After this step, run `mise //cafleet:test` and confirm green. <!-- completed: 2026-05-01T14:00 -->
 
 ### Step 6: Refactor alembic migration tests
 

--- a/design-docs/0000044-pytest-functional-style/design-doc.md
+++ b/design-docs/0000044-pytest-functional-style/design-doc.md
@@ -26,7 +26,7 @@ The CAFleet test suite has 32 `test_*.py` files under `cafleet/tests/` (plus `co
 
 The `[tool.pytest.ini_options]` table in `cafleet/pyproject.toml` is empty, so pytest's default collection rules apply (`Test*` classes and `test_*` functions). Removing the `Test*` containers does not alter collection because top-level `test_*` functions are also collected by default.
 
-The §A recipe assumes there are no class-scoped marks (`@pytest.mark.parametrize` or other `@pytest.mark.*`) sitting directly on the class declarations. This is verifiable today via `git grep -nE "^@pytest\.mark\." cafleet/tests/`, which returns zero matches. Existing `@pytest.mark.parametrize` decorators all sit on individual methods inside classes (see §A step 5).
+The §A recipe assumes there were no class-scoped marks (`@pytest.mark.parametrize` or other `@pytest.mark.*`) sitting directly on the class declarations in the pre-refactor suite. Before the refactor, `git grep -nE "^@pytest\.mark\." cafleet/tests/` returned zero matches because existing `@pytest.mark.parametrize` decorators sat on individual methods inside classes rather than at module scope (see §A step 5). After the refactor, module-level `@pytest.mark.parametrize` decorators are expected, so that grep is no longer a valid post-refactor invariant.
 
 Functional style is the more common modern convention in pytest projects: less ceremony, fewer indentation levels, no `self` argument noise, and no organizational hierarchy that pytest does not actually use beyond test ID generation.
 
@@ -153,7 +153,7 @@ Therefore this design proceeds with **mechanical conversion only**. A separate c
 
 - [x] Run `mise //cafleet:test` from the project root and confirm a green baseline. <!-- completed: 2026-05-01T12:00 -->
 - [x] Capture the pre-refactor test count via `mise //cafleet:test -- --collect-only -q` (mise forwards arguments after `--` to the underlying `uv run python -m pytest`) and record the count in this design doc immediately below this checklist as `Baseline test count: N`. <!-- completed: 2026-05-01T12:00 -->
-- [x] Confirm the §A step 5 invariant by running `git grep -nE "^@pytest\.mark\." cafleet/tests/` and verifying the result is empty (no class-scoped marks). <!-- completed: 2026-05-01T12:00 -->
+- [x] Confirm the §A step 5 invariant by running `git grep -nP "(?s)^@pytest\.mark\..*\nclass Test" cafleet/tests/` and verifying the result is empty (no class-scoped marks immediately preceding `class Test...`). <!-- completed: 2026-05-01T12:00 -->
 
 Baseline test count: 557
 

--- a/design-docs/0000044-pytest-functional-style/design-doc.md
+++ b/design-docs/0000044-pytest-functional-style/design-doc.md
@@ -1,7 +1,7 @@
 # Refactor Test Suite to Functional Pytest Style
 
 **Status**: Approved
-**Progress**: 26/44 tasks complete
+**Progress**: 30/44 tasks complete
 **Last Updated**: 2026-05-01
 
 ## Overview
@@ -196,10 +196,10 @@ Apply the §A recipe to:
 
 ### Step 6: Refactor alembic migration tests
 
-- [ ] `cafleet/tests/test_alembic_0002_upgrade.py` — 2 classes <!-- completed: -->
-- [ ] `cafleet/tests/test_alembic_0006_upgrade.py` — 3 classes <!-- completed: -->
-- [ ] `cafleet/tests/test_alembic_0008_upgrade.py` — 3 classes <!-- completed: -->
-- [ ] After this step, run `mise //cafleet:test` and confirm green. <!-- completed: -->
+- [x] `cafleet/tests/test_alembic_0002_upgrade.py` — 2 classes <!-- completed: 2026-05-01T14:30 -->
+- [x] `cafleet/tests/test_alembic_0006_upgrade.py` — 3 classes <!-- completed: 2026-05-01T14:30 -->
+- [x] `cafleet/tests/test_alembic_0008_upgrade.py` — 3 classes <!-- completed: 2026-05-01T14:30 -->
+- [x] After this step, run `mise //cafleet:test` and confirm green. <!-- completed: 2026-05-01T14:30 -->
 
 ### Step 7: Refactor remaining tests
 

--- a/design-docs/0000044-pytest-functional-style/design-doc.md
+++ b/design-docs/0000044-pytest-functional-style/design-doc.md
@@ -10,13 +10,13 @@ The cafleet test suite currently uses pytest class-style flavor (`class Test...:
 
 ## Success Criteria
 
-- [ ] `git grep "^class Test"` inside `cafleet/tests/` returns no matches
-- [ ] `pytest --collect-only -q` reports the **same number of tests** as the pre-refactor baseline
-- [ ] `mise //cafleet:test` passes
-- [ ] `mise //cafleet:lint` passes
-- [ ] `mise //cafleet:format` reports no changes
-- [ ] `mise //cafleet:typecheck` passes
-- [ ] No new tests are added; the existing suite is the oracle
+- [x] `git grep "^class Test"` inside `cafleet/tests/` returns no matches
+- [x] `pytest --collect-only -q` reports the **same number of tests** as the pre-refactor baseline
+- [x] `mise //cafleet:test` passes
+- [x] `mise //cafleet:lint` passes
+- [x] `mise //cafleet:format` reports no changes
+- [x] `mise //cafleet:typecheck` passes
+- [x] No new tests are added; the existing suite is the oracle
 
 ---
 

--- a/design-docs/0000044-pytest-functional-style/design-doc.md
+++ b/design-docs/0000044-pytest-functional-style/design-doc.md
@@ -1,7 +1,7 @@
 # Refactor Test Suite to Functional Pytest Style
 
 **Status**: Approved
-**Progress**: 30/44 tasks complete
+**Progress**: 37/44 tasks complete
 **Last Updated**: 2026-05-01
 
 ## Overview
@@ -203,13 +203,13 @@ Apply the §A recipe to:
 
 ### Step 7: Refactor remaining tests
 
-- [ ] `cafleet/tests/test_output.py` — 4 classes <!-- completed: -->
-- [ ] `cafleet/tests/test_output_indexed_list.py` — 1 class <!-- completed: -->
-- [ ] `cafleet/tests/test_server_cli.py` — 5 classes; promote `_WARNING_PREFIX` to module-level (§C) <!-- completed: -->
-- [ ] `cafleet/tests/test_tmux.py` — 12 `Test*` classes; **preserve `class _FakeClock`** untouched (§C) <!-- completed: -->
-- [ ] `cafleet/tests/test_tmux_send_helpers.py` — 1 class <!-- completed: -->
-- [ ] `cafleet/tests/test_webui_api_format.py` — 7 classes <!-- completed: -->
-- [ ] After this step, run `mise //cafleet:test` and confirm green. <!-- completed: -->
+- [x] `cafleet/tests/test_output.py` — 4 classes <!-- completed: 2026-05-01T15:00 -->
+- [x] `cafleet/tests/test_output_indexed_list.py` — 1 class <!-- completed: 2026-05-01T15:00 -->
+- [x] `cafleet/tests/test_server_cli.py` — 5 classes; promote `_WARNING_PREFIX` to module-level (§C) <!-- completed: 2026-05-01T15:00 -->
+- [x] `cafleet/tests/test_tmux.py` — 12 `Test*` classes; **preserve `class _FakeClock`** untouched (§C) <!-- completed: 2026-05-01T15:00 -->
+- [x] `cafleet/tests/test_tmux_send_helpers.py` — 1 class <!-- completed: 2026-05-01T15:00 -->
+- [x] `cafleet/tests/test_webui_api_format.py` — 7 classes <!-- completed: 2026-05-01T15:00 -->
+- [x] After this step, run `mise //cafleet:test` and confirm green. <!-- completed: 2026-05-01T15:00 -->
 
 ### Step 8: Final verification
 


### PR DESCRIPTION
- **docs: add design doc 0000044-pytest-functional-style and Step 1 baseline (557 tests)**
- **refactor(tests): convert broker-layer tests to functional pytest style**
- **refactor(tests): convert CLI agent/message/generic tests to functional pytest style**
- **refactor(tests): convert CLI member-family tests to functional pytest style**
- **refactor(tests): convert session and bootstrap tests to functional pytest style**
- **refactor(tests): convert alembic migration tests to functional pytest style**
- **refactor(tests): convert remaining tests to functional pytest style**
- **style(tests): apply ruff format to refactored test files and complete Step 8 verification**
- **docs: check off Success Criteria for design 0000044**
