### PR TITLE
docs: correct plugin install command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Run the following commands on your terminal:
 
 ```
 /plugin marketplace add himkt/cafleet
-/plugin install cafleet@himkt-cafleet
+/plugin install cafleet@cafleet
 ```
 
 > [!IMPORTANT]


### PR DESCRIPTION
## Issue
The command in README failed with the message below.

```
/plugin install cafleet@himkt-cafleet
  ⎿  Marketplace "himkt-cafleet" not found
```

The marketplace name registered from `.claude-plugin/marketplace.json` is `cafleet`, so the correct command is `/plugin install cafleet@cafleet`.