### PR TITLE
Purge historical-trajectory narration (design 0000072)

### DIFF
--- a/.claude/rules/commands.md
+++ b/.claude/rules/commands.md
@@ -25,7 +25,7 @@
   - Stop on first failure with verbose output: `mise //cafleet:test -xvs tests/test_my.py`
   - Match a keyword: `mise //cafleet:test -k my_keyword`
   - Package-relative paths only (`tests/...`, not `cafleet/tests/...`), because the mise task's working directory is `cafleet/`.
-  - **Defensive `--` separator** for args that might collide with a mise flag: `mise //cafleet:test -- --collect-only -q tests/` — design-docs/0000044 uses this form. The bare form (without `--`) works in practice for the common pytest flags above; reach for `--` when an arg starts with two dashes AND could plausibly be parsed by mise itself.
+  - **Defensive `--` separator** for args that might collide with a mise flag: `mise //cafleet:test -- --collect-only -q tests/`. The bare form (without `--`) works in practice for the common pytest flags above; reach for `--` when an arg starts with two dashes AND could plausibly be parsed by mise itself.
 
 ## NEVER bypass mise with the underlying tool
 

--- a/.gitignore
+++ b/.gitignore
@@ -37,10 +37,9 @@ __pycache__/
 # branch inside <repo>/researches/<slug>/ and <repo>/design-docs/<NNNNNNN>-<slug>/.
 .cafleet-base-dir.json
 
-# Legacy spawn-prompt audit directory at the repo root. Audit files are now
-# written under per-task folders (`researches/<slug>/prompts/`,
-# `design-docs/<NNNNNNN>-<slug>/prompts/`); this entry keeps any straggler
-# writes during the rollout out of version control.
+# Stray spawn-prompt audit writes at the repo root; the canonical location is
+# per-task `prompts/` folders (`researches/<slug>/prompts/`,
+# `design-docs/<NNNNNNN>-<slug>/prompts/`).
 /prompts/
 
 # Spawn-prompt audit re-renders written by the Director when ${BASE} = repo root

