### PR TITLE
feat/0000081 docs friendliness

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,62 @@ https://github.com/user-attachments/assets/a66620cb-4a81-4525-95f2-1f1f22765288
 
 Agent Teams reinvented for collaborative coding across multiple coding-agent backends, with full code transparency.
 
-## 1. Install
+## 1. Who is CAFleet for
+
+- Developers running multi-agent coding teams in tmux who want every inter-agent message persisted and auditable.
+- Teams mixing `claude`, `codex`, and `opencode` members in one fleet.
+- Operators who want a single-file SQLite broker with no server to run.
+
+## 2. See it work
+
+Create a fleet, spawn a member pane, message it, and tear everything down — four commands inside a tmux session. The ids below (`1`, `2`, `4`, `10`) are samples; substitute the integers your own commands print.
+
+```bash
+cafleet fleet create --label "demo"
+```
+
+```
+1 director=2 admin=3
+```
+
+```bash
+cafleet --fleet-id 1 member create --agent-id 2 --name "demo-member" \
+  --description "Demo member" -- "You are demo-member. Reply hello when polled."
+```
+
+```
+4 demo-member backend=claude pane=%7
+```
+
+```bash
+cafleet --fleet-id 1 message send --agent-id 2 --to 4 --text "hi"
+```
+
+```
+Message sent.
+[10 | from:2 | 2026-06-11T09:00:00.123456+00:00]
+hi
+```
+
+```bash
+cafleet --fleet-id 1 member delete --member-id 4
+cafleet fleet delete 1
+```
+
+```
+Deleted fleet 1. Deregistered 2 agents.
+```
+
+The full walkthrough with every expected output is the quickstart: <https://himkt.github.io/cafleet/get-started/quickstart/>. Task-oriented guides live at <https://himkt.github.io/cafleet/how-to/>, and the symptom→fix table at <https://himkt.github.io/cafleet/get-started/troubleshooting/>.
+
+## 3. Install
 
 CAFleet works with three coding agents: `claude` (Claude Code), `codex` (OpenAI Codex CLI), and `opencode`.
 Install the plugin in whichever one you use — the broker CLI is shared.
 
-### 1.1. CAFleet skills
+### 3.1. CAFleet skills
 
