### PR TITLE
chore: define uv-sync globally

### DIFF
--- a/.claude/rules/commands.md
+++ b/.claude/rules/commands.md
@@ -7,7 +7,7 @@
 - Lint (admin): `mise //admin:lint`
 - Format: `mise //cafleet:format`
 - Type check: `mise //cafleet:typecheck`
-- Sync dependencies: `mise //:sync`
+- Sync dependencies: `mise //:uv-sync`
 - Install the `cafleet` CLI (editable uv tool): `mise //cafleet:install` — run this after pulling any change under `cafleet/src/cafleet/` if the global `cafleet` binary was previously installed non-editably; the editable reinstall makes future source edits take effect without another install.
 - Build cafleet wheel: `mise //cafleet:build` — emits the wheel into `cafleet/dist/`.
 - Publish cafleet: `mise //cafleet:publish` — chained task that builds admin assets, builds the wheel, then runs `uv publish`.

--- a/.claude/rules/commands.md
+++ b/.claude/rules/commands.md
@@ -7,7 +7,7 @@
 - Lint (admin): `mise //admin:lint`
 - Format: `mise //cafleet:format`
 - Type check: `mise //cafleet:typecheck`
-- Sync dependencies: `mise //cafleet:sync`
+- Sync dependencies: `mise //:sync`
 - Install the `cafleet` CLI (editable uv tool): `mise //cafleet:install` — run this after pulling any change under `cafleet/src/cafleet/` if the global `cafleet` binary was previously installed non-editably; the editable reinstall makes future source edits take effect without another install.
 - Build cafleet wheel: `mise //cafleet:build` — emits the wheel into `cafleet/dist/`.
 - Publish cafleet: `mise //cafleet:publish` — chained task that builds admin assets, builds the wheel, then runs `uv publish`.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -23,19 +23,7 @@
       "Bash(uv run pytest *)",
       "Bash(uv run python -m *)",
       "Bash(uv run --package *)",
-      "Bash(mise run *)",
-      "Bash(mise lint)",
-      "Bash(mise lint *)",
-      "Bash(mise format)",
-      "Bash(mise format *)",
-      "Bash(mise typecheck)",
-      "Bash(mise typecheck *)",
-      "Bash(mise test)",
-      "Bash(mise test *)",
-      "Bash(mise dev)",
-      "Bash(mise dev *)",
-      "Bash(mise build)",
-      "Bash(mise build *)"
+      "Bash(mise run *)"
     ],
     "ask": [
       "Bash(cafleet * member exec *)"

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Clone the repo and use mise for all common tasks:
 git clone https://github.com/himkt/cafleet.git
 cd cafleet
 
-mise //cafleet:sync
+mise //:uv-sync
 mise //cafleet:install    # editable uv tool install of the cafleet CLI
 cafleet db init           # apply schema migrations (idempotent; rerun after upgrades)
 

--- a/cafleet/mise.toml
+++ b/cafleet/mise.toml
@@ -29,10 +29,6 @@ description = "Install the cafleet CLI as an editable uv tool (source edits take
 run = "uv build --wheel --package cafleet --out-dir ./dist"
 description = "Build the cafleet wheel into cafleet/dist/ (the explicit --out-dir prevents uv from writing to the uv-workspace root by default)"
 
-[tasks.sync]
-run = "uv sync --all-groups --all-packages --frozen"
-description = "Sync uv workspace dependencies (all groups, all packages, frozen lockfile)"
-
 [tasks.publish]
 run = [
   { task = "//admin:install" },

--- a/mise.toml
+++ b/mise.toml
@@ -9,3 +9,7 @@ config_roots = [
 [tools]
 "aqua:astral-sh/uv" = "latest"
 "core:bun" = "latest"
+
+[tasks.uv-sync]
+run = "uv sync --all-groups --all-packages --frozen"
+description = "Sync uv workspace dependencies (all groups, all packages, frozen lockfile)"


### PR DESCRIPTION
Since `uv sync --all-groups --all-packages` prepares the Python environment for entire the repository, this task should be defined on the top `mise.toml`.