--- a/admin/src/components/MessageInput.tsx
+++ b/admin/src/components/MessageInput.tsx
@@ -50,7 +50,7 @@ function parseInput(raw: string, recipients: Agent[]): ParseResult {
 
   if (nonAll.length > 1) {
     return parseError(
-      "Multi-recipient unicast not supported in first cut; use @all for broadcast",
+      "Multi-recipient unicast is not supported; use @all for broadcast",
     );
   }
 

--- a/cafleet/tests/test_base_dir_spawn_flow.py
+++ b/cafleet/tests/test_base_dir_spawn_flow.py
@@ -1,4 +1,4 @@
-"""Integration tests for the design-0000055 spawn-prompt + audit-write contract.
+"""Integration tests for the spawn-prompt + audit-write contract.
 
 These tests exercise:
 
@@ -191,7 +191,7 @@ def test_director_side_audit_writes_land_under_base_not_tmp(tmp_path):
 
 
 # ---------------------------------------------------------------------------
-# Design 0000060 — task-scoped spawn-prompt audit-write flow
+# Task-scoped spawn-prompt audit-write flow
 # ---------------------------------------------------------------------------
 
 

--- a/cafleet/tests/test_broker_typed_columns.py
+++ b/cafleet/tests/test_broker_typed_columns.py
@@ -39,26 +39,11 @@ REQUIRED_TASK_KEYS = {
     "text",
 }
 
-FORBIDDEN_LEGACY_KEYS = {
-    "id",
-    "contextId",
-    "fromAgentId",
-    "toAgentId",
-    "originTaskId",
-    "metadata",
-    "artifacts",
-    "history",
-    "kind",
-    "parts",
-    "task_json",
-}
-
 
 def _assert_flat_typed_shape(d: dict, *, expect_type: str | None = None) -> None:
-    missing = REQUIRED_TASK_KEYS - d.keys()
-    assert not missing, f"missing required typed-column keys: {sorted(missing)}"
-    forbidden = FORBIDDEN_LEGACY_KEYS & d.keys()
-    assert not forbidden, f"forbidden legacy keys still present: {sorted(forbidden)}"
+    assert set(d.keys()) == REQUIRED_TASK_KEYS, (
+        f"unexpected typed-column key set: {sorted(d.keys())}"
+    )
     if expect_type is not None:
         assert d["type"] == expect_type
 

--- a/cafleet/tests/test_cli_member_send_input.py
+++ b/cafleet/tests/test_cli_member_send_input.py
@@ -281,16 +281,6 @@ def test_output_format__json_envelope(
     assert data["value"] == expected_value
 
 
-def test_bash_flag_removed__old_bash_flag_form_errors_with_no_such_option(
-    runner, session_id, happy_path_agent
-):
-    result = _invoke(runner, session_id, "--bash", "x")
-    assert result.exit_code == 2, result.output
-    out = result.output or ""
-    assert "No such option" in out
-    assert "--bash" in out
-
-
 @pytest.mark.parametrize(
     ("scenario", "payload", "expect_exit", "expect_in", "expect_not_in"),
     [

--- a/cafleet/tests/test_cli_session_bootstrap.py
+++ b/cafleet/tests/test_cli_session_bootstrap.py
@@ -237,7 +237,7 @@ def test_session_create_coding_agent__claude_records_claude_in_placement(
 
 
 def test_session_create_coding_agent__default_is_claude(db_file, mock_tmux_ok):
-    """No flag → 'claude'. 'unknown' must not appear for newly-created sessions."""
+    """No ``--coding-agent`` flag defaults the placement to ``'claude'``."""
     runner = CliRunner()
     result = runner.invoke(cli, ["session", "create", "--json"])
     assert result.exit_code == 0, result.output

--- a/cafleet/tests/test_cli_session_bootstrap.py
+++ b/cafleet/tests/test_cli_session_bootstrap.py
@@ -332,13 +332,6 @@ def test_session_list_hides_soft_deleted__deleted_session_is_hidden_from_json_li
     assert drop_sid not in ids
 
 
-def test_session_list_hides_soft_deleted__list_has_no_all_flag(db_file):
-    """Design 0000026 explicitly removes/omits an ``--all`` flag."""
-    runner = CliRunner()
-    result = runner.invoke(cli, ["session", "list", "--all"])
-    assert result.exit_code == 2, result.output
-
-
 def test_session_delete_unknown_and_idempotent__unknown_session_id_exits_1_with_not_found(
     db_file, mock_tmux_ok
 ):

--- a/cafleet/tests/test_cli_session_flag.py
+++ b/cafleet/tests/test_cli_session_flag.py
@@ -157,7 +157,7 @@ def test_session_id_flag_flows_into_broker__send_passes_session_id_to_broker(
 def test_session_id_flag_flows_into_broker__session_id_not_read_from_environment(
     db_runner, monkeypatch
 ):
-    """The env var CAFLEET_SESSION_ID was removed; only the CLI flag works."""
+    """Session id is read only from the ``--session-id`` flag; the environment is never consulted."""
     monkeypatch.setenv("CAFLEET_SESSION_ID", str(uuid.uuid4()))
     result = db_runner.invoke(
         cli,

--- a/cafleet/tests/test_cli_version.py
+++ b/cafleet/tests/test_cli_version.py
@@ -19,10 +19,3 @@ def test_version_flag_does_not_require_session_id() -> None:
     result = runner.invoke(cli, ["--version"])
     assert result.exit_code == 0, result.output
     assert "session-id" not in result.output.lower(), result.output
-
-
-def test_pretty_flag_rejected_as_unknown_option() -> None:
-    runner = CliRunner()
-    result = runner.invoke(cli, ["--pretty", "session", "list"])
-    assert result.exit_code == 2, result.output
-    assert "No such option: --pretty" in result.output

--- a/cafleet/tests/test_output_render_broadcast_summary.py
+++ b/cafleet/tests/test_output_render_broadcast_summary.py
@@ -35,9 +35,6 @@ def test_broadcast_summary__exactly_typed_column_keys_no_recipient_ids_no_metada
     }
     extra = set(summary.keys()) - expected_keys
     assert not extra, f"unexpected extras: {sorted(extra)}"
-    # Defensive guards against removed wrapper keys re-emerging.
-    for forbidden in ("recipient_ids", "recipientIds", "metadata"):
-        assert forbidden not in summary
 
 
 def test_broadcast_summary__wrapper_count_and_text_describes_recipient_count():

--- a/cafleet/tests/test_output_render_task.py
+++ b/cafleet/tests/test_output_render_task.py
@@ -162,7 +162,7 @@ def test_format_task__compact_two_lines_with_expected_fields(line, needle):
 
 
 def test_format_task__full_layout_has_more_lines_and_field_labels():
-    task = _typed_task(text="legacy body")
+    task = _typed_task(text="message body")
     compact = output.format_task(task, full=False)
     full = output.format_task(task, full=True)
     assert full.count("\n") > compact.count("\n")

--- a/cafleet/tests/test_server_routing.py
+++ b/cafleet/tests/test_server_routing.py
@@ -1,6 +1,6 @@
 """Tests for FastAPI app routing: SPA mount, reserved-prefix re-raise, mount order.
 
-Guards the behaviors specified in design-doc 0000068 §Part A Backend and §Risks:
+Guards the following behaviors:
 
 - The mount at ``/`` serves the SPA shell for ``/`` and unknown client-side routes.
 - ``SPAStaticFiles.get_response`` re-raises 404 for paths under the reserved
@@ -61,7 +61,7 @@ def test_create_app__unknown_api_path_returns_404_not_spa(client, path):
 
 
 def test_create_app__known_api_route_reaches_router_returns_json_400(client):
-    # Mount-order regression guard from design-doc 0000068 §Risks: if the SPA
+    # Mount-order regression guard: if the SPA
     # mount intercepts /api/* before the router, this would return the SPA
     # mount's 404 instead of the expected JSON 400 from get_webui_session().
     # The 400 short-circuits before any DB access, so no broker fixture needed.

--- a/design-docs/0000072-purge-historical-narration/design-doc.md
+++ b/design-docs/0000072-purge-historical-narration/design-doc.md
@@ -1,7 +1,7 @@
 # 0000072 — Purge Historical-Trajectory Narration
 
 **Status**: Approved
-**Progress**: 12/24 tasks complete
+**Progress**: 16/24 tasks complete
 **Last Updated**: 2026-06-06
 
 ## Overview
@@ -172,10 +172,10 @@ This is a documentation/test-hygiene cleanup. It removes **no runtime behavior**
 
 ### Step 4: Tests — mixed cases (keep live coverage, drop sentinel)
 
-- [ ] T4 — `test_cli_session_flag.py`: reword the `CAFLEET_SESSION_ID was removed` docstring; keep the assertion <!-- completed: -->
-- [ ] T5 — `test_output_render_broadcast_summary.py`: delete the forbidden-keys loop + comment; keep the exact-key-set assertion <!-- completed: -->
-- [ ] T6 — `test_broker_typed_columns.py`: delete `FORBIDDEN_LEGACY_KEYS` + its check; keep the required-keys present-check (verify suite green) <!-- completed: -->
-- [ ] T7 — `test_cli_session_bootstrap.py`: simplify the `default_is_claude` docstring (drop the `'unknown'` reference) <!-- completed: -->
+- [x] T4 — `test_cli_session_flag.py`: reword the `CAFLEET_SESSION_ID was removed` docstring; keep the assertion <!-- completed: 2026-06-06T02:38 -->
+- [x] T5 — `test_output_render_broadcast_summary.py`: delete the forbidden-keys loop + comment; keep the exact-key-set assertion <!-- completed: 2026-06-06T02:38 -->
+- [x] T6 — `test_broker_typed_columns.py`: delete `FORBIDDEN_LEGACY_KEYS` + its check; keep the required-keys present-check (verify suite green) <!-- completed: 2026-06-06T02:38 --> <!-- applied optional exact-set hardening: `_assert_flat_typed_shape` now asserts `set(d.keys()) == REQUIRED_TASK_KEYS`; full suite (727) green -->
+- [x] T7 — `test_cli_session_bootstrap.py`: simplify the `default_is_claude` docstring (drop the `'unknown'` reference) <!-- completed: 2026-06-06T02:38 -->
 
 ### Step 5: Tests — design-doc-number citations (reword)
 

--- a/design-docs/0000072-purge-historical-narration/design-doc.md
+++ b/design-docs/0000072-purge-historical-narration/design-doc.md
@@ -1,7 +1,7 @@
 # 0000072 — Purge Historical-Trajectory Narration
 
 **Status**: Approved
-**Progress**: 7/24 tasks complete
+**Progress**: 9/24 tasks complete
 **Last Updated**: 2026-06-06
 
 ## Overview
@@ -160,8 +160,9 @@ This is a documentation/test-hygiene cleanup. It removes **no runtime behavior**
 
 ### Step 2: Config
 
-- [ ] C1 — `.gitignore`: reword the `/prompts/` comment to present tense (drop "Legacy"/"now"/"during the rollout") <!-- completed: -->
-- [ ] C2 — `.claude/rules/commands.md`: drop the "— design-docs/0000044 uses this form" citation <!-- completed: -->
+- [x] C1 — `.gitignore`: reword the `/prompts/` comment to present tense (drop "Legacy"/"now"/"during the rollout") <!-- completed: 2026-06-06T02:31 -->
+- [x] C2 — `.claude/rules/commands.md`: drop the "— design-docs/0000044 uses this form" citation <!-- completed: 2026-06-06T02:33 -->
+
 
 ### Step 3: Tests — delete pure removal-sentinels (Q2)
 

--- a/design-docs/0000072-purge-historical-narration/design-doc.md
+++ b/design-docs/0000072-purge-historical-narration/design-doc.md
@@ -1,7 +1,7 @@
 # 0000072 — Purge Historical-Trajectory Narration
 
 **Status**: Approved
-**Progress**: 19/24 tasks complete
+**Progress**: 21/24 tasks complete
 **Last Updated**: 2026-06-06
 
 ## Overview
@@ -185,8 +185,8 @@ This is a documentation/test-hygiene cleanup. It removes **no runtime behavior**
 
 ### Step 6: Skills — design-doc pointers (judgment)
 
-- [ ] S1 — `skills/cafleet-design-doc/coordination.md`: remove the "Rationale-of-record: design-docs/0000050…" pointer line <!-- completed: -->
-- [ ] S2 — `skills/cafleet-design-doc-interview/SKILL.md`: drop the `design-docs/0000050` parenthetical; keep the "by design" statement <!-- completed: -->
+- [x] S1 — `skills/cafleet-design-doc/coordination.md`: remove the "Rationale-of-record: design-docs/0000050…" pointer line <!-- completed: 2026-06-06T02:43 -->
+- [x] S2 — `skills/cafleet-design-doc-interview/SKILL.md`: drop the `design-docs/0000050` parenthetical; keep the "by design" statement <!-- completed: 2026-06-06T02:43 -->
 
 ### Step 7: Verification
 

--- a/design-docs/0000072-purge-historical-narration/design-doc.md
+++ b/design-docs/0000072-purge-historical-narration/design-doc.md
@@ -1,7 +1,7 @@
 # 0000072 — Purge Historical-Trajectory Narration
 
 **Status**: Approved
-**Progress**: 9/24 tasks complete
+**Progress**: 12/24 tasks complete
 **Last Updated**: 2026-06-06
 
 ## Overview
@@ -166,9 +166,9 @@ This is a documentation/test-hygiene cleanup. It removes **no runtime behavior**
 
 ### Step 3: Tests — delete pure removal-sentinels (Q2)
 
-- [ ] T1 — delete `test_bash_flag_removed__old_bash_flag_form_errors_with_no_such_option` <!-- completed: -->
-- [ ] T2 — delete `test_pretty_flag_rejected_as_unknown_option` <!-- completed: -->
-- [ ] T3 — delete `test_session_list_hides_soft_deleted__list_has_no_all_flag` <!-- completed: -->
+- [x] T1 — delete `test_bash_flag_removed__old_bash_flag_form_errors_with_no_such_option` <!-- completed: 2026-06-06T02:35 -->
+- [x] T2 — delete `test_pretty_flag_rejected_as_unknown_option` <!-- completed: 2026-06-06T02:35 -->
+- [x] T3 — delete `test_session_list_hides_soft_deleted__list_has_no_all_flag` <!-- completed: 2026-06-06T02:35 -->
 
 ### Step 4: Tests — mixed cases (keep live coverage, drop sentinel)
 

--- a/design-docs/0000072-purge-historical-narration/design-doc.md
+++ b/design-docs/0000072-purge-historical-narration/design-doc.md
@@ -1,6 +1,6 @@
 # 0000072 — Purge Historical-Trajectory Narration
 
-**Status**: Approved
+**Status**: Complete
 **Progress**: 24/24 tasks complete
 **Last Updated**: 2026-06-06
 
@@ -10,12 +10,12 @@ The repository carries "historical-trajectory" narration — text meaningful onl
 
 ## Success Criteria
 
-- [ ] Every inventory item in the Specification table is resolved (removed or reworded to present-tense current-behavior phrasing).
-- [ ] `docs/spec/data-model.md` no longer documents `coding_agent = "unknown"` as a current value, and its root-Director bootstrap description matches `docs/spec/cli-options.md` (default `"claude"`).
-- [ ] No source, doc, skill, or test (outside the exempt areas) cites a design-doc number as the reason for current code, or narrates a removal/deprecation.
-- [ ] Every "removal-sentinel" test (asserts a non-existent flag/key errors) is deleted; every test that mixes a sentinel with live coverage keeps the live assertion and loses only the sentinel framing — no live coverage is lost.
-- [ ] `mise //cafleet:test`, `mise //cafleet:lint`, and `mise //cafleet:typecheck` pass.
-- [ ] A re-run of the verification sweep (Step 7) returns zero **unaccounted** matches — every remaining hit is KEEP-listed, exempt, or a benign present-tense usage confirmed by judgment (see "Known-benign sweep matches" in the KEEP list); no historical-trajectory narration remains.
+- [x] Every inventory item in the Specification table is resolved (removed or reworded to present-tense current-behavior phrasing).
+- [x] `docs/spec/data-model.md` no longer documents `coding_agent = "unknown"` as a current value, and its root-Director bootstrap description matches `docs/spec/cli-options.md` (default `"claude"`).
+- [x] No source, doc, skill, or test (outside the exempt areas) cites a design-doc number as the reason for current code, or narrates a removal/deprecation.
+- [x] Every "removal-sentinel" test (asserts a non-existent flag/key errors) is deleted; every test that mixes a sentinel with live coverage keeps the live assertion and loses only the sentinel framing — no live coverage is lost.
+- [x] `mise //cafleet:test`, `mise //cafleet:lint`, and `mise //cafleet:typecheck` pass.
+- [x] A re-run of the verification sweep (Step 7) returns zero **unaccounted** matches — every remaining hit is KEEP-listed, exempt, or a benign present-tense usage confirmed by judgment (see "Known-benign sweep matches" in the KEEP list); no historical-trajectory narration remains.
 
 ---
 
@@ -206,3 +206,4 @@ This is a documentation/test-hygiene cleanup. It removes **no runtime behavior**
 | 2026-06-06 | Reviewer pass: reworded the sweep success criterion to "zero unaccounted matches"; added the "Known-benign sweep matches" KEEP bullet |
 | 2026-06-06 | User approved; Status → Approved |
 | 2026-06-06 | Execution: Steps 1–6 applied and committed. Step 7 verification — test (727) / lint / typecheck green; narration sweep clean except one `first cut` hit in `admin/src/components/MessageInput.tsx`. User scope decision: extend scope to `admin/src/` and reword that string (the only narration outside the originally-declared surfaces). |
+| 2026-06-06 | Execution complete: all 24 tasks done, 6 Success Criteria verified. PR #94 opened; Copilot reviewed HEAD with zero comments. Status → Complete. |

--- a/design-docs/0000072-purge-historical-narration/design-doc.md
+++ b/design-docs/0000072-purge-historical-narration/design-doc.md
@@ -1,7 +1,7 @@
 # 0000072 — Purge Historical-Trajectory Narration
 
 **Status**: Approved
-**Progress**: 16/24 tasks complete
+**Progress**: 19/24 tasks complete
 **Last Updated**: 2026-06-06
 
 ## Overview
@@ -179,9 +179,9 @@ This is a documentation/test-hygiene cleanup. It removes **no runtime behavior**
 
 ### Step 5: Tests — design-doc-number citations (reword)
 
-- [ ] T8 + T9 — `test_server_routing.py`: drop the `design-doc 0000068` citations from the docstring and the mount-order comment <!-- completed: -->
-- [ ] T10 + T11 — `test_base_dir_spawn_flow.py`: drop the `design-0000055` / `Design 0000060` citations from the docstring and comment <!-- completed: -->
-- [ ] T12 — `test_output_render_task.py`: reword the incidental `text="legacy body"` fixture → `text="message body"` <!-- completed: -->
+- [x] T8 + T9 — `test_server_routing.py`: drop the `design-doc 0000068` citations from the docstring and the mount-order comment <!-- completed: 2026-06-06T02:41 -->
+- [x] T10 + T11 — `test_base_dir_spawn_flow.py`: drop the `design-0000055` / `Design 0000060` citations from the docstring and comment <!-- completed: 2026-06-06T02:41 -->
+- [x] T12 — `test_output_render_task.py`: reword the incidental `text="legacy body"` fixture → `text="message body"` <!-- completed: 2026-06-06T02:41 -->
 
 ### Step 6: Skills — design-doc pointers (judgment)
 

--- a/design-docs/0000072-purge-historical-narration/design-doc.md
+++ b/design-docs/0000072-purge-historical-narration/design-doc.md
@@ -1,12 +1,12 @@
 # 0000072 — Purge Historical-Trajectory Narration
 
 **Status**: Approved
-**Progress**: 21/24 tasks complete
+**Progress**: 24/24 tasks complete
 **Last Updated**: 2026-06-06
 
 ## Overview
 
-The repository carries "historical-trajectory" narration — text meaningful only to someone who knows the project's past ("X was deprecated in design NNNN", "previously Y, now Z", "preserved for forensic visibility", design-doc-number citations as the reason for current code, and sentinel "removed-flag → error" tests). This change deletes or rewrites every such mention across `docs/`, `README.md`, `.claude/`, `skills/`, `cafleet/src/` (excluding Alembic migrations), and `cafleet/tests/` so the repository reads as if the removed/rejected features never existed.
+The repository carries "historical-trajectory" narration — text meaningful only to someone who knows the project's past ("X was deprecated in design NNNN", "previously Y, now Z", "preserved for forensic visibility", design-doc-number citations as the reason for current code, and sentinel "removed-flag → error" tests). This change deletes or rewrites every such mention across `docs/`, `README.md`, `.claude/`, `skills/`, `admin/src/`, `cafleet/src/` (excluding Alembic migrations), and `cafleet/tests/` so the repository reads as if the removed/rejected features never existed.
 
 ## Success Criteria
 
@@ -190,9 +190,10 @@ This is a documentation/test-hygiene cleanup. It removes **no runtime behavior**
 
 ### Step 7: Verification
 
-- [ ] Run `mise //cafleet:test` — full suite green (special attention to T6) <!-- completed: -->
-- [ ] Run `mise //cafleet:lint` and `mise //cafleet:typecheck` — clean <!-- completed: -->
-- [ ] Re-run the sweep (use `git grep` over tracked files, which also excludes the untracked WebUI build output) and confirm zero matches **outside** the exempt areas (`design-docs/`, `researches/`, `cafleet/src/cafleet/alembic/`, `cafleet/src/cafleet/webui/assets/**`, lock files), for: `deprecat`, `no longer|formerly|previously|used to|historically`, `forensic|preserved for|for history`, `restoration`, `\blegacy\b`, `design[ -]?0000[0-9]{3}|\b0000[0-9]{3}\b` (word-boundary form so all-zero UUID constants like `00000000-0000-…` do not false-match; the KEEP-listed example slugs `0000060`/`0000099` are expected matches to ignore), `in v1|first cut`, `was removed|removed .* re-emerg`. Each remaining hit is either KEEP-listed or exempt — record any judgment calls. <!-- completed: -->
+- [x] Run `mise //cafleet:test` — full suite green (special attention to T6) <!-- completed: 2026-06-06T02:45 --> <!-- 727 passed; test_broker_typed_columns.py (T6) green -->
+- [x] Run `mise //cafleet:lint` and `mise //cafleet:typecheck` — clean <!-- completed: 2026-06-06T02:45 --> <!-- ruff check + format --check clean (91 files); ty check clean -->
+
+- [x] Re-run the sweep (use `git grep` over tracked files, which also excludes the untracked WebUI build output) and confirm zero matches **outside** the exempt areas (`design-docs/`, `researches/`, `cafleet/src/cafleet/alembic/`, `cafleet/src/cafleet/webui/assets/**`, lock files), for: `deprecat`, `no longer|formerly|previously|used to|historically`, `forensic|preserved for|for history`, `restoration`, `\blegacy\b`, `design[ -]?0000[0-9]{3}|\b0000[0-9]{3}\b` (word-boundary form so all-zero UUID constants like `00000000-0000-…` do not false-match; the KEEP-listed example slugs `0000060`/`0000099` are expected matches to ignore), `in v1|first cut`, `was removed|removed .* re-emerg`. Each remaining hit is either KEEP-listed or exempt — record any judgment calls. <!-- completed: 2026-06-06T03:01 --> <!-- re-sweep after admin/src reword: zero unaccounted matches; all remaining hits KEEP-listed/exempt/benign -->
 
 ---
 
@@ -204,3 +205,4 @@ This is a documentation/test-hygiene cleanup. It removes **no runtime behavior**
 | 2026-06-06 | Reviewer pass: added C2 (`.claude/rules/commands.md`) and T12 (`test_output_render_task.py`); exempted generated WebUI build output; resolved the D15 downgrade-narration judgment (keep); added the D1/D2-vs-Out-of-scope note; extended example-slug KEEP coverage to skill files; tightened the Step 7 sweep to a word-boundary form |
 | 2026-06-06 | Reviewer pass: reworded the sweep success criterion to "zero unaccounted matches"; added the "Known-benign sweep matches" KEEP bullet |
 | 2026-06-06 | User approved; Status → Approved |
+| 2026-06-06 | Execution: Steps 1–6 applied and committed. Step 7 verification — test (727) / lint / typecheck green; narration sweep clean except one `first cut` hit in `admin/src/components/MessageInput.tsx`. User scope decision: extend scope to `admin/src/` and reword that string (the only narration outside the originally-declared surfaces). |

--- a/design-docs/0000072-purge-historical-narration/design-doc.md
+++ b/design-docs/0000072-purge-historical-narration/design-doc.md
@@ -1,0 +1,205 @@
+# 0000072 — Purge Historical-Trajectory Narration
+
+**Status**: Approved
+**Progress**: 7/24 tasks complete
+**Last Updated**: 2026-06-06
+
+## Overview
+
+The repository carries "historical-trajectory" narration — text meaningful only to someone who knows the project's past ("X was deprecated in design NNNN", "previously Y, now Z", "preserved for forensic visibility", design-doc-number citations as the reason for current code, and sentinel "removed-flag → error" tests). This change deletes or rewrites every such mention across `docs/`, `README.md`, `.claude/`, `skills/`, `cafleet/src/` (excluding Alembic migrations), and `cafleet/tests/` so the repository reads as if the removed/rejected features never existed.
+
+## Success Criteria
+
+- [ ] Every inventory item in the Specification table is resolved (removed or reworded to present-tense current-behavior phrasing).
+- [ ] `docs/spec/data-model.md` no longer documents `coding_agent = "unknown"` as a current value, and its root-Director bootstrap description matches `docs/spec/cli-options.md` (default `"claude"`).
+- [ ] No source, doc, skill, or test (outside the exempt areas) cites a design-doc number as the reason for current code, or narrates a removal/deprecation.
+- [ ] Every "removal-sentinel" test (asserts a non-existent flag/key errors) is deleted; every test that mixes a sentinel with live coverage keeps the live assertion and loses only the sentinel framing — no live coverage is lost.
+- [ ] `mise //cafleet:test`, `mise //cafleet:lint`, and `mise //cafleet:typecheck` pass.
+- [ ] A re-run of the verification sweep (Step 7) returns zero **unaccounted** matches — every remaining hit is KEEP-listed, exempt, or a benign present-tense usage confirmed by judgment (see "Known-benign sweep matches" in the KEEP list); no historical-trajectory narration remains.
+
+---
+
+## Background
+
+The governing rule is `~/.claude/rules/removal.md` ("Removal"). Its principle: git history and the design doc are the historical record; source, user-facing docs, skills, and examples describe **only the current state**. Deprecation notices and "for history" pointers turn user-facing surfaces into archaeological digs.
+
+This is a documentation/test-hygiene cleanup. It removes **no runtime behavior** — every CLI flag, column, and code path that exists today still exists after this change. Only the *narration about what used to exist* is removed.
+
+### The keep / remove line (authoritative for this change)
+
+`removal.md` contains two passages that, read together, leave the test-side line ambiguous. The user resolved it explicitly for this change:
+
+| Surface | Action |
+|---|---|
+| Historical narration in **user-facing docs** (deprecation notices, "previously/now/no longer/formerly", "preserved for forensic visibility", restoration pointers, design-number-as-reason) | **Remove or reword** to present tense |
+| **Removal-sentinel tests** — a test whose *only* job is to assert a removed/never-added flag or key produces an error (`--bash`/`--pretty`/`--all` → Click "No such option"; "removed wrapper keys re-emerging"; `FORBIDDEN_LEGACY_KEYS`) | **Delete the test/assertion outright** (this change overrides removal.md's "keep the absence guard" reading) |
+| A test that **mixes** a current-behavior assertion with a removal sentinel | **Keep the current-behavior assertion; drop only the sentinel part.** Never lose live coverage. Each such case is flagged below. |
+| Alembic migration files (`cafleet/src/cafleet/alembic/versions/*`) | **Exempt** — a migration's purpose is to describe a transformation, so it must reference the prior state. Treat like git history. |
+| A real **Non-goals / out-of-scope** section scoping *this* feature, with no historical reference | **Keep** (not cruft) |
+| Design-number **example paths / test fixtures** that are illustrative input, not citations-as-reason | **Keep** |
+| Forward-looking design-debt notes (e.g. the `acknowledged_at` note) and "do-not-refactor-this-into-that" editing guards | **Keep** (forward-facing, not historical) |
+
+---
+
+## Specification
+
+### Decisions (from the user)
+
+1. **Q1 — Alembic migrations: exempt entirely.** No edits to `cafleet/src/cafleet/alembic/versions/*`. This includes the `0006`/`0007` design-doc citations and the `0009`/`0010` "legacy"/"unknown" framing.
+2. **Q2 — Removal-sentinel tests: delete outright** (not reword). Safety clause: if a single test function mixes a current-behavior assertion with a sentinel, keep the current-behavior assertion and drop only the sentinel part.
+3. **Q3 — Migration prose in user docs: strip the "pre-existing session" / "backfill" narration clauses; keep the real migration *filename* references.**
+4. **Q4 — Version qualifiers: sweep them.** Reword "in v1" / "first cut" / "no pagination in the first cut" into plain present-tense statements.
+5. **Q5 — Output format: a `file → action` inventory table plus an explicit KEEP list as the doc's spine.**
+
+> **Line numbers below are current-HEAD references and may drift as edits are applied. The quoted text is the stable anchor — match on the text, not the number.**
+
+### Inventory — `docs/` (user-facing prose)
+
+| # | Location | Current text (anchor) | Action |
+|---|---|---|---|
+| D1 | `docs/spec/data-model.md` ~L31 | `coding_agent='unknown'` (auto-detection is deferred) | **Reword** → `coding_agent=<value of --coding-agent>` (default `'claude'`), matching `cli-options.md` "Root Director bootstrap" (the placement records the chosen backend; new sessions never write `"unknown"`). |
+| D2 | `docs/spec/data-model.md` ~L126 | `coding_agent` row: "Current known values are `"claude"` … and `"unknown"` for the session's root Director placement" | **Reword** → drop `"unknown"`. Keep the column constraints (`NOT NULL`, `DEFAULT 'claude'`). Describe current values: `"claude"` (default) and `"codex"` / `"opencode"` when chosen at create time. Do **not** document the dead `"unknown"` value (migration `0010` already backfilled it to `"claude"`). |
+| D3 | `docs/spec/data-model.md` ~L214 | table row `Historical row from before the 0002_add_origin_task_id migration | NULL (no backfill)` | **Remove the row.** |
+| D4 | `docs/spec/data-model.md` ~L230 | "The previous `DEREGISTERED_TASK_TTL_DAYS` and `CLEANUP_INTERVAL_SECONDS` settings have been removed." | **Remove the sentence.** Also reword the preceding "it can be **reintroduced** as an opt-in admin command" → "it can be **added** as an opt-in admin command" (drop the implication it once existed). |
+| D5 | `docs/spec/webui-api.md` ~L154 | table row `Historical row from before the origin_task_id migration | null` | **Remove the row.** |
+| D6 | `docs/concepts/tmux-push.md` ~L58–61 | "This replaces the design-0000049-pre keystroke (the literal … sequence, which forced the recipient to dump its full unacked-inbox envelope on every send and dominated per-message token cost)." | **Remove the whole sentence.** The surrounding paragraph already states current behavior. |
+| D7 | `docs/concepts/coding-agents.md` ~L10–11 | "the default is `claude` so existing invocations behave unchanged" | **Reword** → "the default is `claude`." |
+| D8 | `docs/reference/coding-agents/codex.md` ~L16 | "The default is `--coding-agent claude`, so existing invocations are unchanged." | **Reword** → drop "so existing invocations are unchanged". |
+| D9 | `docs/reference/coding-agents/opencode.md` ~L16 | "The default is `--coding-agent claude`, so existing invocations are unchanged." | **Reword** → drop "so existing invocations are unchanged". |
+| D10 | `docs/concepts/storage.md` ~L138 | "are not exposed via the CLI in v1." | **Reword (Q4)** → "are not exposed via the CLI." |
+| D11 | `docs/spec/data-model.md` ~L23 | "no `--all` flag in v1" | **Reword (Q4)** → "no `--all` flag". |
+| D12 | `docs/spec/data-model.md` ~L143 | "There is no path in v1 that physically deletes an agent" | **Reword (Q4)** → "There is no path that physically deletes an agent". |
+| D13 | `docs/spec/data-model.md` ~L224 | "This is accepted residual risk for the first cut of the Discord-style timeline and is explicitly flagged here so the next contributor…" | **Reword (Q4)** → drop "for the first cut of the Discord-style timeline". **Keep** the rest of this forward-looking design-debt note. |
+| D14 | `docs/spec/webui-api.md` ~L144 | "Hard-capped at 200 rows. No pagination in the first cut." | **Reword (Q4)** → "Hard-capped at 200 rows; no pagination." |
+| D15 | `docs/spec/data-model.md` ~L80 | "Alembic revision `0006_seed_administrator_agent.py` **backfills one Administrator into each pre-existing session**. …" | **Reword (Q3)** → strip **only** the "into each pre-existing session" clause; state present-tense that revision `0006_seed_administrator_agent.py` is the migration that seeds the Administrator. **Keep** the filename, the `json_extract` probe, the idempotency note, **and** the downgrade-behavior sentence ("Downgrade is provided for empty sessions only … `tasks.context_id` uses `ON DELETE RESTRICT` … raises `IntegrityError`") — that documents the migration's current downgrade behavior, not historical trajectory, and is outside Q3's scope. |
+| D16 | `docs/concepts/session-isolation.md` ~L106–108 | "Alembic revision `0006_seed_administrator_agent.py` **backfills one into each pre-existing session** on `cafleet db init` (idempotent via a `json_extract` probe)." | **Reword (Q3)** → strip the "backfills one into each pre-existing session on `cafleet db init`" clause. Keep "Every session has exactly one Administrator" and a bare current-state filename reference. |
+| D17 | `docs/spec/message-envelope.md` ~L26 | "… and the `0009_drop_task_json_add_text` migration shape **with the operator backup procedure**)." | **Reword (Q3, judgment)** → keep the `0009_drop_task_json_add_text` filename reference; drop "with the operator backup procedure". |
+
+> **Note — D1/D2 vs. Out-of-scope.** `"unknown"` is a *removed* coding-agent value: migration `0010` backfilled it to `"claude"` and `broker.create_session` never writes it, so documenting it is historical narration, in scope per removal.md's "do not document the removed value." This is distinct from the `click.Choice(['claude','codex'])` docstring listed under Out of scope — that is a *live-but-undercounted* enum (plain accuracy drift, not a removed value), which is why it stays out of scope.
+
+### Inventory — config
+
+| # | Location | Current text (anchor) | Action |
+|---|---|---|---|
+| C1 | `.gitignore` ~L40–43 | "# Legacy spawn-prompt audit directory at the repo root. Audit files are now written under per-task folders …; this entry keeps any straggler writes during the rollout out of version control." | **Reword** → present tense, drop "Legacy" / "now" / "during the rollout". E.g. "# Stray spawn-prompt audit writes at the repo root; the canonical location is per-task `prompts/` folders (`researches/<slug>/prompts/`, `design-docs/<NNNNNNN>-<slug>/prompts/`)." Keep the `/prompts/` ignore entry itself. |
+| C2 | `.claude/rules/commands.md` ~L28 | "`mise //cafleet:test -- --collect-only -q tests/` — design-docs/0000044 uses this form." | **Reword** → drop "— design-docs/0000044 uses this form" (a design-number-as-reason citation; forbidden by removal.md). The guidance stands alone: "…`mise //cafleet:test -- --collect-only -q tests/`. The bare form (without `--`) works in practice…". |
+
+### Inventory — `cafleet/tests/`: delete pure sentinels (Q2)
+
+| # | Location | Function | Action |
+|---|---|---|---|
+| T1 | `cafleet/tests/test_cli_member_send_input.py` ~L284–291 | `test_bash_flag_removed__old_bash_flag_form_errors_with_no_such_option` | **Delete the entire function.** Pure sentinel (only asserts `--bash` → "No such option"). |
+| T2 | `cafleet/tests/test_cli_version.py` ~L24–28 | `test_pretty_flag_rejected_as_unknown_option` | **Delete the entire function.** Pure sentinel (only asserts `--pretty` → "No such option"). The `--version` test above it is unrelated — keep it. |
+| T3 | `cafleet/tests/test_cli_session_bootstrap.py` ~L335–339 | `test_session_list_hides_soft_deleted__list_has_no_all_flag` | **Delete the entire function.** Pure sentinel (only asserts `session list --all` → exit 2) **and** carries a `Design 0000026 explicitly removes/omits an --all flag` docstring. The live "hides soft-deleted" coverage lives in the **preceding** `test_session_list_*` function and is untouched. |
+
+### Inventory — `cafleet/tests/`: mixed cases — keep live coverage, drop sentinel (Q2 safety)
+
+| # | Location | Action |
+|---|---|---|
+| T4 | `cafleet/tests/test_cli_session_flag.py` ~L157–166 (`test_session_id_flag_flows_into_broker__session_id_not_read_from_environment`) | **Keep** the test + assertion (register without `--session-id`, with `CAFLEET_SESSION_ID` set, exits 1 → the env var is never consulted). **Replace** the docstring "The env var CAFLEET_SESSION_ID was removed; only the CLI flag works." with present tense, e.g. "Session id is read only from the `--session-id` flag; the environment is never consulted." |
+| T5 | `cafleet/tests/test_output_render_broadcast_summary.py` ~L36–40 | **Delete** the `# Defensive guards against removed wrapper keys re-emerging.` comment and the `for forbidden in ("recipient_ids", "recipientIds", "metadata"): assert forbidden not in summary` loop. **Keep** the exact-key-set assertion at ~L36–37 (`extra = set(summary.keys()) - expected_keys; assert not extra`) — it already excludes those keys, so **no coverage is lost**. |
+| T6 | `cafleet/tests/test_broker_typed_columns.py` ~L42–54, ~L60–61 | **Delete** the `FORBIDDEN_LEGACY_KEYS` constant and the forbidden-absent check in `_assert_flat_typed_shape` (`forbidden = FORBIDDEN_LEGACY_KEYS & d.keys(); assert not forbidden, …`). **Keep** the `REQUIRED_TASK_KEYS` present-check (positive live coverage of the flat typed shape). This intentionally drops the named "old keys must not re-emerge" guard (the exact anti-pattern the user named). *Optional, non-required hardening:* the executor MAY tighten the present-check to exact-set equality (`assert d.keys() == REQUIRED_TASK_KEYS`) to retain strictness, **but must not re-introduce a named legacy-key enumeration.** **Most delicate item — verify the full suite is green after the edit** (`_assert_flat_typed_shape` is shared across the module). |
+| T7 | `cafleet/tests/test_cli_session_bootstrap.py` ~L239–245 (`test_session_create_coding_agent__default_is_claude`) | **Keep** the test + assertion (new session → `coding_agent == "claude"`). **Simplify** the docstring "No flag → 'claude'. 'unknown' must not appear for newly-created sessions." → "No `--coding-agent` flag defaults the placement to `'claude'`." (drop the dead-value reference). |
+
+### Inventory — non-sentinel test rewords (design-number citations + incidental sweep matches; reword, keep coverage)
+
+| # | Location | Action |
+|---|---|---|
+| T8 | `cafleet/tests/test_server_routing.py` ~L3 | **Reword** the module docstring: drop "Guards the behaviors specified in design-doc 0000068 §Part A Backend and §Risks:" → "Guards the following behaviors:". Keep the behavior bullets. |
+| T9 | `cafleet/tests/test_server_routing.py` ~L64 | **Reword** the comment "Mount-order regression guard from design-doc 0000068 §Risks: if the SPA…" → "Mount-order regression guard: if the SPA…". |
+| T10 | `cafleet/tests/test_base_dir_spawn_flow.py` ~L1 | **Reword** the module docstring "Integration tests for the design-0000055 spawn-prompt + audit-write contract." → "Integration tests for the spawn-prompt + audit-write contract." |
+| T11 | `cafleet/tests/test_base_dir_spawn_flow.py` ~L194 | **Reword** the comment "# Design 0000060 — task-scoped spawn-prompt audit-write flow" → "# Task-scoped spawn-prompt audit-write flow". |
+| T12 | `cafleet/tests/test_output_render_task.py` ~L165 | **Reword** the incidental fixture string `_typed_task(text="legacy body")` → `text="message body"`. Matches the `\blegacy\b` sweep but is plain test data, not a removal note; no coverage change. |
+
+### Inventory — `skills/` design-doc pointers (judgment — Reviewer-confirm)
+
+| # | Location | Action |
+|---|---|---|
+| S1 | `skills/cafleet-design-doc/coordination.md` ~L1 | **Remove** the bare pointer line "Rationale-of-record: design-docs/0000050-design-doc-as-medium/design-doc.md." (a design-number-as-reason pointer in a skill reference). |
+| S2 | `skills/cafleet-design-doc-interview/SKILL.md` ~L26 | **Reword** — drop the parenthetical "(see `design-docs/0000050-design-doc-as-medium/design-doc.md` Step 7 for the plugin-install self-containment rationale)". Keep the substantive statement that no cross-skill markdown link is added, by design. |
+
+### Explicit KEEP list (do **not** delete — prevents over-deletion)
+
+- **Live test assertions** in T4–T11 — only framing changes; every assertion stays.
+- `docs/concepts/tmux-push.md` ~L63–69 — "The `TmuxMultiplexer.send_inline_preview` method is **NOT** a reuse of `send_freetext_and_submit` …" — a current "do-not-refactor-this-into-that" editing guard, not historical narration.
+- `skills/cafleet/reference/broadcast.md` — "`--full` … preserved for surface consistency …" / "the broker only ever returns the single summary …" — current rationale for a current flag's behavior, not a removal note.
+- `docs/spec/data-model.md` ~L224 — the forward-looking `acknowledged_at` design-debt note (only the "first cut" qualifier is reworded per D13).
+- Design-number **example paths / fixtures** (illustrative input-path examples, not citations-as-reason — leave them): `cafleet/src/cafleet/base_dir.py` ~L213 (`design-docs/0000060-foo/design-doc.md`); the `0000060`/`0000099` fixture slugs in `cafleet/tests/test_base_dir.py` and `test_base_dir_spawn_flow.py`; and the `0000060-…` example slugs in `skills/cafleet-design-doc-create/SKILL.md` (~L209, L215), `skills/cafleet-design-doc-execute/SKILL.md` (~L220, L222, L228), `skills/cafleet-design-doc-interview/SKILL.md` (~L110, L116), and `skills/cafleet-base-dir/SKILL.md` (~L25).
+- `docs/spec/cli-options.md` `--coding-agent` rows — current flag; this file is the source of truth the D1 reword aligns to.
+- `README.md`, `CLAUDE.md` — **swept and already clean** of historical-trajectory narration; no edits needed (recorded so the absence of edits is intentional, not an oversight). `.claude/rules/*` — swept; the only narration-style citation to fix is item **C2** (`commands.md` ~L28). The `previously` at `commands.md` ~L11 is benign (see "Known-benign sweep matches").
+- **Known-benign sweep matches** — present-tense English that trips the broad Step 7 patterns but is **not** historical narration; do **not** reword:
+  - `cafleet/src/cafleet/broker.py` ~L1214 — "Session UUID **used to** gate visibility" (`used to` = *utilized to*, not *formerly*).
+  - `.claude/rules/commands.md` ~L11 — "the global `cafleet` binary was **previously** installed non-editably" (a conditional describing the user's own environment, not project history).
+  - `skills/cafleet-design-doc-execute/SKILL.md` ~L258 — "Tier 3 is **preserved for** the no-argument branch" (`preserved for` = *retained for*, current behavior).
+  - The implementer confirms each remaining sweep hit falls in this class (or is exempt / KEEP-listed) before declaring the sweep clean.
+
+### Out of scope
+
+- `cafleet/src/cafleet/alembic/versions/*` — **exempt** (Q1).
+- `cafleet/src/cafleet/webui/assets/**` — generated WebUI build output (minified `index-*.js` / `index-*.css` bundles, rebuilt by `mise //admin:build`; not authored prose). Excluded from the sweep like lock files; minified strings produce false matches and must never be hand-edited.
+- `design-docs/` and `researches/` — the historical record; not touched.
+- General doc-drift that is **not** historical narration. Example: `cafleet/tests/test_cli_session_bootstrap.py` ~L249 docstring says `click.Choice(['claude','codex'])` but the live choice set is `['claude','codex','opencode']`. That is an accuracy bug, not trajectory narration — leave it for a separate change.
+- Any runtime behavior change. Flags, columns, and code paths are unchanged.
+
+---
+
+## Implementation
+
+> Documentation is edited first (project rule), then tests, then verification.
+> Task format: `- [x] Done task <!-- completed: 2026-02-13T14:30 -->`
+
+### Step 1: User-facing docs — remove/reword historical narration
+
+- [x] D1 + D2 — `docs/spec/data-model.md`: fix the root-Director `coding_agent` description and the `coding_agent` column row (drop `"unknown"`; align to `cli-options.md`) <!-- completed: 2026-06-06T02:28 -->
+- [x] D3 + D5 — remove the two "Historical row from before the … migration" table rows (`data-model.md`, `webui-api.md`) <!-- completed: 2026-06-06T02:28 -->
+- [x] D4 — `docs/spec/data-model.md`: remove the "previous … settings have been removed" sentence; reword "reintroduced" → "added" <!-- completed: 2026-06-06T02:28 -->
+- [x] D6 — `docs/concepts/tmux-push.md`: remove the "This replaces the design-0000049-pre keystroke …" sentence <!-- completed: 2026-06-06T02:28 -->
+- [x] D7 + D8 + D9 — drop "so existing invocations (behave/are) unchanged" in `coding-agents.md`, `codex.md`, `opencode.md` <!-- completed: 2026-06-06T02:28 -->
+- [x] D10 + D11 + D12 + D13 + D14 — sweep version qualifiers ("in v1", "first cut", "no pagination in the first cut") to present tense <!-- completed: 2026-06-06T02:28 -->
+- [x] D15 + D16 + D17 — strip "pre-existing session"/backfill narration in migration prose (`data-model.md`, `session-isolation.md`, `message-envelope.md`); keep filename references <!-- completed: 2026-06-06T02:28 -->
+
+### Step 2: Config
+
+- [ ] C1 — `.gitignore`: reword the `/prompts/` comment to present tense (drop "Legacy"/"now"/"during the rollout") <!-- completed: -->
+- [ ] C2 — `.claude/rules/commands.md`: drop the "— design-docs/0000044 uses this form" citation <!-- completed: -->
+
+### Step 3: Tests — delete pure removal-sentinels (Q2)
+
+- [ ] T1 — delete `test_bash_flag_removed__old_bash_flag_form_errors_with_no_such_option` <!-- completed: -->
+- [ ] T2 — delete `test_pretty_flag_rejected_as_unknown_option` <!-- completed: -->
+- [ ] T3 — delete `test_session_list_hides_soft_deleted__list_has_no_all_flag` <!-- completed: -->
+
+### Step 4: Tests — mixed cases (keep live coverage, drop sentinel)
+
+- [ ] T4 — `test_cli_session_flag.py`: reword the `CAFLEET_SESSION_ID was removed` docstring; keep the assertion <!-- completed: -->
+- [ ] T5 — `test_output_render_broadcast_summary.py`: delete the forbidden-keys loop + comment; keep the exact-key-set assertion <!-- completed: -->
+- [ ] T6 — `test_broker_typed_columns.py`: delete `FORBIDDEN_LEGACY_KEYS` + its check; keep the required-keys present-check (verify suite green) <!-- completed: -->
+- [ ] T7 — `test_cli_session_bootstrap.py`: simplify the `default_is_claude` docstring (drop the `'unknown'` reference) <!-- completed: -->
+
+### Step 5: Tests — design-doc-number citations (reword)
+
+- [ ] T8 + T9 — `test_server_routing.py`: drop the `design-doc 0000068` citations from the docstring and the mount-order comment <!-- completed: -->
+- [ ] T10 + T11 — `test_base_dir_spawn_flow.py`: drop the `design-0000055` / `Design 0000060` citations from the docstring and comment <!-- completed: -->
+- [ ] T12 — `test_output_render_task.py`: reword the incidental `text="legacy body"` fixture → `text="message body"` <!-- completed: -->
+
+### Step 6: Skills — design-doc pointers (judgment)
+
+- [ ] S1 — `skills/cafleet-design-doc/coordination.md`: remove the "Rationale-of-record: design-docs/0000050…" pointer line <!-- completed: -->
+- [ ] S2 — `skills/cafleet-design-doc-interview/SKILL.md`: drop the `design-docs/0000050` parenthetical; keep the "by design" statement <!-- completed: -->
+
+### Step 7: Verification
+
+- [ ] Run `mise //cafleet:test` — full suite green (special attention to T6) <!-- completed: -->
+- [ ] Run `mise //cafleet:lint` and `mise //cafleet:typecheck` — clean <!-- completed: -->
+- [ ] Re-run the sweep (use `git grep` over tracked files, which also excludes the untracked WebUI build output) and confirm zero matches **outside** the exempt areas (`design-docs/`, `researches/`, `cafleet/src/cafleet/alembic/`, `cafleet/src/cafleet/webui/assets/**`, lock files), for: `deprecat`, `no longer|formerly|previously|used to|historically`, `forensic|preserved for|for history`, `restoration`, `\blegacy\b`, `design[ -]?0000[0-9]{3}|\b0000[0-9]{3}\b` (word-boundary form so all-zero UUID constants like `00000000-0000-…` do not false-match; the KEEP-listed example slugs `0000060`/`0000099` are expected matches to ignore), `in v1|first cut`, `was removed|removed .* re-emerg`. Each remaining hit is either KEEP-listed or exempt — record any judgment calls. <!-- completed: -->
+
+---
+
+## Changelog
+
+| Date | Changes |
+|------|---------|
+| 2026-06-06 | Initial draft |
+| 2026-06-06 | Reviewer pass: added C2 (`.claude/rules/commands.md`) and T12 (`test_output_render_task.py`); exempted generated WebUI build output; resolved the D15 downgrade-narration judgment (keep); added the D1/D2-vs-Out-of-scope note; extended example-slug KEEP coverage to skill files; tightened the Step 7 sweep to a word-boundary form |
+| 2026-06-06 | Reviewer pass: reworded the sweep success criterion to "zero unaccounted matches"; added the "Known-benign sweep matches" KEEP bullet |
+| 2026-06-06 | User approved; Status → Approved |

--- a/docs/concepts/coding-agents.md
+++ b/docs/concepts/coding-agents.md
@@ -7,8 +7,7 @@ icon: lucide/cpu
 cafleet supports three coding-agent binaries inside member panes: `claude`
 (Claude Code), `codex` (OpenAI Codex CLI), and `opencode` (opencode.ai). The
 backend is selected at session-create and member-create time via
-`--coding-agent {claude,codex,opencode}`; the default is `claude` so existing
-invocations behave unchanged.
+`--coding-agent {claude,codex,opencode}`; the default is `claude`.
 
 ## Backend resolution
 

--- a/docs/concepts/session-isolation.md
+++ b/docs/concepts/session-isolation.md
@@ -104,8 +104,8 @@ session in the same transaction as the session row. The Administrator is an
 ordinary `agents` row distinguished only by `agent_card_json.cafleet.kind ==
 "builtin-administrator"` — no schema change, no separate table. Every session
 has exactly one Administrator, and Alembic revision
-`0006_seed_administrator_agent.py` backfills one into each pre-existing
-session on `cafleet db init` (idempotent via a `json_extract` probe).
+`0006_seed_administrator_agent.py` seeds it (idempotent via a `json_extract`
+probe).
 
 The Admin WebUI Send control always submits messages with
 `from_agent_id = administrator.agent_id`, so there is no sender dropdown.

--- a/docs/concepts/storage.md
+++ b/docs/concepts/storage.md
@@ -135,7 +135,7 @@ is idempotent across six DB states:
 Without `db init`, the first request fails with `OperationalError: no such
 table: agents`. The development workflow uses `alembic revision
 --autogenerate` directly; the `revision` and `downgrade` commands are not
-exposed via the CLI in v1.
+exposed via the CLI.
 
 ## No physical cleanup
 

--- a/docs/concepts/tmux-push.md
+++ b/docs/concepts/tmux-push.md
@@ -55,10 +55,7 @@ per-test `monkeypatch.setattr` on the class method is honored):
 The recipient's coding agent processes the keystroked text as a fresh
 user-turn input — no `cafleet message poll` invocation is in the auto-fire
 path. The recipient acks via `cafleet message ack --task-id <task_id>` once
-it has consumed the message. This replaces the design-0000049-pre keystroke
-(the literal `cafleet --session-id <s> message poll --agent-id <r>` + Enter
-sequence, which forced the recipient to dump its full unacked-inbox envelope
-on every send and dominated per-message token cost).
+it has consumed the message.
 
 The `TmuxMultiplexer.send_inline_preview` method is **NOT** a reuse of
 `send_freetext_and_submit` (which prepends a literal `4` for

--- a/docs/reference/coding-agents/codex.md
+++ b/docs/reference/coding-agents/codex.md
@@ -13,7 +13,7 @@ cafleet --session-id <session-id> member create --agent-id <director-agent-id> \
   --name Codex-A --description "<one-sentence purpose>" --coding-agent codex
 ```
 
-The default is `--coding-agent claude`, so existing invocations are unchanged. A single Director may spawn `claude`, `codex`, and `opencode` members in the same session — the broker, message lifecycle, and tmux primitives behave identically for all three. See [Opencode members](opencode.md) for opencode-specific operational detail.
+The default is `--coding-agent claude`. A single Director may spawn `claude`, `codex`, and `opencode` members in the same session — the broker, message lifecycle, and tmux primitives behave identically for all three. See [Opencode members](opencode.md) for opencode-specific operational detail.
 
 ## Spawn flags
 

--- a/docs/reference/coding-agents/opencode.md
+++ b/docs/reference/coding-agents/opencode.md
@@ -13,7 +13,7 @@ cafleet --session-id <session-id> member create --agent-id <director-agent-id> \
   --name Opencode-A --description "<one-sentence purpose>" --coding-agent opencode
 ```
 
-The default is `--coding-agent claude`, so existing invocations are unchanged. A single Director may spawn `claude`, `codex`, and `opencode` members in the same session — the broker, message lifecycle, and tmux primitives behave identically for all three.
+The default is `--coding-agent claude`. A single Director may spawn `claude`, `codex`, and `opencode` members in the same session — the broker, message lifecycle, and tmux primitives behave identically for all three.
 
 The opencode pane runs the bare `opencode` command, which per <https://opencode.ai/docs/cli/> is the documented TUI entry point ("The OpenCode CLI by default starts the TUI when run without any arguments"). The pane stays alive as a long-lived TUI you can scroll, switch to, and observe — matching the operator affordance of `claude` and `codex` panes. The `opencode run` subcommand (the documented headless / scripting entry) is **not** used.
 

--- a/docs/spec/data-model.md
+++ b/docs/spec/data-model.md
@@ -20,7 +20,7 @@ Schema management is handled by Alembic (`cafleet/src/cafleet/alembic/`); the ru
 
 Session deletion is a **soft-delete**: `broker.delete_session` sets `deleted_at=now`, then deregisters every active agent in the session (including the root Director) and physically deletes their `agent_placements` rows in the same transaction. Tasks are preserved. Re-running `session delete` on an already-soft-deleted session is a no-op that reports `Deregistered 0 agents.` because the initial `UPDATE` guard `WHERE deleted_at IS NULL` short-circuits the cascade.
 
-`broker.get_session` always returns the row (regardless of `deleted_at`) and exposes the field so callers can decide; `broker.list_sessions` filters `WHERE deleted_at IS NULL`, so `cafleet session list` hides soft-deleted sessions (no `--all` flag in v1). `broker.register_agent` inspects `get_session(...).deleted_at` and rejects a soft-deleted session with `Error: session X is deleted` (distinct from the `Session 'X' not found.` path).
+`broker.get_session` always returns the row (regardless of `deleted_at`) and exposes the field so callers can decide; `broker.list_sessions` filters `WHERE deleted_at IS NULL`, so `cafleet session list` hides soft-deleted sessions (no `--all` flag). `broker.register_agent` inspects `get_session(...).deleted_at` and rejects a soft-deleted session with `Error: session X is deleted` (distinct from the `Session 'X' not found.` path).
 
 #### Root Director bootstrap
 
@@ -28,7 +28,7 @@ Session deletion is a **soft-delete**: `broker.delete_session` sets `deleted_at=
 
 1. `INSERT INTO sessions (...)` with `deleted_at=NULL`, `director_agent_id=NULL`.
 2. `INSERT INTO agents (...)` for the hardcoded root Director (`name='Director'`, `description='Root Director for this session'`, `status='active'`).
-3. `INSERT INTO agent_placements (...)` for the Director with `director_agent_id=NULL` (the root has no parent Director) and `coding_agent='unknown'` (auto-detection is deferred).
+3. `INSERT INTO agent_placements (...)` for the Director with `director_agent_id=NULL` (the root has no parent Director) and `coding_agent=<value of --coding-agent>` (default `'claude'`).
 4. `UPDATE sessions SET director_agent_id = <director's agent_id> WHERE session_id = <new>`.
 5. `INSERT INTO agents (...)` for the built-in `Administrator` with `agent_card_json.cafleet.kind == 'builtin-administrator'`. The Administrator never gets an `agent_placements` row.
 
@@ -77,7 +77,7 @@ The `cafleet.*` namespace inside `agent_card_json` is reserved for broker-owned 
 **Creation paths**:
 
 - `broker.create_session(label, director_context)` inserts the Administrator row as the final operation of the 5-step root-Director bootstrap transaction (see "Root Director bootstrap" under the `sessions` table above); `registered_at` matches `sessions.created_at` exactly. The result dict exposes `administrator_agent_id` alongside the `director` sub-object for the caller.
-- Alembic revision `0006_seed_administrator_agent.py` backfills one Administrator into each pre-existing session. The migration generates `agent_id = str(uuid.uuid4())` in Python (matching the broker's idiom — no SQL-side `gen_random_uuid()`), probes for an existing Administrator via `json_extract(agent_card_json, '$.cafleet.kind') = 'builtin-administrator'`, and is idempotent by construction (a second `upgrade` finds the existing row and skips the INSERT). Downgrade is provided for empty sessions only and is forward-only in practice — `tasks.context_id` uses `ON DELETE RESTRICT`, so downgrading a session that has tasks addressed to or from the Administrator raises `IntegrityError`. (`agent_placements.agent_id` uses `ON DELETE CASCADE`, but Administrators never receive a placement anyway.)
+- Alembic revision `0006_seed_administrator_agent.py` is the migration that seeds the Administrator. The migration generates `agent_id = str(uuid.uuid4())` in Python (matching the broker's idiom — no SQL-side `gen_random_uuid()`), probes for an existing Administrator via `json_extract(agent_card_json, '$.cafleet.kind') = 'builtin-administrator'`, and is idempotent by construction (a second `upgrade` finds the existing row and skips the INSERT). Downgrade is provided for empty sessions only and is forward-only in practice — `tasks.context_id` uses `ON DELETE RESTRICT`, so downgrading a session that has tasks addressed to or from the Administrator raises `IntegrityError`. (`agent_placements.agent_id` uses `ON DELETE CASCADE`, but Administrators never receive a placement anyway.)
 
 **Invariant**: Every session has exactly one active `Administrator` agent. Both `broker.list_session_agents` and `broker.get_agent` surface a derived `kind` field (`"builtin-administrator"` | `"user"`) so the WebUI can locate the Administrator without matching on the name. `list_session_agents` derives the discriminator in SQL via `json_extract(agent_card_json, '$.cafleet.kind')` and never fetches the full card blob; `get_agent` already loads the full ORM row and computes the discriminator via `_is_administrator`.
 
@@ -123,7 +123,7 @@ Indexes:
 | `tmux_session` | `TEXT` | `NOT NULL` | e.g. `'main'`, from `tmux display-message '#{session_name}'`. |
 | `tmux_window_id` | `TEXT` | `NOT NULL` | e.g. `'@3'`, from `#{window_id}`. |
 | `tmux_pane_id` | `TEXT` | nullable | e.g. `'%7'`. `NULL` = pending (row inserted at register time, pane not yet spawned). Set via `PATCH /api/v1/agents/{id}/placement` after `tmux split-window` succeeds. |
-| `coding_agent` | `TEXT` | `NOT NULL`, `DEFAULT 'claude'` | Free-form coding-agent identifier. Current known values are `"claude"` (the server default for normal registrations) and `"unknown"` for the session's root Director placement created by `broker.create_session`. The SQL default ensures existing rows are backfilled on migration. |
+| `coding_agent` | `TEXT` | `NOT NULL`, `DEFAULT 'claude'` | Free-form coding-agent identifier. Current known values are `"claude"` (the server default for normal registrations) and `"codex"` / `"opencode"` when chosen at create time. The SQL default ensures existing rows are backfilled on migration. |
 | `created_at` | `TEXT` | `NOT NULL` | ISO-8601 timestamp, set server-side to match `agents.registered_at`. |
 
 Indexes:
@@ -140,7 +140,7 @@ If a user kills a pane manually without going through `cafleet member delete`, t
 
 SQLite ignores foreign key declarations unless `PRAGMA foreign_keys=ON` is issued on every connection. The registry installs a SQLAlchemy engine `connect` event listener that runs the PRAGMA on every new DBAPI connection. A regression test verifies the PRAGMA is active on a fresh connection.
 
-The two foreign keys (`agents.session_id → sessions.session_id`, `tasks.context_id → agents.agent_id`) both use `ON DELETE RESTRICT`. There is no path in v1 that physically deletes an agent — deregistration is a soft-status flip — so RESTRICT is the safest default. The added `sessions.director_agent_id → agents.agent_id` FK also uses `ON DELETE RESTRICT` for the same reason: it should never point at a row that can vanish. Session deletion uses a soft-delete (`deleted_at`) — it never physically removes rows, so the RESTRICTs are never triggered by the delete path.
+The two foreign keys (`agents.session_id → sessions.session_id`, `tasks.context_id → agents.agent_id`) both use `ON DELETE RESTRICT`. There is no path that physically deletes an agent — deregistration is a soft-status flip — so RESTRICT is the safest default. The added `sessions.director_agent_id → agents.agent_id` FK also uses `ON DELETE RESTRICT` for the same reason: it should never point at a row that can vanish. Session deletion uses a soft-delete (`deleted_at`) — it never physically removes rows, so the RESTRICTs are never triggered by the delete path.
 
 ## Operation mapping
 
@@ -211,7 +211,6 @@ Broadcast fan-out in `BrokerExecutor._handle_broadcast` produces N+1 rows per `S
 | Unicast delivery (today's `_handle_unicast`) | `NULL` |
 | Broadcast delivery row (one per recipient) | The summary task's `task_id` (shared across all N delivery rows in the same broadcast) |
 | Broadcast summary row | Its own `task_id` (self-reference) |
-| Historical row from before the `0002_add_origin_task_id` migration | `NULL` (no backfill) |
 
 The column is populated by pre-allocating the summary task's UUID **before** the delivery loop in `_handle_broadcast`, then threading that UUID into every delivery task's metadata as `originTaskId`. `TaskStore.save` reads `metadata.get("originTaskId")` and writes it into the column on both `INSERT` and `ON CONFLICT DO UPDATE` so idempotent re-saves preserve the value. `_handle_unicast` is NOT touched — the absence of `originTaskId` in its metadata writes the column as `NULL`.
 
@@ -221,10 +220,10 @@ The grouping predicate on the wire is `origin_task_id IS NOT NULL`, which cleanl
 
 The timeline UI renders a per-recipient ACK time in each broadcast's hover tooltip. That time is read from the `status_timestamp` of the matching delivery row whose `status_state == 'completed'`. This works today because **delivery tasks make exactly one state transition over their lifetime**: `input_required → completed` via `BrokerExecutor._handle_ack`, which overwrites `status_timestamp` with the ACK moment. Consequently, for any completed delivery row, `status_timestamp` IS the ACK timestamp.
 
-**No dedicated `acknowledged_at` column is added.** If any future change introduces a second state transition on a delivery task — retry, resurrect, a metadata-only re-save that moves `status_timestamp`, or any other path that rewrites `status_timestamp` after ACK — this invariant breaks and the reaction tooltip silently starts showing wrong times. At that point a dedicated `acknowledged_at` TEXT column MUST be added to `tasks`, populated in `_handle_ack`, and the WebUI tooltip code MUST be switched to read it instead of `status_timestamp`. This is accepted residual risk for the first cut of the Discord-style timeline and is explicitly flagged here so the next contributor who breaks the invariant knows exactly which column to add.
+**No dedicated `acknowledged_at` column is added.** If any future change introduces a second state transition on a delivery task — retry, resurrect, a metadata-only re-save that moves `status_timestamp`, or any other path that rewrites `status_timestamp` after ACK — this invariant breaks and the reaction tooltip silently starts showing wrong times. At that point a dedicated `acknowledged_at` TEXT column MUST be added to `tasks`, populated in `_handle_ack`, and the WebUI tooltip code MUST be switched to read it instead of `status_timestamp`. This is accepted residual risk and is explicitly flagged here so the next contributor who breaks the invariant knows exactly which column to add.
 
 ## Deregistered Agents
 
 Deregistration is a soft-delete only. There is no background cleanup loop and no physical removal of agent or task rows. Deregistered agents continue to exist as rows with `status='deregistered'` indefinitely; their inbox tasks remain readable by the WebUI (the only consumer that surfaces deregistered agents). Active query paths filter `status='active'` so dead rows are invisible to normal traffic.
 
-If physical cleanup becomes necessary in the future, it can be reintroduced as an opt-in admin command (e.g., `cafleet db purge --older-than 30d`) without disturbing the runtime. The previous `DEREGISTERED_TASK_TTL_DAYS` and `CLEANUP_INTERVAL_SECONDS` settings have been removed.
+If physical cleanup becomes necessary in the future, it can be added as an opt-in admin command (e.g., `cafleet db purge --older-than 30d`) without disturbing the runtime.

--- a/docs/spec/message-envelope.md
+++ b/docs/spec/message-envelope.md
@@ -23,7 +23,7 @@ Every message lives in `tasks` as a flat row of typed columns. There is no JSON 
 
 The persisted shape is the canonical source of truth. Every render the broker produces is a projection of these columns.
 
-See [data-model.md](data-model.md) for the full SQL schema (including indexes, foreign-key declarations, and the `0009_drop_task_json_add_text` migration shape with the operator backup procedure).
+See [data-model.md](data-model.md) for the full SQL schema (including indexes, foreign-key declarations, and the `0009_drop_task_json_add_text` migration shape).
 
 ## Rendered shape
 

--- a/docs/spec/webui-api.md
+++ b/docs/spec/webui-api.md
@@ -141,7 +141,7 @@ Session scoping is reached through the `tasks.context_id → agents.agent_id →
 
 **Ordering**: `status_timestamp DESC` (newest first). The frontend re-orders ascending for newest-at-bottom chat rendering.
 
-**Row cap**: Hard-capped at 200 rows. No pagination in the first cut.
+**Row cap**: Hard-capped at 200 rows; no pagination.
 
 **Exclusions**: Rows with `type == "broadcast_summary"` are filtered out of the response. The summary row's metadata (`recipientIds`) is not needed for the UI; the grouping convention below lets the frontend reconstruct broadcasts from their delivery rows alone.
 
@@ -151,7 +151,6 @@ Session scoping is reached through the `tasks.context_id → agents.agent_id →
 |---|---|
 | Unicast delivery | `null` |
 | Broadcast delivery | The broadcast's summary task id (shared across all N delivery rows in the same broadcast) |
-| Historical row from before the `origin_task_id` migration | `null` |
 
 The client groups rows by `origin_task_id` (non-null rows sharing a value form one broadcast entry; null rows are standalone unicast entries). Each broadcast entry's sort key is the `MIN(created_at)` of its rows — stable, so a broadcast never drifts when a lagging recipient ACKs.
 

--- a/skills/cafleet-design-doc-interview/SKILL.md
+++ b/skills/cafleet-design-doc-interview/SKILL.md
@@ -23,7 +23,7 @@ Validate an existing design document through structured, fine-grained Q&A across
 
 This skill writes only `COMMENT(claude)` markers in the design document, and the Director-Analyzer cafleet messages are exempt from the verb + pointer + `COMMENT(role)` schema used by the `cafleet-design-doc-create` and `cafleet-design-doc-execute` skills. The Analyzer's question list is a one-time payload deliverable (a numbered list, not iterative coordination), and the Director's user-facing relay goes through `AskUserQuestion`, not cafleet. Only the inline `COMMENT(claude)` annotation rules below are in scope.
 
-> **Maintainer source-of-truth.** The `COMMENT(role)` marker convention is mirrored from `skills/cafleet-design-doc/coordination.md` (the canonical reference; updates to one require updates to the other). The convention is fully inlined below so this skill stands alone when packaged as an independent plugin — no cross-skill markdown link is added, by design (see `design-docs/0000050-design-doc-as-medium/design-doc.md` Step 7 for the plugin-install self-containment rationale).
+> **Maintainer source-of-truth.** The `COMMENT(role)` marker convention is mirrored from `skills/cafleet-design-doc/coordination.md` (the canonical reference; updates to one require updates to the other). The convention is fully inlined below so this skill stands alone when packaged as an independent plugin — no cross-skill markdown link is added, by design.
 
 ### COMMENT(claude) Marker
 

--- a/skills/cafleet-design-doc/coordination.md
+++ b/skills/cafleet-design-doc/coordination.md
@@ -1,5 +1,3 @@
-Rationale-of-record: design-docs/0000050-design-doc-as-medium/design-doc.md.
-
 # Coordination Protocol
 
 Mechanics for inter-agent coordination. The design document is the substantive communication medium; `cafleet message send --text` carries only a single-line **verb + pointer** poke. Substantive content (feedback, reports, escalation reasons, review items) lives in inline `COMMENT(role)` markers in the design doc — except for source-anchored Copilot inline review, which is annotated in the source file at `<file>:<line>` because that is where the comment lives.


### PR DESCRIPTION
Implements design **0000072 — Purge Historical-Trajectory Narration**.

Removes or rewords historical-trajectory narration (deprecation notes, "previously/now", "preserved for forensic visibility", design-number-as-reason citations, and removal-sentinel tests) across `docs/`, `.gitignore`, `.claude/`, `skills/`, `cafleet/tests/`, and one `admin/` string. No runtime behavior changes — only the narration is removed.

**Verification:** `mise //cafleet:test` 727 passed · `mise //cafleet:lint` clean · `mise //cafleet:typecheck` clean · narration sweep (8 patterns) zero unaccounted matches.

Design doc: `design-docs/0000072-purge-historical-narration/design-doc.md`.