-Use your favorite tool to install skills (for example, GitHub CLI `gh skill`, vercel `skills`, or marketplace of each coding agent.
+Use your favorite tool to install skills (for example, GitHub CLI `gh skill`, vercel `skills`, or the marketplace of each coding agent).
 
 #### (a) GitHub CLI (recommended)
 
@@ -35,7 +83,7 @@ codex plugin marketplace add himkt/cafleet
 ```
 
 
-### 1.2. CAFleet CLI (required for CAFleet to function)
+### 3.2. CAFleet CLI (required for CAFleet to function)
 
 ```bash
 uv tool install cafleet     # or: pip install cafleet
@@ -46,9 +94,9 @@ The default database is `~/.local/share/cafleet/cafleet.db`. Override with `CAFL
 
 Per-coding-agent config (Claude `permissions.allow`, Codex `config.toml` + rules, opencode) lives on the Configure page: <https://himkt.github.io/cafleet/get-started/configure/>.
 
-## 2. Examples
+## 4. Examples
 
-### 2.1. Simple example to use CAFleet
+### 4.1. Simple example to use CAFleet
 
 Provide the following prompt to Claude Code or Codex to see how it works.
 
@@ -58,7 +106,7 @@ Please create a new team with two members using cafleet and let them ping-pong e
 After the demonstration, please shutdown the team.
 ```
 
-### 2.2. Real world usage; Design-doc-driven development
+### 4.2. Real world usage; Design-doc-driven development
 
 CAFleet provides the builtin skills for Spec Driven Development (SDD). **We're using CAFleet to develop CAFleet!**
 
@@ -72,10 +120,10 @@ See your coding-agent's skill documentation for the literal invocation syntax (C
 
 You can see the existing design docs on [`design-docs/`](design-docs/), which are actually created by the skills.
 
-## 3. Architecture
+## 5. Architecture
 
 CAFleet ships a unified `cafleet` CLI and an admin WebUI on top of a single-file SQLite database. Fleets partition agents into isolated namespaces; the CLI accesses SQLite directly through a shared `broker` module, so no HTTP server is required for agent operations. Members spawn as tmux panes running any of the three coding-agent backends, optionally pinned to a specific LLM via `cafleet member create --model <m>` (e.g. `sonnet`, `gpt-5.4-mini`, `anthropic/claude-sonnet-4-6`). Full architecture documentation is published at <https://himkt.github.io/cafleet/concepts/overview/>.
 
-## 4. Contributing
+## 6. Contributing
 
 Build, test, and project-structure instructions, plus the design-doc-driven contribution flow, are published at <https://himkt.github.io/cafleet/get-started/contributing/>.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Agent Teams reinvented for collaborative coding across multiple coding-agent bac
 
 ## 2. See it work
 
-Create a fleet, spawn a member pane, message it, and tear everything down — four commands inside a tmux session. The ids below (`1`, `2`, `4`, `10`) are samples; substitute the integers your own commands print.
+Create a fleet, spawn a member pane, message it, and tear everything down — five commands inside a tmux session. The ids below (`1`, `2`, `4`, `10`) are samples; substitute the integers your own commands print.
 
 ```bash
 cafleet fleet create --label "demo"

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Agent Teams reinvented for collaborative coding across multiple coding-agent bac
 
 ## 2. See it work
 
-Create a fleet, spawn a member pane, message it, and tear everything down — five commands inside a tmux session. The ids below (`1`, `2`, `4`, `10`) are samples; substitute the integers your own commands print.
+Create a fleet, spawn a member pane, message it, and tear everything down — five commands inside a tmux session. The ids below are samples — fleet `1`, root Director `2`, built-in Administrator `3`, member `4`, task `10`; substitute the integers your own commands print.
 
 ```bash
 cafleet fleet create --label "demo"

--- a/design-docs/0000079-docs-simplification/design-doc.md
+++ b/design-docs/0000079-docs-simplification/design-doc.md
@@ -1,8 +1,8 @@
 # Documentation Simplification (docs/ + README.md)
 
-**Status**: Approved
+**Status**: Complete
 **Progress**: 24/24 tasks complete
-**Last Updated**: 2026-06-09
+**Last Updated**: 2026-06-11
 
 ## Overview
 
@@ -288,3 +288,4 @@ This is the canonical CLI reference and the new canonical home for fleet bootstr
 |------|---------|
 | 2026-06-08 | Initial draft |
 | 2026-06-09 | Implementation complete — all 24 tasks across the 5 steps; clean `mise //:docs-build`, stale-term grep empty. |
+| 2026-06-11 | Status flipped to Complete — the field was left at Approved when implementation finished. |

--- a/design-docs/0000081-docs-friendliness/design-doc.md
+++ b/design-docs/0000081-docs-friendliness/design-doc.md
@@ -1,7 +1,7 @@
 # Documentation Friendliness (README.md + docs/ + zensical.toml)
 
 **Status**: Approved
-**Progress**: 0/20 tasks complete
+**Progress**: 2/20 tasks complete
 **Last Updated**: 2026-06-10
 
 ## Overview
@@ -262,8 +262,8 @@ The `navigation.indexes` feature is already enabled, so `how-to/index.md` and `a
 
 ### Step 1: Foundations (style + terms)
 
-- [ ] `docs/get-started/contributing.md` — append the Documentation style section (audience split, voice, term linking, example format with the sample-id cast, SSOT rule). <!-- completed: -->
-- [ ] `docs/concepts/overview.md` — insert the Core terms table after the opening paragraph. <!-- completed: -->
+- [x] `docs/get-started/contributing.md` — append the Documentation style section (audience split, voice, term linking, example format with the sample-id cast, SSOT rule). <!-- completed: 2026-06-11T08:52 -->
+- [x] `docs/concepts/overview.md` — insert the Core terms table after the opening paragraph. <!-- completed: 2026-06-11T08:52 -->
 
 ### Step 2: Quickstart fix + CLI reference scannability
 

--- a/design-docs/0000081-docs-friendliness/design-doc.md
+++ b/design-docs/0000081-docs-friendliness/design-doc.md
@@ -1,7 +1,7 @@
 # Documentation Friendliness (README.md + docs/ + zensical.toml)
 
 **Status**: Approved
-**Progress**: 2/20 tasks complete
+**Progress**: 5/20 tasks complete
 **Last Updated**: 2026-06-10
 
 ## Overview
@@ -29,7 +29,7 @@ Design doc 0000079 made the docs lean (SSOT map, necessity test, symbol strip); 
 
 Verified gaps in the current tree (each confirmed against the files on 2026-06-10):
 
-1. **Shell-var contradiction**: `docs/get-started/quickstart.md` tells readers to `export FLEET_ID` / `export DIRECTOR_ID`, while `docs/spec/cli-options.md` § Option Source Matrix explicitly forbids shell variables (permission-pattern matching). The quickstart also passes `--full` to `fleet create`, which takes no such flag (its flags are `--label`, `--coding-agent`, `--json`) — the walkthrough as written fails.
+1. **Shell-var contradiction**: `docs/get-started/quickstart.md` tells readers to `export FLEET_ID` / `export DIRECTOR_ID`, while `docs/spec/cli-options.md` § Option Source Matrix explicitly forbids shell variables (permission-pattern matching). The quickstart also passes `--full` to `fleet create` — a hidden flag (`hidden=True`, absent from `--help`) that does work but selects the verbose 7-line output; the default non-JSON output is the compact `<fleet_id> director=<id> admin=<id>` line, and `spec/cli-options.md` § `cafleet fleet create` is stale in presenting the 7-line block as the default shape.
 2. **No task-oriented layer** between the one-screen quickstart and the exhaustive spec pages.
 3. **`spec/cli-options.md` (669 lines)** has no scannable subcommand summary up front; moreover the `agent` and `message` subcommand groups have **no reference sections at all** on the page that `concepts/overview.md` calls "the canonical CLI surface".
 4. **No glossary**: concepts pages assume fleet/member/Director/placement/broker/inline-preview terminology.
@@ -172,7 +172,7 @@ One short page: the Python API matters to **contributors** changing cafleet and 
 
 #### `docs/get-started/quickstart.md`
 
-- **Rewrite the "Raw CLI walkthrough"** with literal ids: run `cafleet fleet create --label "demo"` (drop the invalid `--full` flag), show the non-JSON output block (`1` / `2` / `label:` … per the shape in `spec/cli-options.md`), then paste the literal ids into every subsequent command — `--fleet-id 1` on all of them, plus `--agent-id 2` only on the commands that take an identity flag (`member create`, `message send`); `agent list` takes only `--fleet-id`. Include the one-time "your ids will differ" note.
+- **Rewrite the "Raw CLI walkthrough"** with literal ids: run `cafleet fleet create --label "demo"` (drop the hidden `--full` flag), show the default compact output line (`1 director=2 admin=3`, per the corrected shape in `spec/cli-options.md`), then paste the literal ids into every subsequent command — `--fleet-id 1` on all of them, plus `--agent-id 2` only on the commands that take an identity flag (`member create`, `message send`); `agent list` takes only `--fleet-id`. Include the one-time "your ids will differ" note.
 - Show expected output for `member create`, `agent list` (member id `4` appears), and `message send` (compact envelope, task id `10`).
 - Add one recovery tip: if the `fleet create` output scrolled away, `cafleet fleet list` re-prints the fleet id and the DIRECTOR column.
 - End with next-step links: How-to guides and Troubleshooting (alongside the existing CLI-options link).
@@ -182,6 +182,7 @@ One short page: the Python API matters to **contributors** changing cafleet and 
 
 - **Add a `## Subcommand summary` table** directly after the page intro (before the Option Source Matrix): one row per subcommand — `db init`, `fleet create/list/show/delete`, `doctor`, `server`, `agent register/deregister/list/show`, `message send/broadcast/poll/ack/cancel/show`, `member create/delete/list/capture/send-input/exec/ping` (24 rows) — with a one-line purpose, whether `--fleet-id` is required, the identity flag (`--agent-id` / `--member-id` / none), and a link to the subcommand's section on this page.
 - **Add the two missing reference sections** so every summary row has a target: a compact `## cafleet agent` section (register / deregister / list / show: flag tables and output shapes) and a compact `## cafleet message` section (send / broadcast / poll / ack / cancel / show: flag tables; link `spec/message-envelope.md` for the envelope schema and the existing § Message Body Truncation for `--full`/truncation instead of restating either). This closes the gap where the page `concepts/overview.md` calls "the canonical CLI surface" had no agent/message sections at all.
+- **Correct the § `cafleet fleet create` output documentation**: the default non-JSON output is the compact `<fleet_id> director=<id> admin=<id>` line; the 7-line block currently presented as the default is the hidden `--full` shape. Content correction only, no restructuring.
 - **Document the `member create` output shape** in its existing section: the observable text (and `--json`) output as emitted by the current CLI, verified against the implementation while editing. Guiding principle 3 makes this page the arbiter of every shown output block, and both the quickstart rewrite and the mixed-backend how-to need `member create` expected-output blocks — the canonical shape must exist here first.
 - No restructuring otherwise; the page stays one page and all existing anchors (`#full-semantics`, `#message-body-truncation`, `#error-messages`) are preserved.
 
@@ -267,9 +268,9 @@ The `navigation.indexes` feature is already enabled, so `how-to/index.md` and `a
 
 ### Step 2: Quickstart fix + CLI reference scannability
 
-- [ ] `docs/get-started/quickstart.md` — rewrite the raw CLI walkthrough with literal ids (no shell vars), drop the invalid `--full` on `fleet create`, add expected-output blocks, the "your ids will differ" note, the `fleet list` recovery tip, and next-step links. <!-- completed: -->
-- [ ] `docs/spec/cli-options.md` — add the Subcommand summary table (24 rows with section links) after the page intro. <!-- completed: -->
-- [ ] `docs/spec/cli-options.md` — add the compact `cafleet agent` and `cafleet message` reference sections (flag tables + output shapes; link message-envelope.md and § Message Body Truncation instead of restating), and document the `member create` output shape in its existing section (verified against the implementation). <!-- completed: -->
+- [x] `docs/get-started/quickstart.md` — rewrite the raw CLI walkthrough with literal ids (no shell vars), drop the hidden `--full` on `fleet create`, add expected-output blocks, the "your ids will differ" note, the `fleet list` recovery tip, and next-step links. <!-- completed: 2026-06-11T09:05 -->
+- [x] `docs/spec/cli-options.md` — add the Subcommand summary table (24 rows with section links) after the page intro. <!-- completed: 2026-06-11T09:05 -->
+- [x] `docs/spec/cli-options.md` — add the compact `cafleet agent` and `cafleet message` reference sections (flag tables + output shapes; link message-envelope.md and § Message Body Truncation instead of restating), and document the `member create` output shape in its existing section (verified against the implementation). <!-- completed: 2026-06-11T09:05 -->
 
 ### Step 3: How-to guides
 
@@ -309,3 +310,4 @@ The `navigation.indexes` feature is already enabled, so `how-to/index.md` and `a
 |------|---------|
 | 2026-06-10 | Initial draft |
 | 2026-06-10 | Reviewer round 1: broadened the shell-var acceptance grep to cover DIRECTOR_ID; unified the troubleshooting row threshold at ≥ 12; made the member-id cast open-ended; scoped the quickstart literal-id instruction to commands that take an identity flag; added a directive to document the `member create` output shape in cli-options; corrected the README §1.1 verbatim quote; re-pointed the docs/index.md API Reference link to `api/index.md`. |
+| 2026-06-11 | Director arbitration (Step 2): `fleet create` accepts a hidden `--full` flag and its default output is the compact `<fleet_id> director=<id> admin=<id>` line — corrected Background §1, the quickstart directive (compact default output), and added a cli-options directive to fix the stale § fleet create output shape. |

--- a/design-docs/0000081-docs-friendliness/design-doc.md
+++ b/design-docs/0000081-docs-friendliness/design-doc.md
@@ -1,7 +1,7 @@
 # Documentation Friendliness (README.md + docs/ + zensical.toml)
 
 **Status**: Approved
-**Progress**: 5/20 tasks complete
+**Progress**: 10/20 tasks complete
 **Last Updated**: 2026-06-10
 
 ## Overview
@@ -274,11 +274,11 @@ The `navigation.indexes` feature is already enabled, so `how-to/index.md` and `a
 
 ### Step 3: How-to guides
 
-- [ ] `docs/how-to/index.md` — section index page. <!-- completed: -->
-- [ ] `docs/how-to/mixed-backend-team.md` — per the outline (prereqs → fleet create → three member creates → pane discovery → cross-backend round-trip → teardown). <!-- completed: -->
-- [ ] `docs/how-to/monitor-and-recover.md` — per the outline (`member list --activity` → `capture` → recovery ladder ping/send-input/exec/delete[-f]). <!-- completed: -->
-- [ ] `docs/how-to/use-the-webui.md` — per the outline (`cafleet server` → fleet picker → timeline → @-send → history; webui-api link; 404/build note). <!-- completed: -->
-- [ ] `docs/how-to/design-doc-development.md` — per the outline (three skills → output location → WebUI audit trail → invocation pointer). <!-- completed: -->
+- [x] `docs/how-to/index.md` — section index page. <!-- completed: 2026-06-11T09:12 -->
+- [x] `docs/how-to/mixed-backend-team.md` — per the outline (prereqs → fleet create → three member creates → pane discovery → cross-backend round-trip → teardown). <!-- completed: 2026-06-11T09:12 -->
+- [x] `docs/how-to/monitor-and-recover.md` — per the outline (`member list --activity` → `capture` → recovery ladder ping/send-input/exec/delete[-f]). <!-- completed: 2026-06-11T09:12 -->
+- [x] `docs/how-to/use-the-webui.md` — per the outline (`cafleet server` → fleet picker → timeline → @-send → history; webui-api link; 404/build note). <!-- completed: 2026-06-11T09:12 -->
+- [x] `docs/how-to/design-doc-development.md` — per the outline (three skills → output location → WebUI audit trail → invocation pointer). <!-- completed: 2026-06-11T09:12 -->
 
 ### Step 4: Troubleshooting
 

--- a/design-docs/0000081-docs-friendliness/design-doc.md
+++ b/design-docs/0000081-docs-friendliness/design-doc.md
@@ -1,7 +1,7 @@
 # Documentation Friendliness (README.md + docs/ + zensical.toml)
 
 **Status**: Approved
-**Progress**: 14/20 tasks complete
+**Progress**: 17/20 tasks complete
 **Last Updated**: 2026-06-10
 
 ## Overview
@@ -292,9 +292,9 @@ The `navigation.indexes` feature is already enabled, so `how-to/index.md` and `a
 
 ### Step 6: Landing surfaces
 
-- [ ] `README.md` — add "Who is CAFleet for" + the condensed "See it work" example with output; fix the §1.1 unclosed parenthesis; add How-to / Troubleshooting links; keep and renumber existing sections. <!-- completed: -->
-- [ ] `docs/index.md` — add the who-for sentence, extend the Browse list with How-to guides and Troubleshooting, and re-point the API Reference entry to `api/index.md`. <!-- completed: -->
-- [ ] `CONTRIBUTING.md` (root) — verify the pointer needs no change. <!-- completed: -->
+- [x] `README.md` — add "Who is CAFleet for" + the condensed "See it work" example with output; fix the §1.1 unclosed parenthesis; add How-to / Troubleshooting links; keep and renumber existing sections. <!-- completed: 2026-06-11T09:20 -->
+- [x] `docs/index.md` — add the who-for sentence, extend the Browse list with How-to guides and Troubleshooting, and re-point the API Reference entry to `api/index.md`. <!-- completed: 2026-06-11T09:20 -->
+- [x] `CONTRIBUTING.md` (root) — verify the pointer needs no change. <!-- completed: 2026-06-11T09:20 -->
 
 ### Step 7: Nav + verification
 

--- a/design-docs/0000081-docs-friendliness/design-doc.md
+++ b/design-docs/0000081-docs-friendliness/design-doc.md
@@ -1,8 +1,8 @@
 # Documentation Friendliness (README.md + docs/ + zensical.toml)
 
 **Status**: Approved
-**Progress**: 17/20 tasks complete
-**Last Updated**: 2026-06-10
+**Progress**: 20/20 tasks complete
+**Last Updated**: 2026-06-11
 
 ## Overview
 
@@ -298,9 +298,9 @@ The `navigation.indexes` feature is already enabled, so `how-to/index.md` and `a
 
 ### Step 7: Nav + verification
 
-- [ ] `zensical.toml` — apply the nav additions (Troubleshooting entry, How-to guides section, `api/index.md` section index). <!-- completed: -->
-- [ ] Run `mise //:docs-build`; confirm a clean build with all nav entries and cross-references resolving. <!-- completed: -->
-- [ ] Consistency greps: `grep -rE "export (FLEET|DIRECTOR)_ID" docs/ README.md` empty; `grep -rn '\-\-full' docs/get-started/quickstart.md` shows no `fleet create --full`; spot-check that the sample-id cast (`--fleet-id 1`, `--agent-id 2`) is used consistently across README, quickstart, and how-to pages. <!-- completed: -->
+- [x] `zensical.toml` — apply the nav additions (Troubleshooting entry, How-to guides section, `api/index.md` section index). <!-- completed: 2026-06-11T09:23 -->
+- [x] Run `mise //:docs-build`; confirm a clean build with all nav entries and cross-references resolving. <!-- completed: 2026-06-11T09:23 -->
+- [x] Consistency greps: `grep -rE "export (FLEET|DIRECTOR)_ID" docs/ README.md` empty; `grep -rn '\-\-full' docs/get-started/quickstart.md` shows no `fleet create --full`; spot-check that the sample-id cast (`--fleet-id 1`, `--agent-id 2`) is used consistently across README, quickstart, and how-to pages. <!-- completed: 2026-06-11T09:23 -->
 
 ---
 

--- a/design-docs/0000081-docs-friendliness/design-doc.md
+++ b/design-docs/0000081-docs-friendliness/design-doc.md
@@ -1,6 +1,6 @@
 # Documentation Friendliness (README.md + docs/ + zensical.toml)
 
-**Status**: Approved
+**Status**: Complete
 **Progress**: 20/20 tasks complete
 **Last Updated**: 2026-06-11
 
@@ -311,3 +311,4 @@ The `navigation.indexes` feature is already enabled, so `how-to/index.md` and `a
 | 2026-06-10 | Initial draft |
 | 2026-06-10 | Reviewer round 1: broadened the shell-var acceptance grep to cover DIRECTOR_ID; unified the troubleshooting row threshold at ≥ 12; made the member-id cast open-ended; scoped the quickstart literal-id instruction to commands that take an identity flag; added a directive to document the `member create` output shape in cli-options; corrected the README §1.1 verbatim quote; re-pointed the docs/index.md API Reference link to `api/index.md`. |
 | 2026-06-11 | Director arbitration (Step 2): `fleet create` accepts a hidden `--full` flag and its default output is the compact `<fleet_id> director=<id> admin=<id>` line — corrected Background §1, the quickstart directive (compact default output), and added a cli-options directive to fix the stale § fleet create output shape. |
+| 2026-06-11 | Implementation complete — all 20 tasks and all 10 success criteria verified; two Copilot review rounds addressed on PR #107. Status flipped to Complete. |

--- a/design-docs/0000081-docs-friendliness/design-doc.md
+++ b/design-docs/0000081-docs-friendliness/design-doc.md
@@ -1,7 +1,7 @@
 # Documentation Friendliness (README.md + docs/ + zensical.toml)
 
 **Status**: Approved
-**Progress**: 12/20 tasks complete
+**Progress**: 14/20 tasks complete
 **Last Updated**: 2026-06-10
 
 ## Overview
@@ -287,8 +287,8 @@ The `navigation.indexes` feature is already enabled, so `how-to/index.md` and `a
 
 ### Step 5: API Reference orientation
 
-- [ ] `docs/api/index.md` — landing page (who needs the Python API; one line per module). <!-- completed: -->
-- [ ] `docs/api/{broker,config,coding-agent,multiplexer}.md` — one orienting paragraph above each `:::` directive. <!-- completed: -->
+- [x] `docs/api/index.md` — landing page (who needs the Python API; one line per module). <!-- completed: 2026-06-11T09:17 -->
+- [x] `docs/api/{broker,config,coding-agent,multiplexer}.md` — one orienting paragraph above each `:::` directive. <!-- completed: 2026-06-11T09:17 -->
 
 ### Step 6: Landing surfaces
 

--- a/design-docs/0000081-docs-friendliness/design-doc.md
+++ b/design-docs/0000081-docs-friendliness/design-doc.md
@@ -10,16 +10,16 @@ Design doc 0000079 made the docs lean (SSOT map, necessity test, symbol strip); 
 
 ## Success Criteria
 
-- [ ] No doc instructs the reader to store ids in shell variables: `grep -rE "export (FLEET|DIRECTOR)_ID" docs/ README.md` returns nothing, and every walkthrough pastes literal integer ids, consistent with the `spec/cli-options.md` Option Source Matrix rationale.
-- [ ] Every CLI walkthrough in README, quickstart, and the how-to pages shows the command **and** an expected-output block, using the standard sample-id cast (fleet `1`, root Director `2`, Administrator `3`, members `4`+).
-- [ ] A top-level **How-to guides** nav section exists with four task pages (mixed-backend team; monitor + recover members; WebUI; design-doc-driven development) plus a section index. Each page sequences existing facts and links to canonical homes — it introduces no new normative facts.
-- [ ] `docs/get-started/troubleshooting.md` exists under Get Started, maps ≥ 12 symptoms to fixes, opens with `cafleet doctor`, and links to (never duplicates) the Error Messages table in `spec/cli-options.md`.
-- [ ] `spec/cli-options.md` opens with a subcommand summary table (one row per subcommand: name, one-line purpose, needs `--fleet-id`, identity flag, link), and every row's link resolves to a section on the page — including new compact `cafleet agent` / `cafleet message` sections.
-- [ ] `concepts/overview.md` opens with a **Core terms** table defining fleet, root Director, member, placement, Administrator, broker, task/message, inline preview, poll/ack, and coding-agent backend, each with a link to its canonical page. Other pages link to it instead of re-defining terms.
-- [ ] The API Reference section has an `api/index.md` landing page stating who needs the Python API, and each of the four mkdocstrings stubs carries an orienting paragraph.
-- [ ] README.md and `docs/index.md` state who CAFleet is for, and README shows a compelling end-to-end example with expected output near the top.
-- [ ] A **Documentation style** section is published in `docs/get-started/contributing.md` (tone/voice, sample-id cast, example format, SSOT linking rule).
-- [ ] 0000079's SSOT map and necessity test are preserved: no canonical fact is restated in the new pages; `mise //:docs-build` passes with all nav entries and cross-references resolving.
+- [x] No doc instructs the reader to store ids in shell variables: `grep -rE "export (FLEET|DIRECTOR)_ID" docs/ README.md` returns nothing, and every walkthrough pastes literal integer ids, consistent with the `spec/cli-options.md` Option Source Matrix rationale.
+- [x] Every CLI walkthrough in README, quickstart, and the how-to pages shows the command **and** an expected-output block, using the standard sample-id cast (fleet `1`, root Director `2`, Administrator `3`, members `4`+).
+- [x] A top-level **How-to guides** nav section exists with four task pages (mixed-backend team; monitor + recover members; WebUI; design-doc-driven development) plus a section index. Each page sequences existing facts and links to canonical homes — it introduces no new normative facts.
+- [x] `docs/get-started/troubleshooting.md` exists under Get Started, maps ≥ 12 symptoms to fixes, opens with `cafleet doctor`, and links to (never duplicates) the Error Messages table in `spec/cli-options.md`.
+- [x] `spec/cli-options.md` opens with a subcommand summary table (one row per subcommand: name, one-line purpose, needs `--fleet-id`, identity flag, link), and every row's link resolves to a section on the page — including new compact `cafleet agent` / `cafleet message` sections.
+- [x] `concepts/overview.md` opens with a **Core terms** table defining fleet, root Director, member, placement, Administrator, broker, task/message, inline preview, poll/ack, and coding-agent backend, each with a link to its canonical page. Other pages link to it instead of re-defining terms.
+- [x] The API Reference section has an `api/index.md` landing page stating who needs the Python API, and each of the four mkdocstrings stubs carries an orienting paragraph.
+- [x] README.md and `docs/index.md` state who CAFleet is for, and README shows a compelling end-to-end example with expected output near the top.
+- [x] A **Documentation style** section is published in `docs/get-started/contributing.md` (tone/voice, sample-id cast, example format, SSOT linking rule).
+- [x] 0000079's SSOT map and necessity test are preserved: no canonical fact is restated in the new pages; `mise //:docs-build` passes with all nav entries and cross-references resolving.
 
 ---
 

--- a/design-docs/0000081-docs-friendliness/design-doc.md
+++ b/design-docs/0000081-docs-friendliness/design-doc.md
@@ -1,7 +1,7 @@
 # Documentation Friendliness (README.md + docs/ + zensical.toml)
 
 **Status**: Approved
-**Progress**: 10/20 tasks complete
+**Progress**: 12/20 tasks complete
 **Last Updated**: 2026-06-10
 
 ## Overview
@@ -282,8 +282,8 @@ The `navigation.indexes` feature is already enabled, so `how-to/index.md` and `a
 
 ### Step 4: Troubleshooting
 
-- [ ] `docs/get-started/troubleshooting.md` — `cafleet doctor` lead + the ≥ 12-row symptom→fix table + Error Messages pointer. <!-- completed: -->
-- [ ] `docs/get-started/index.md` — add the Troubleshooting bullet. <!-- completed: -->
+- [x] `docs/get-started/troubleshooting.md` — `cafleet doctor` lead + the ≥ 12-row symptom→fix table + Error Messages pointer. <!-- completed: 2026-06-11T09:15 -->
+- [x] `docs/get-started/index.md` — add the Troubleshooting bullet. <!-- completed: 2026-06-11T09:15 -->
 
 ### Step 5: API Reference orientation
 

--- a/docs/api/broker.md
+++ b/docs/api/broker.md
@@ -1,3 +1,8 @@
 # broker
 
+The data-access layer every CLI command and the WebUI share: all agent,
+fleet, and message operations against SQLite live here. Read this page to
+embed the broker from Python or to change any persisted behavior — see the
+[API Reference landing page](index.md) for who needs which module.
+
 ::: cafleet.broker

--- a/docs/api/coding-agent.md
+++ b/docs/api/coding-agent.md
@@ -1,3 +1,8 @@
 # coding_agent
 
+The backend abstraction behind `--coding-agent`: the interface each spawned
+binary (`claude`, `codex`, `opencode`) implements — spawn argv, model
+validation, availability checks. Read this page to add or change a backend —
+see the [API Reference landing page](index.md) for who needs which module.
+
 ::: cafleet.coding_agent.base

--- a/docs/api/config.md
+++ b/docs/api/config.md
@@ -1,3 +1,8 @@
 # config
 
+The settings surface: every `CAFLEET_*` environment variable resolves to a
+field on the `Settings` model defined here. Read this page to see defaults
+and aliases when embedding or contributing — see the
+[API Reference landing page](index.md) for who needs which module.
+
 ::: cafleet.config

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -1,0 +1,15 @@
+# API Reference
+
+The Python API matters to two audiences: **contributors** changing cafleet
+itself, and **embedders** driving the broker from Python instead of the CLI.
+CLI users never need it — every operation on these pages has a CLI
+equivalent in [CLI options](../spec/cli-options.md).
+
+One page per module:
+
+- [broker](broker.md) — all agent, fleet, and message operations.
+- [config](config.md) — settings and their environment variables.
+- [coding_agent](coding-agent.md) — the coding-agent backend abstraction.
+- [multiplexer](multiplexer.md) — the tmux abstraction.
+
+The reference is generated from the source docstrings via mkdocstrings.

--- a/docs/api/multiplexer.md
+++ b/docs/api/multiplexer.md
@@ -1,3 +1,8 @@
 # multiplexer
 
+The tmux abstraction: pane discovery, window splitting, keystroke delivery,
+and capture used by the spawn and push-notification paths. Read this page to
+change how cafleet drives tmux — see the
+[API Reference landing page](index.md) for who needs which module.
+
 ::: cafleet.multiplexer.base

--- a/docs/concepts/overview.md
+++ b/docs/concepts/overview.md
@@ -11,6 +11,21 @@ into **fleets** identified by a non-secret `fleet_id` created via
 `cafleet fleet create`. Agents sharing the same fleet can discover and message
 each other; agents in different fleets are invisible to one another.
 
+## Core terms
+
+| Term | Definition | Links to |
+|---|---|---|
+| fleet | isolated namespace partitioning agents; identified by a non-secret integer `fleet_id` | [Fleet isolation](fleet-isolation.md) |
+| root Director | the agent created by `fleet create`; the only agent that may own members | [Member lifecycle](member-lifecycle.md) |
+| member | an agent spawned by the Director via `member create`, bound to a tmux pane | [Member lifecycle](member-lifecycle.md) |
+| placement | the row linking an agent to its tmux session/window/pane and backend | [Data model](../spec/data-model.md) |
+| Administrator | the built-in write-only agent that the WebUI sends as | [Data model](../spec/data-model.md) |
+| broker | the data-access layer all CLI commands and the WebUI share; writes SQLite directly | Overview (this page) |
+| task / message | one delivered message; lifecycle `input_required → completed/canceled` | [Message envelope](../spec/message-envelope.md) |
+| inline preview | the 2-line message preview the broker keystrokes into the recipient's pane | [tmux push](tmux-push.md) |
+| poll / ack | how a recipient fetches and then confirms consumption of a message | [CLI options](../spec/cli-options.md) |
+| coding-agent backend | the binary in a member pane: `claude`, `codex`, or `opencode` | [Coding agents](coding-agents.md) |
+
 ## Architecture diagram
 
 ```mermaid

--- a/docs/get-started/contributing.md
+++ b/docs/get-started/contributing.md
@@ -66,3 +66,22 @@ codebase. Some tips for new contributors:
 See your coding-agent's skill documentation for the literal invocation syntax.
 Existing design documents under [`design-docs/`](https://github.com/himkt/cafleet/tree/main/design-docs)
 are real examples produced by this loop.
+
+## Documentation style
+
+When editing `docs/` or `README.md`, follow these conventions:
+
+- **Audience split**: `docs/` is written for human developers and operators;
+  `skills/` is written for coding agents. Do not mix the registers.
+- **Voice**: second person ("you"), active voice, present tense. Lead each
+  page with what the reader accomplishes, not with architecture.
+- **Terms**: link a term's first use on a page to the
+  [Core terms](../concepts/overview.md#core-terms) table in the concepts
+  overview; do not re-define it.
+- **Examples**: every CLI example is a runnable command using the standard
+  sample-id cast — fleet `1`, root Director `2`, Administrator `3`, members
+  `4`+ — followed by an expected-output block matching the output shapes in
+  [CLI options](../spec/cli-options.md). Never use shell variables to hold
+  ids.
+- **SSOT**: one fact, one home. When another page needs the fact, link;
+  when a fact serves no install/configure/use/understand purpose, delete.

--- a/docs/get-started/index.md
+++ b/docs/get-started/index.md
@@ -15,5 +15,7 @@ your machine.
   per-coding-agent settings.
 - [Quickstart](quickstart.md) — one-screen walkthrough that creates a fleet,
   spawns two members, and sends a message between them.
+- [Troubleshooting](troubleshooting.md) — `cafleet doctor` plus a
+  symptom→fix table for the most common errors.
 - [Contributing](contributing.md) — project layout, local development loop, and
   the design-doc-driven contribution flow.

--- a/docs/get-started/quickstart.md
+++ b/docs/get-started/quickstart.md
@@ -44,29 +44,66 @@ If you would rather drive CAFleet from the shell directly, the commands below
 mirror what the skill does internally. Run them inside a tmux session — the
 `fleet create` and `member create` commands require one.
 
+The walkthrough pastes literal integer ids: fleet `1`, root Director `2`,
+member `4`, task `10`. Your ids will differ — substitute the integers your
+own commands print.
+
+Create a fleet. This records your current pane as the root Director's pane:
+
 ```bash
-# 1. Create a fleet. Records this pane as the root Director's pane.
-cafleet fleet create --label "demo" --full
+cafleet fleet create --label "demo"
+```
 
-# The output prints the fleet id and the root Director's agent id on the
-# first two lines. Export them as shell vars for the snippets below.
-export FLEET_ID="<paste from the first output line>"
-export DIRECTOR_ID="<paste from the second output line>"
+```
+1 director=2 admin=3
+```
 
-# 2. Spawn a member pane. The member's prompt is just a one-line greeting.
-#    Optional: add --model <m> (e.g. --model sonnet) to pin the member's LLM;
-#    omitted, the backend binary uses its own default model.
-cafleet --fleet-id "$FLEET_ID" member create \
-  --agent-id "$DIRECTOR_ID" \
+The line carries the fleet id (`1`), the root Director's agent id (`2`), and
+the built-in Administrator's agent id (`3`). If it scrolls away, run
+`cafleet fleet list` — it re-prints the fleet id and the Director id (the
+`DIRECTOR` column).
+
+Spawn a member pane. The member's prompt is just a one-line greeting.
+Optional: add `--model <m>` (e.g. `--model sonnet`) to pin the member's LLM;
+omitted, the backend binary uses its own default model:
+
+```bash
+cafleet --fleet-id 1 member create \
+  --agent-id 2 \
   --name "demo-member" \
   --description "Demo member" \
   -- "You are demo-member. Reply hello when polled."
+```
 
-# 3. The Director sends a message to the new member.
-cafleet --fleet-id "$FLEET_ID" agent list
-# Pick the demo-member agent_id from the output and replace <member-id> below.
-cafleet --fleet-id "$FLEET_ID" message send --agent-id "$DIRECTOR_ID" \
-  --to "<member-id>" --text "hi"
+```
+4 demo-member backend=claude pane=%7
+```
+
+List the fleet's agents — the new member's id (`4`) appears alongside the
+Director and the Administrator:
+
+```bash
+cafleet --fleet-id 1 agent list
+```
+
+```
+2 Director active
+
+3 Administrator active
+
+4 demo-member active
+```
+
+The Director sends a message to the new member:
+
+```bash
+cafleet --fleet-id 1 message send --agent-id 2 --to 4 --text "hi"
+```
+
+```
+Message sent.
+[10 | from:2 | 2026-06-11T09:00:00.123456+00:00]
+hi
 ```
 
 The member receives the message as a 2-line inline preview pushed into its
@@ -77,10 +114,17 @@ once it has consumed the message.
 When you are done, tear the fleet down:
 
 ```bash
-cafleet --fleet-id "$FLEET_ID" member delete \
-  --member-id "<member-id>"
-cafleet fleet delete "$FLEET_ID"
+cafleet --fleet-id 1 member delete --member-id 4
+cafleet fleet delete 1
 ```
 
-See the [CLI options](../spec/cli-options.md) reference for every subcommand
-and flag.
+```
+Deleted fleet 1. Deregistered 2 agents.
+```
+
+Where to go next:
+
+- [CLI options](../spec/cli-options.md) — every subcommand and flag.
+- [How-to guides](../how-to/index.md) — task-oriented walkthroughs.
+- [Troubleshooting](troubleshooting.md) — symptom→fix table when something
+  does not behave.

--- a/docs/get-started/quickstart.md
+++ b/docs/get-started/quickstart.md
@@ -45,8 +45,8 @@ mirror what the skill does internally. Run them inside a tmux session — the
 `fleet create` and `member create` commands require one.
 
 The walkthrough pastes literal integer ids: fleet `1`, root Director `2`,
-member `4`, task `10`. Your ids will differ — substitute the integers your
-own commands print.
+members `4` and `5`, task `10`. Your ids will differ — substitute the
+integers your own commands print.
 
 Create a fleet. This records your current pane as the root Director's pane:
 
@@ -63,8 +63,8 @@ the built-in Administrator's agent id (`3`). If it scrolls away, run
 `cafleet fleet list` — it re-prints the fleet id and the Director id (the
 `DIRECTOR` column).
 
-Spawn a member pane. The member's prompt is just a one-line greeting.
-Optional: add `--model <m>` (e.g. `--model sonnet`) to pin the member's LLM;
+Spawn two member panes. Each member's prompt is just a one-line greeting.
+Optional: add `--model <m>` (e.g. `--model sonnet`) to pin a member's LLM;
 omitted, the backend binary uses its own default model:
 
 ```bash
@@ -79,8 +79,20 @@ cafleet --fleet-id 1 member create \
 4 demo-member backend=claude pane=%7
 ```
 
-List the fleet's agents — the new member's id (`4`) appears alongside the
-Director and the Administrator:
+```bash
+cafleet --fleet-id 1 member create \
+  --agent-id 2 \
+  --name "reviewer" \
+  --description "Reviewer member" \
+  -- "You are reviewer. Reply hello when polled."
+```
+
+```
+5 reviewer backend=claude pane=%8
+```
+
+List the fleet's agents — the new members' ids (`4` and `5`) appear
+alongside the Director and the Administrator:
 
 ```bash
 cafleet --fleet-id 1 agent list
@@ -92,21 +104,24 @@ cafleet --fleet-id 1 agent list
 3 Administrator active
 
 4 demo-member active
+
+5 reviewer active
 ```
 
-The Director sends a message to the new member:
+Send a message between the members — `demo-member` (`4`) messages
+`reviewer` (`5`):
 
 ```bash
-cafleet --fleet-id 1 message send --agent-id 2 --to 4 --text "hi"
+cafleet --fleet-id 1 message send --agent-id 4 --to 5 --text "hi"
 ```
 
 ```
 Message sent.
-[10 | from:2 | 2026-06-11T09:00:00.123456+00:00]
+[10 | from:4 | 2026-06-11T09:00:00.123456+00:00]
 hi
 ```
 
-The member receives the message as a 2-line inline preview pushed into its
+`reviewer` receives the message as a 2-line inline preview pushed into its
 tmux pane and the message lands in the broker queue. From here, the typical
 flow is `cafleet message poll` from the recipient and `cafleet message ack`
 once it has consumed the message.
@@ -115,6 +130,7 @@ When you are done, tear the fleet down:
 
 ```bash
 cafleet --fleet-id 1 member delete --member-id 4
+cafleet --fleet-id 1 member delete --member-id 5
 cafleet fleet delete 1
 ```
 

--- a/docs/get-started/troubleshooting.md
+++ b/docs/get-started/troubleshooting.md
@@ -1,0 +1,44 @@
+---
+icon: lucide/wrench
+---
+
+# Troubleshooting
+
+Start with `cafleet doctor`. It prints the calling pane's tmux identifiers
+and is the first thing to run on any placement or tmux confusion — a fleet
+that will not create, a member command that claims you are outside tmux, a
+pane that cannot be found. It requires the `TMUX` and `TMUX_PANE`
+environment variables to be set (the standard tmux pane environment):
+
+```bash
+cafleet doctor
+```
+
+```
+tmux:
+  session_name:  main
+  window_id:     @1
+  pane_id:       %0
+  TMUX_PANE:     %0
+```
+
+## Symptom → fix
+
+| Symptom | Fix |
+|---|---|
+| `Error: cafleet fleet create must be run inside a tmux session` | Run the command inside tmux; verify the pane environment with `cafleet doctor`. |
+| `Error: cafleet member commands must be run inside a tmux session` | Same as above — `member` commands (and `doctor` itself) need the tmux pane environment. |
+| `OperationalError: no such table: agents` | The schema was never applied: run `cafleet db init` → [Install](install.md). |
+| `cafleet db init` refuses with `DB schema is at revision <X> which is unknown to this version of cafleet.` | Old (UUID-era) database; delete the file and re-run `cafleet db init` → the upgrade warning on [Install](install.md). |
+| `Error: --fleet-id <int> is required for this subcommand.` | Create a fleet with `cafleet fleet create` and pass the printed literal id → [CLI options](../spec/cli-options.md). |
+| `Error: agent <id> is not a member of fleet <id>.` | Wrong `--fleet-id`/`--agent-id` pairing; recover the ids with `cafleet fleet list` (the `DIRECTOR` column carries the Director's id). |
+| Permission prompts keep interrupting an agent | Shell variables break `permissions.allow` pattern matching — paste literal integer ids instead → [Configure](configure.md). |
+| `Error: binary <name> not found on PATH` | Install the backend binary you asked `member create` to spawn → [Coding agents](../concepts/coding-agents.md). |
+| A member never reacts to messages | It missed the inline preview; check `member list --activity`, then `member ping` → [Monitor and recover members](../how-to/monitor-and-recover.md). |
+| `Error: pane %N did not close within 15.0s after /exit.` | Follow the recovery hint the command printed (capture → send-input → re-run delete); `member delete --force` as the last resort. |
+| WebUI `/` returns 404 | The UI is not built (source checkout): run `mise //admin:build` → [Use the admin WebUI](../how-to/use-the-webui.md). |
+| `OSError: [Errno 98] Address already in use` on `cafleet server` | Another process owns the port; pass `--port` → [CLI options](../spec/cli-options.md#cafleet-server). |
+
+Symptom not listed? Check the full
+[Error Messages](../spec/cli-options.md#error-messages) table for every
+exact error string and exit code.

--- a/docs/get-started/troubleshooting.md
+++ b/docs/get-started/troubleshooting.md
@@ -29,8 +29,8 @@ tmux:
 | `Error: cafleet fleet create must be run inside a tmux session` | Run the command inside tmux; verify the pane environment with `cafleet doctor`. |
 | `Error: cafleet member commands must be run inside a tmux session` | Same as above — `member` commands (and `doctor` itself) need the tmux pane environment. |
 | `OperationalError: no such table: agents` | The schema was never applied: run `cafleet db init` → [Install](install.md). |
-| `cafleet db init` refuses with `DB schema is at revision <X> which is unknown to this version of cafleet.` | Old (UUID-era) database; delete the file and re-run `cafleet db init` → the upgrade warning on [Install](install.md). |
-| `Error: --fleet-id <int> is required for this subcommand.` | Create a fleet with `cafleet fleet create` and pass the printed literal id → [CLI options](../spec/cli-options.md). |
+| `Error: DB schema is at revision <X> which is unknown to this version of cafleet. Refusing to downgrade automatically.` (from `cafleet db init`) | Old (UUID-era) database; delete the file and re-run `cafleet db init` → the upgrade warning on [Install](install.md). |
+| `Error: --fleet-id <int> is required for this subcommand. Create a fleet with 'cafleet fleet create' and pass its id.` | Do what it says — pass the literal fleet id the create printed → [CLI options](../spec/cli-options.md). |
 | `Error: agent <id> is not a member of fleet <id>.` | Wrong `--fleet-id`/`--agent-id` pairing; recover the ids with `cafleet fleet list` (the `DIRECTOR` column carries the Director's id). |
 | Permission prompts keep interrupting an agent | Shell variables break `permissions.allow` pattern matching — paste literal integer ids instead → [Configure](configure.md). |
 | `Error: binary <name> not found on PATH` | Install the backend binary you asked `member create` to spawn → [Coding agents](../concepts/coding-agents.md). |

--- a/docs/how-to/design-doc-development.md
+++ b/docs/how-to/design-doc-development.md
@@ -1,0 +1,37 @@
+---
+icon: lucide/file-text
+---
+
+# Design-doc-driven development
+
+CAFleet ships three skills that run spec-driven development as
+CAFleet-orchestrated teams. Invoke them in order from your coding agent:
+
+1. The `cafleet-design-doc-create` skill — a Director / Drafter / Reviewer
+   team drafts the design document.
+2. The `cafleet-design-doc-interview` skill — a fine-grained Q&A pass that
+   annotates the document with your answers.
+3. The `cafleet-design-doc-execute` skill — a Director / Programmer / Tester
+   team implements the document.
+
+The contributor-facing description of this loop, including what to pass to
+each skill, lives in [Contributing](../get-started/contributing.md).
+
+## Where output lands
+
+Each run produces `design-docs/NNNNNNN-<slug>/design-doc.md` in your
+repository. The CAFleet repo's own
+[`design-docs/`](https://github.com/himkt/cafleet/tree/main/design-docs)
+folder holds real examples produced by this loop.
+
+## Watch the team work
+
+Every inter-agent message is persisted in SQLite, so you can follow the
+team's coordination live: open the WebUI timeline for the team's fleet —
+see [Use the admin WebUI](use-the-webui.md).
+
+## Invocation syntax
+
+See your coding-agent's skill documentation for the literal invocation
+syntax (Claude Code's `/skills`, codex's `/skills`, opencode's skill
+discovery).

--- a/docs/how-to/index.md
+++ b/docs/how-to/index.md
@@ -1,0 +1,14 @@
+---
+icon: lucide/map
+---
+
+# How-to guides
+
+This section answers "how do I …" questions with copy-paste walkthroughs.
+Each guide sequences commands into one task and links to the
+[spec pages](../spec/cli-options.md) for the full flag surface.
+
+- [Run a mixed-backend team](mixed-backend-team.md)
+- [Monitor and recover members](monitor-and-recover.md)
+- [Use the admin WebUI](use-the-webui.md)
+- [Design-doc-driven development](design-doc-development.md)

--- a/docs/how-to/mixed-backend-team.md
+++ b/docs/how-to/mixed-backend-team.md
@@ -45,7 +45,7 @@ cafleet --fleet-id 1 member create --agent-id 2 \
 ```
 
 ```
-4 alice backend=claude pane=%4
+4 alice backend=claude pane=%7
 ```
 
 ```bash
@@ -55,7 +55,7 @@ cafleet --fleet-id 1 member create --agent-id 2 \
 ```
 
 ```
-5 bob backend=codex pane=%5
+5 bob backend=codex pane=%8
 ```
 
 ```bash
@@ -65,7 +65,7 @@ cafleet --fleet-id 1 member create --agent-id 2 \
 ```
 
 ```
-6 carol backend=opencode pane=%6
+6 carol backend=opencode pane=%9
 ```
 
 ## Find the panes
@@ -78,9 +78,9 @@ cafleet --fleet-id 1 member list
 3 members:
   agent_id        name      status  backend  session  window_id  pane_id  created_at
   --------------  --------  ------  -------  -------  ---------  -------  --------------------
-  4               alice     active  claude   main     @1         %4       2026-06-11T09:01:00.000000+00:00
-  5               bob       active  codex    main     @1         %5       2026-06-11T09:02:00.000000+00:00
-  6               carol     active  opencode  main     @1         %6       2026-06-11T09:03:00.000000+00:00
+  4               alice     active  claude   main     @1         %7       2026-06-11T09:01:00.000000+00:00
+  5               bob       active  codex    main     @1         %8       2026-06-11T09:02:00.000000+00:00
+  6               carol     active  opencode  main     @1         %9       2026-06-11T09:03:00.000000+00:00
 ```
 
 Only the `claude` pane shows the member name in its pane title — see
@@ -112,7 +112,7 @@ cafleet --fleet-id 1 member delete --member-id 4
 ```
 Member deleted.
   agent_id:  4
-  pane_id:   %4 (closed)
+  pane_id:   %7 (closed)
 ```
 
 Repeat for members `5` and `6`, then delete the fleet:

--- a/docs/how-to/mixed-backend-team.md
+++ b/docs/how-to/mixed-backend-team.md
@@ -1,0 +1,129 @@
+---
+icon: lucide/users
+---
+
+# Run a mixed-backend team
+
+A single Director can spawn `claude`, `codex`, and `opencode` members in the
+same fleet — there are no broker-level differences between the backends
+([Coding agents](../concepts/coding-agents.md)). This guide creates a fleet
+with one member per backend and messages each of them.
+
+The walkthrough pastes literal ids: fleet `1`, root Director `2`, members
+`4`/`5`/`6`. Your ids will differ — substitute the integers your own
+commands print.
+
+## Prerequisites
+
+- The backend binaries you want to mix (`claude`, `codex`, `opencode`) are on
+  `PATH` — `member create` exits 1 with `Error: binary <name> not found on
+  PATH` otherwise.
+- You have followed [Install](../get-started/install.md) and
+  [Configure](../get-started/configure.md), and you are inside a tmux
+  session.
+
+## Create the fleet
+
+```bash
+cafleet fleet create --label "demo" --coding-agent claude
+```
+
+```
+1 director=2 admin=3
+```
+
+`--coding-agent` here declares which binary is running in *your* pane — the
+operator declares it because cafleet cannot auto-detect it
+([Coding agents](../concepts/coding-agents.md)).
+
+## Spawn one member per backend
+
+```bash
+cafleet --fleet-id 1 member create --agent-id 2 \
+  --name "alice" --description "claude member" \
+  --coding-agent claude -- "You are alice. Wait for instructions."
+```
+
+```
+4 alice backend=claude pane=%4
+```
+
+```bash
+cafleet --fleet-id 1 member create --agent-id 2 \
+  --name "bob" --description "codex member" \
+  --coding-agent codex -- "You are bob. Wait for instructions."
+```
+
+```
+5 bob backend=codex pane=%5
+```
+
+```bash
+cafleet --fleet-id 1 member create --agent-id 2 \
+  --name "carol" --description "opencode member" \
+  --coding-agent opencode -- "You are carol. Wait for instructions."
+```
+
+```
+6 carol backend=opencode pane=%6
+```
+
+## Find the panes
+
+```bash
+cafleet --fleet-id 1 member list
+```
+
+```
+3 members:
+  agent_id        name      status  backend  session  window_id  pane_id  created_at
+  --------------  --------  ------  -------  -------  ---------  -------  --------------------
+  4               alice     active  claude   main     @1         %4       2026-06-11T09:01:00.000000+00:00
+  5               bob       active  codex    main     @1         %5       2026-06-11T09:02:00.000000+00:00
+  6               carol     active  opencode  main     @1         %6       2026-06-11T09:03:00.000000+00:00
+```
+
+Only the `claude` pane shows the member name in its pane title — see
+[Known asymmetries](../concepts/coding-agents.md#known-asymmetries-intentional-non-goals)
+— so use the `pane_id` column to locate `bob` and `carol`.
+
+## Message round-trip across backends
+
+```bash
+cafleet --fleet-id 1 message send --agent-id 2 --to 4 --text "alice: report status"
+```
+
+```
+Message sent.
+[10 | from:2 | 2026-06-11T09:05:00.123456+00:00]
+alice: report status
+```
+
+Repeat with `--to 5` and `--to 6` — the envelope is identical for every
+backend, and each member receives the same 2-line inline preview in its pane
+([tmux push](../concepts/tmux-push.md)).
+
+## Tear down
+
+```bash
+cafleet --fleet-id 1 member delete --member-id 4
+```
+
+```
+Member deleted.
+  agent_id:  4
+  pane_id:   %4 (closed)
+```
+
+Repeat for members `5` and `6`, then delete the fleet:
+
+```bash
+cafleet fleet delete 1
+```
+
+```
+Deleted fleet 1. Deregistered 2 agents.
+```
+
+Every `member create` / `member delete` flag and exit code is documented in
+[CLI options](../spec/cli-options.md#member-commands).

--- a/docs/how-to/monitor-and-recover.md
+++ b/docs/how-to/monitor-and-recover.md
@@ -60,7 +60,7 @@ cafleet --fleet-id 1 member ping --member-id 4
 ```
 
 ```
-Pinged member alice (%4) — poll keystroke dispatched.
+Pinged member alice (%7) — poll keystroke dispatched.
 ```
 
 Injects a `cafleet message poll` keystroke into the pane so the member
@@ -73,7 +73,7 @@ cafleet --fleet-id 1 member send-input --member-id 4 --choice 1
 ```
 
 ```
-Sent choice 1 to member alice (%4).
+Sent choice 1 to member alice (%7).
 ```
 
 `--choice 1..3` answers an AskUserQuestion option; `--freetext "<text>"`
@@ -86,7 +86,7 @@ cafleet --fleet-id 1 member exec --member-id 4 "git status"
 ```
 
 ```
-Sent bash command 'git status' to member alice (%4).
+Sent bash command 'git status' to member alice (%7).
 ```
 
 Keystrokes `! git status` into the pane so the coding agent runs it natively
@@ -102,7 +102,7 @@ cafleet --fleet-id 1 member delete --member-id 4
 ```
 Member deleted.
   agent_id:  4
-  pane_id:   %4 (closed)
+  pane_id:   %7 (closed)
 ```
 
 The default path sends `/exit` and waits up to 15 s for the pane to close.
@@ -110,8 +110,8 @@ A pane that refuses to close makes the command exit 2 with the pane tail and
 a built-in recovery hint:
 
 ```
-Error: pane %4 did not close within 15.0s after /exit.
---- pane %4 tail (last 80 lines) ---
+Error: pane %7 did not close within 15.0s after /exit.
+--- pane %7 tail (last 80 lines) ---
 <captured terminal buffer>
 ---
 Recovery: inspect with `cafleet member capture`, answer any prompt with `cafleet member send-input`, then re-run `cafleet member delete`. Or re-run with `--force` to skip the wait and kill the pane.

--- a/docs/how-to/monitor-and-recover.md
+++ b/docs/how-to/monitor-and-recover.md
@@ -1,0 +1,124 @@
+---
+icon: lucide/activity
+---
+
+# Monitor and recover members
+
+Members run unattended in tmux panes, so the Director needs two primitives: a
+cheap roster watch and an escalation ladder for a member that stopped
+reacting. All commands run from the Director's pane. The walkthrough pastes
+literal ids: fleet `1`, members `4`/`5`/`6` — your ids will differ.
+
+## Watch the team
+
+```bash
+cafleet --fleet-id 1 member list --activity
+```
+
+```
+3 members:
+  agent_id        name      status  last_sent  last_recv  last_ack   idle
+  --------------  --------  ------  ---------  ---------  ---------  -----
+  4               alice     active  -          12:20:00   12:20:00   14m
+  5               bob       active  12:30:11   12:33:02   12:33:02   2m
+  6               carol     active  12:34:56   12:34:50   12:34:50   6s
+```
+
+`last_sent` is the member's most recent outgoing message, `last_recv` its
+most recent delivery, `last_ack` the most recent delivery it acknowledged,
+and `idle` the wall-time since the latest of `last_sent` / `last_recv`.
+A member that receives work but never sends or acks is stalled — `alice`
+(`4`) above has been quiet for 14 minutes. The exact aggregation rules live
+in [CLI options](../spec/cli-options.md#member-list-activity-output).
+
+## Inspect a quiet member
+
+```bash
+cafleet --fleet-id 1 member capture --member-id 4
+```
+
+Prints the last 30 lines of the member's pane buffer with ANSI escapes
+stripped; pass `--lines N` for a longer tail. A stalled member typically
+shows a pending prompt, for example:
+
+```
+ Do you want to proceed?
+ ❯ 1. Yes
+   2. No
+```
+
+## The recovery ladder
+
+Work from the mildest intervention up. The reason panes need re-poking at
+all — inline previews are best-effort keystrokes — is explained in
+[tmux push](../concepts/tmux-push.md).
+
+### 1. `member ping` — re-poke a missed preview
+
+```bash
+cafleet --fleet-id 1 member ping --member-id 4
+```
+
+```
+Pinged member alice (%4) — poll keystroke dispatched.
+```
+
+Injects a `cafleet message poll` keystroke into the pane so the member
+drains anything it missed.
+
+### 2. `member send-input` — answer a pending prompt
+
+```bash
+cafleet --fleet-id 1 member send-input --member-id 4 --choice 1
+```
+
+```
+Sent choice 1 to member alice (%4).
+```
+
+`--choice 1..3` answers an AskUserQuestion option; `--freetext "<text>"`
+fills the "Type something" field.
+
+### 3. `member exec` — dispatch a shell command
+
+```bash
+cafleet --fleet-id 1 member exec --member-id 4 "git status"
+```
+
+```
+Sent bash command 'git status' to member alice (%4).
+```
+
+Keystrokes `! git status` into the pane so the coding agent runs it natively
+— the dispatch half of the bash-via-Director protocol
+([Bash routing](../concepts/bash-routing.md)).
+
+### 4. `member delete` — last resort
+
+```bash
+cafleet --fleet-id 1 member delete --member-id 4
+```
+
+```
+Member deleted.
+  agent_id:  4
+  pane_id:   %4 (closed)
+```
+
+The default path sends `/exit` and waits up to 15 s for the pane to close.
+A pane that refuses to close makes the command exit 2 with the pane tail and
+a built-in recovery hint:
+
+```
+Error: pane %4 did not close within 15.0s after /exit.
+--- pane %4 tail (last 80 lines) ---
+<captured terminal buffer>
+---
+Recovery: inspect with `cafleet member capture`, answer any prompt with `cafleet member send-input`, then re-run `cafleet member delete`. Or re-run with `--force` to skip the wait and kill the pane.
+```
+
+`cafleet member delete --member-id 4 --force` skips the wait, kills the
+pane, and exits 0 even if the pane was already gone.
+
+Every flag, validation rule, and exit code for the member subcommands is
+documented in [CLI options](../spec/cli-options.md#member-commands).

--- a/docs/how-to/use-the-webui.md
+++ b/docs/how-to/use-the-webui.md
@@ -38,7 +38,8 @@ broadcast messages, and a bottom input.
 
 The bottom input parses `@<agent> text` for unicast and `@all text` for
 broadcast. Every send goes out as the fleet's built-in Administrator agent —
-the admin is not itself a CAFleet agent.
+a write-only registry identity with no tmux pane — so you never register
+yourself as an agent to use the dashboard.
 
 ## Inspect history
 

--- a/docs/how-to/use-the-webui.md
+++ b/docs/how-to/use-the-webui.md
@@ -1,0 +1,52 @@
+---
+icon: lucide/monitor
+---
+
+# Use the admin WebUI
+
+The admin WebUI is a browser dashboard for watching and joining a fleet's
+message traffic ([Overview](../concepts/overview.md)). It is the only
+surface that needs a running server — CLI commands write to SQLite directly
+and never require one — and it is read/write for messages only.
+
+## Start the server
+
+```bash
+cafleet server
+```
+
+```
+INFO:     Started server process [12345]
+INFO:     Uvicorn running on http://127.0.0.1:8000 (Press CTRL+C to quit)
+```
+
+Open `http://127.0.0.1:8000`. Host/port overrides (`--host` / `--port` and
+the matching env vars) are documented in
+[CLI options](../spec/cli-options.md#cafleet-server).
+
+Running from a source checkout instead of an installed wheel? `/` returns
+404 until you build the UI with `mise //admin:build` — installed wheels
+bundle the built UI.
+
+## Pick a fleet
+
+The first load lands on a fleet picker. Selecting a fleet opens the unified
+timeline: a sidebar of the fleet's agents, a center timeline of unicast and
+broadcast messages, and a bottom input.
+
+## Send as the Administrator
+
+The bottom input parses `@<agent> text` for unicast and `@all text` for
+broadcast. Every send goes out as the fleet's built-in Administrator agent —
+the admin is not itself a CAFleet agent.
+
+## Inspect history
+
+Clicking an agent in the sidebar opens its detail panel with Inbox / Sent
+tabs. This works for deregistered agents too — the WebUI is the only surface
+that shows them ([Storage](../concepts/storage.md#no-physical-cleanup)).
+
+## API contracts
+
+The `/api/*` request/response shapes behind the dashboard are documented in
+[WebUI API](../spec/webui-api.md).

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,13 +15,18 @@ for agent operations.
 
 CAFleet works with three coding-agent backends — `claude` (Claude Code), `codex`
 (OpenAI Codex CLI), and `opencode` — and members from different backends can
-coexist in the same fleet.
+coexist in the same fleet. It is built for developers running multi-agent
+coding teams in tmux who want every inter-agent message persisted and
+auditable, and for operators who want a single-file SQLite broker with no
+server to run.
 
 [Get started :material-arrow-right:](get-started/){ .md-button .md-button--primary }
 
 ## Browse the docs
 
 - [Get Started](get-started/) — install, configure, and quickstart walkthroughs.
+- [How-to guides](how-to/) — task-oriented walkthroughs: mixed-backend teams, monitoring and recovery, the admin WebUI, design-doc-driven development.
+- [Troubleshooting](get-started/troubleshooting.md) — `cafleet doctor` plus a symptom→fix table for the most common errors.
 - [Concepts](concepts/overview.md) — architecture overview, fleet isolation, storage, member lifecycle, coding agents, bash routing, tmux push notifications, token reduction.
 - [Specification](spec/data-model.md) — data model, message envelope, CLI options, WebUI API, plus per-backend operational pages.
-- [API Reference](api/broker.md) — Python API documentation generated from source for `cafleet.broker`, `cafleet.config`, `cafleet.coding_agent.base`, and `cafleet.multiplexer.base`.
+- [API Reference](api/) — Python API documentation generated from source for `cafleet.broker`, `cafleet.config`, `cafleet.coding_agent.base`, and `cafleet.multiplexer.base`.

--- a/docs/spec/cli-options.md
+++ b/docs/spec/cli-options.md
@@ -2,6 +2,37 @@
 
 How the unified CAFleet CLI (`cafleet`) accepts configuration parameters.
 
+## Subcommand summary
+
+One row per subcommand. "Identity flag" is the per-subcommand option naming the acting agent (`--agent-id`) or the target member (`--member-id`); the Agent ID section below documents the split.
+
+| Subcommand | Purpose | `--fleet-id` | Identity flag | Section |
+|---|---|---|---|---|
+| `db init` | Create or migrate the SQLite schema to head | no | none | [db init](#db-init) |
+| `fleet create` | Create a fleet with its root Director and Administrator | no | none | [fleet create](#fleet-create) |
+| `fleet list` | List non-deleted fleets | no | none | [fleet list](#fleet-list) |
+| `fleet show` | Show one fleet (soft-deleted included) | no | none | [fleet show](#fleet-show) |
+| `fleet delete` | Soft-delete a fleet and deregister its agents | no | none | [fleet delete](#fleet-delete) |
+| `doctor` | Print the calling pane's tmux identifiers | no | none | [doctor](#cafleet-doctor) |
+| `server` | Start the admin WebUI server | no | none | [server](#cafleet-server) |
+| `agent register` | Register a new agent | yes | none | [agent register](#agent-register) |
+| `agent deregister` | Deregister an agent | yes | `--agent-id` | [agent deregister](#agent-deregister) |
+| `agent list` | List the fleet's agents | yes | none | [agent list](#agent-list) |
+| `agent show` | Show one agent's detail | yes | `--agent-id` | [agent show](#agent-show) |
+| `message send` | Send a unicast message | yes | `--agent-id` | [message send](#message-send) |
+| `message broadcast` | Broadcast a message to all fleet agents | yes | `--agent-id` | [message broadcast](#message-broadcast) |
+| `message poll` | Fetch un-acked incoming messages | yes | `--agent-id` | [message poll](#message-poll) |
+| `message ack` | Acknowledge a received message | yes | `--agent-id` | [message ack](#message-ack) |
+| `message cancel` | Retract an un-acked sent message | yes | `--agent-id` | [message cancel](#message-cancel) |
+| `message show` | Show one task | yes | `--agent-id` | [message show](#message-show) |
+| `member create` | Register a member and spawn its coding-agent pane | yes | `--agent-id` | [member create](#member-create) |
+| `member delete` | Close a member's pane and deregister it | yes | `--member-id` | [member delete](#member-delete) |
+| `member list` | List the fleet's members | yes | none | [member list](#member-list) |
+| `member capture` | Capture the tail of a member's pane | yes | `--member-id` | [member capture](#member-capture) |
+| `member send-input` | Forward a restricted keystroke to a member's pane | yes | `--member-id` | [member send-input](#member-send-input) |
+| `member exec` | Dispatch a shell command into a member's pane | yes | `--member-id` | [member exec](#member-exec) |
+| `member ping` | Inject an inbox-poll keystroke into a member's pane | yes | `--member-id` | [member ping](#member-ping) |
+
 ## Option Source Matrix
 
 Each parameter has exactly one input source:
@@ -120,6 +151,16 @@ cafleet --fleet-id <fleet-id> message poll --agent-id <my-agent-id> --full   # f
 
 This applies to CLI emit sites only. FastAPI `/api/*` responses (see [webui-api.md](./webui-api.md)) are unchanged — the WebUI is human-facing and renders full bodies. `agent.description`, `skills[].description`, `agent_card_json` sub-fields, and `member capture` content are also untouched in this release.
 
+## `cafleet db` — Schema Management
+
+### `db init`
+
+No flags. Creates the database file if missing and applies Alembic migrations
+to the head revision; idempotent, so re-run it after every package upgrade.
+Prints which action was taken (created, upgraded, or already at head).
+Install-time usage and the upgrade warning for pre-integer-PK databases are
+canonical on the [Install](../get-started/install.md) page.
+
 ## `cafleet fleet` — Fleet Management
 
 The `cafleet fleet` subgroup manages fleets. These commands write directly to SQLite — the broker server does not need to be running.
@@ -131,12 +172,19 @@ The `cafleet fleet` subgroup manages fleets. These commands write directly to SQ
 | `--label` | no | Free-form text label for the fleet |
 | `--coding-agent` | no | One of `claude` (default), `codex`, or `opencode`. Operator-declared metadata only — `fleet create` does not spawn the root Director's coding-agent process and cannot auto-detect the binary running in the calling pane. The value is recorded as the root Director's placement `coding_agent`. Help text: `Coding-agent binary to spawn / declare for the placement.` (Click appends `[default: claude]` automatically.) |
 | `--json` | no | Output as JSON |
+| `--full` | no | Hidden flag (accepted but not shown in `--help`): switches the non-JSON output from the compact one-line form to the 7-line block below. |
 
 There are no `--name` / `--description` flags. The root Director's name and description are hardcoded (`name="Director"`, `description="Root Director for this fleet"`).
 
 Creates a new fleet with a DB-assigned integer identifier. **Must be run inside a tmux session** — outside tmux the command exits 1 with `Error: cafleet fleet create must be run inside a tmux session` and writes nothing to the DB. It creates the fleet, its root Director (and placement), and the built-in Administrator atomically (all-or-nothing) — see [data-model.md](./data-model.md) for the Administrator's distinguishing `agent_card_json.cafleet.kind` flag.
 
-**Non-JSON output** — line 1 is `fleet_id` (preserves backward-compatible scripts that parse only the first line), line 2 is the root Director's `agent_id`:
+**Non-JSON output (default)** — one compact line carrying the new `fleet_id`, the root Director's `agent_id`, and the built-in Administrator's `agent_id`:
+
+```
+<fleet_id> director=<director_agent_id> admin=<administrator_agent_id>
+```
+
+**Non-JSON output (hidden `--full` flag)** — line 1 is `fleet_id` (preserves backward-compatible scripts that parse only the first line), line 2 is the root Director's `agent_id`:
 
 ```
 <fleet_id>
@@ -229,7 +277,7 @@ There is no `--force` flag. Calling `fleet delete` on an unknown `fleet_id` exit
 
 Member tmux panes spawned by `cafleet member create` are **not** automatically closed by `fleet delete`. For a clean teardown, call `cafleet member delete` per member first (which sends `/exit` to the pane). If a member pane refuses to close (e.g. blocked on a confirmation prompt), rerun `cafleet member delete` with `--force`, which kill-panes the target, sweeps the placement, and rebalances the layout.
 
-## `cafleet doctor` — Placement Diagnostics
+## `cafleet doctor` — Placement Diagnostics {#cafleet-doctor}
 
 Prints the calling pane's tmux session/window/pane identifiers (plus `$TMUX_PANE`) for operators diagnosing placement issues without reaching for raw tmux commands. Intended as the home for future health checks (DB connectivity, orphan-placement scans, etc.); today it covers tmux metadata only.
 
@@ -273,7 +321,7 @@ Exit codes:
 | `0` | Success — all four fields printed. |
 | `1` | Any tmux or environment failure: `TMUX` env var unset, `tmux` binary not on PATH, `TMUX_PANE` env var unset, or a tmux subprocess (e.g. `display-message`) failure. |
 
-## `cafleet server` — Admin WebUI Server
+## `cafleet server` — Admin WebUI Server {#cafleet-server}
 
 Starts the admin WebUI FastAPI app (the same app served by `mise //cafleet:dev`) via uvicorn. CLI commands do not require this server to be running — it is only needed when a user wants to view the WebUI at `/` or hit the `/api/*` endpoints from a browser.
 
@@ -320,6 +368,147 @@ CAFLEET_BROKER_HOST=0.0.0.0 CAFLEET_BROKER_PORT=9000 cafleet server
 cafleet --fleet-id 1 server
 ```
 
+## `cafleet agent` — Agent Registry
+
+All four subcommands require the global `--fleet-id`. The default-vs-`--full`
+output projection shared by `agent list` and `agent show` is documented in
+[`--full` semantics](#full-semantics) and is not restated per subcommand.
+
+### `agent register`
+
+| Flag | Required | Notes |
+|---|---|---|
+| `--name` | yes | Short human-identifiable label. |
+| `--description` | yes | One-sentence purpose statement. |
+| `--skills` | no | Skill descriptors as a JSON array string, persisted into the agent's `agent_card_json`. Invalid JSON exits 1 with `Error: Invalid JSON in --skills: <detail>`. |
+
+No identity flag — registering is how an agent obtains its id. Text output:
+
+```
+Agent registered successfully!
+  agent_id:  <agent_id>
+  name:      <name>
+```
+
+`--json` returns `{"agent_id":<id>,"name":"<name>","registered_at":"<iso8601>"}`.
+
+### `agent deregister`
+
+| Flag | Required | Notes |
+|---|---|---|
+| `--agent-id` | yes | The agent to deregister. |
+
+Text output: `Agent deregistered successfully.`; `--json` returns
+`{"status":"deregistered"}`. The root Director and the Administrator are
+protected — see [Error Messages](#error-messages).
+
+### `agent list`
+
+| Flag | Required | Notes |
+|---|---|---|
+| `--full` | no | See [`--full` semantics](#full-semantics). |
+
+No identity flag — the listing is scoped by the global `--fleet-id` alone.
+Default text output is one `<agent_id> <name> <status>` line per agent,
+blank-line separated; an empty fleet prints `No agents found.`:
+
+```
+2 Director active
+
+3 Administrator active
+
+4 demo-member active
+```
+
+### `agent show`
+
+| Flag | Required | Notes |
+|---|---|---|
+| `--agent-id` | yes | The acting agent (fleet-membership gate). |
+| `--id` | yes | The target agent to show. |
+| `--full` | no | See [`--full` semantics](#full-semantics). |
+
+Default text output is the same one-line `<agent_id> <name> <status>` row as
+`agent list`; the default `--json` projection additionally carries
+`coding_agent` when the target has a placement (see
+[`--full` semantics](#full-semantics)).
+
+## `cafleet message` — Message Broker
+
+All six subcommands require the global `--fleet-id` and act as `--agent-id`.
+The task envelope schema is canonical in
+[Message envelope](./message-envelope.md); body truncation and the
+`--full` / `--quiet` flags are canonical in
+[Message Body Truncation](#message-body-truncation) — neither is restated
+per subcommand. The compact text render is `[<id> | from:<from> | <ts>]` on
+line 1 (plus `kind` / `origin` segments only when present) and the body on
+line 2.
+
+### `message send`
+
+| Flag | Required | Notes |
+|---|---|---|
+| `--agent-id` | yes | Sender. |
+| `--to` | yes | Recipient agent id. |
+| `--text` | yes | Message body. |
+| `--full` / `--quiet` | no | See [Message Body Truncation](#message-body-truncation). |
+
+Text output is `Message sent.` followed by the compact rendered envelope;
+`--quiet` prints only the new task id.
+
+### `message broadcast`
+
+| Flag | Required | Notes |
+|---|---|---|
+| `--agent-id` | yes | Broadcaster. |
+| `--text` | yes | Message body. |
+| `--full` | no | See [`--full` semantics](#full-semantics). |
+
+Default text output is the one-line summary
+`broadcast id=<task_id> recipients=<count>`.
+
+### `message poll`
+
+| Flag | Required | Notes |
+|---|---|---|
+| `--agent-id` | yes | Recipient whose inbox is fetched. |
+| `--full` | no | See [Message Body Truncation](#message-body-truncation). |
+
+Returns only un-acked (`input_required`) deliveries addressed to the agent.
+Text output is the compact envelopes blank-line separated; an empty inbox
+prints `No messages found.`.
+
+### `message ack`
+
+| Flag | Required | Notes |
+|---|---|---|
+| `--agent-id` | yes | Recipient acknowledging the message. |
+| `--task-id` | yes | Task to acknowledge. |
+| `--full` / `--quiet` | no | See [Message Body Truncation](#message-body-truncation). |
+
+Text output is `Message acknowledged.` followed by the compact envelope;
+`--quiet` prints only the task id.
+
+### `message cancel`
+
+| Flag | Required | Notes |
+|---|---|---|
+| `--agent-id` | yes | Sender retracting the message (sender-only). |
+| `--task-id` | yes | Task to cancel. |
+| `--full` | no | See [Message Body Truncation](#message-body-truncation). |
+
+Text output is `Task canceled.` followed by the compact envelope.
+
+### `message show`
+
+| Flag | Required | Notes |
+|---|---|---|
+| `--agent-id` | yes | The acting agent (fleet-membership gate). |
+| `--task-id` | yes | Task to fetch. |
+| `--full` | no | See [Message Body Truncation](#message-body-truncation). |
+
+Text output is the compact envelope alone.
+
 ## Member Commands
 
 The `cafleet member` subgroup manages tmux-backed member agents and must be run inside a tmux session. `member create` takes `--agent-id` (the spawning Director's agent ID, validated to equal the fleet root); the other subcommands identify their target by `--member-id`, scoped to the global `--fleet-id`.
@@ -362,6 +551,32 @@ The `--prompt-file` path is BOTH the spawn input AND the permanent audit artifac
 #### Focus behavior
 
 The spawn always invokes `tmux split-window` with `-d` so the Director's pane and active window keep focus — the new member pane is created in the Director's window but is not made active.
+
+#### Output format
+
+Text (default) — one compact line; `pane` renders `(pending)` when the pane
+id has not been patched onto the placement yet:
+
+```
+<agent_id> <name> backend=<coding_agent> pane=<pane_id>
+```
+
+Text (hidden `--full` flag, accepted but not shown in `--help`) — 6-line block:
+
+```
+Member registered and spawned.
+  agent_id:  <agent_id>
+  name:      <name>
+  backend:   <coding_agent>
+  pane_id:   <pane_id>
+  window_id: <window_id>
+```
+
+`--json` returns
+`{"agent_id":<id>,"name":"<name>","registered_at":"<iso8601>","placement":{...}}`
+where `placement` carries `director_agent_id`, `tmux_session`,
+`tmux_window_id`, `tmux_pane_id`, `coding_agent`, and `created_at` (the same
+shape as `fleet create`'s `director.placement`).
 
 ### `member delete`
 

--- a/docs/spec/cli-options.md
+++ b/docs/spec/cli-options.md
@@ -615,7 +615,7 @@ Lists every member of the fleet identified by the global `--fleet-id`. The root 
 |---|---|---|
 | `--activity` | no | Aggregate per-member activity timestamps from the `tasks` table and render `last_sent`, `last_recv`, `last_ack`, and `idle` columns alongside the default member columns. The aggregation filters `Task.type != 'broadcast_summary'` for the `last_ack` proxy (mirrors `poll_tasks`). Primary inputs to the Director's `/loop` monitoring tick. |
 
-#### `member list --activity` output
+#### `member list --activity` output {#member-list-activity-output}
 
 ```
 $ cafleet --fleet-id <s> member list --activity

--- a/docs/spec/cli-options.md
+++ b/docs/spec/cli-options.md
@@ -620,11 +620,11 @@ Lists every member of the fleet identified by the global `--fleet-id`. The root 
 ```
 $ cafleet --fleet-id <s> member list --activity
 3 members:
-  agent_id  name      state   last_sent    last_recv    last_ack     idle
-  --------  --------  ------  -----------  -----------  -----------  -----
-  5         alice     active  12:34:56     12:34:50     12:34:50     6s
-  6         bob       active  12:30:11     12:33:02     12:33:02     2m
-  7         carol     idle    -            12:20:00     12:20:00     14m
+  agent_id        name      status  last_sent  last_recv  last_ack   idle
+  --------------  --------  ------  ---------  ---------  ---------  -----
+  4               alice     active  -          12:20:00   12:20:00   14m
+  5               bob       active  12:30:11   12:33:02   12:33:02   2m
+  6               carol     active  12:34:56   12:34:50   12:34:50   6s
 ```
 
 `last_sent` / `last_recv` come from `MAX(tasks.status_timestamp)` filtered by `from_agent_id` / `context_id`; `last_ack` is `MAX(tasks.status_timestamp WHERE status_state='completed' AND type != 'broadcast_summary')`. `idle` is wall-time minus `MAX(last_sent, last_recv)`. Existing indexes `idx_tasks_context_status_ts` and `idx_tasks_from_agent_status_ts` cover the aggregation joins; benchmark target is < 100 ms at 1k messages.

--- a/zensical.toml
+++ b/zensical.toml
@@ -48,7 +48,15 @@ nav = [
         { "Install" = "get-started/install.md" },
         { "Configure" = "get-started/configure.md" },
         { "Quickstart" = "get-started/quickstart.md" },
+        { "Troubleshooting" = "get-started/troubleshooting.md" },
         { "Contributing" = "get-started/contributing.md" },
+    ] },
+    { "How-to guides" = [
+        "how-to/index.md",
+        { "Run a mixed-backend team" = "how-to/mixed-backend-team.md" },
+        { "Monitor and recover members" = "how-to/monitor-and-recover.md" },
+        { "Use the admin WebUI" = "how-to/use-the-webui.md" },
+        { "Design-doc-driven development" = "how-to/design-doc-development.md" },
     ] },
     { "Concepts" = [
         { "Overview" = "concepts/overview.md" },
@@ -71,6 +79,7 @@ nav = [
         ] },
     ] },
     { "API Reference" = [
+        "api/index.md",
         { "broker" = "api/broker.md" },
         { "config" = "api/config.md" },
         { "coding_agent" = "api/coding-agent.md" },


### PR DESCRIPTION
- **docs: mark design doc 0000079 as complete**
- **docs: add documentation style guide and core terms table**
- **docs: rewrite quickstart with literal ids and add CLI subcommand summary with agent/message reference sections**
- **docs: add four how-to guides with section index and fix stale member list activity sample**
- **docs: add troubleshooting page with symptom-fix table under get started**
- **docs: add api reference landing page and orienting paragraphs on module stubs**
- **docs: add who-for framing and see-it-work example to README and docs landing page**
- **docs: add troubleshooting, how-to guides, and api index to nav**
- **docs: check off verified success criteria for design doc 0000081**
