### PR TITLE
feat/0000086 opencode send exit keystroke race

### DIFF
--- a/cafleet/src/cafleet/multiplexer/tmux.py
+++ b/cafleet/src/cafleet/multiplexer/tmux.py
@@ -15,8 +15,9 @@ _PANE_GONE_MARKERS = ("can't find pane", "no such pane")
 
 
 # Sleep between literal-text ``send-keys -l`` and following ``send-keys Enter``
-# so the codex TUI's bracketed-paste finalises before submit (applied
-# unconditionally to keep the helpers backend-agnostic).
+# so the codex TUI's bracketed-paste finalises and opencode's slash-command
+# autocomplete popup settles before submit (applied unconditionally to keep
+# the helpers backend-agnostic).
 _SUBMIT_DELAY = 0.12
 
 
@@ -38,9 +39,11 @@ def _run(args: list[str], *, timeout: float | None = None) -> str:
     return result.stdout
 
 
-def _run_tolerating_pane_gone(args: list[str], *, ignore_missing: bool) -> None:
+def _run_tolerating_pane_gone(
+    args: list[str], *, ignore_missing: bool, timeout: float | None = None
+) -> None:
     try:
-        _run(args)
+        _run(args, timeout=timeout)
     except TmuxError as exc:
         if ignore_missing and any(m in str(exc).lower() for m in _PANE_GONE_MARKERS):
             return
@@ -48,15 +51,21 @@ def _run_tolerating_pane_gone(args: list[str], *, ignore_missing: bool) -> None:
 
 
 def _send_literal_then_enter(
-    *, target_pane_id: str, payload: str, timeout: float | None = None
+    *,
+    target_pane_id: str,
+    payload: str,
+    timeout: float | None = None,
+    ignore_missing: bool = False,
 ) -> None:
-    _run(
+    _run_tolerating_pane_gone(
         ["tmux", "send-keys", "-t", target_pane_id, "-l", payload],
+        ignore_missing=ignore_missing,
         timeout=timeout,
     )
     time.sleep(_SUBMIT_DELAY)
-    _run(
+    _run_tolerating_pane_gone(
         ["tmux", "send-keys", "-t", target_pane_id, "Enter"],
+        ignore_missing=ignore_missing,
         timeout=timeout,
     )
 
@@ -135,9 +144,15 @@ class TmuxMultiplexer:
         _run(["tmux", "select-layout", "-t", target_window_id, layout])
 
     def send_exit(self, *, target_pane_id: str, ignore_missing: bool = False) -> None:
-        """Send ``/exit`` + Enter, swallowing pane-gone errors when requested."""
+        """Send literal ``/exit`` + Enter + trailing Enter, swallowing pane-gone errors when requested."""
+        _send_literal_then_enter(
+            target_pane_id=target_pane_id,
+            payload="/exit",
+            ignore_missing=ignore_missing,
+        )
+        time.sleep(_SUBMIT_DELAY)
         _run_tolerating_pane_gone(
-            ["tmux", "send-keys", "-t", target_pane_id, "/exit", "Enter"],
+            ["tmux", "send-keys", "-t", target_pane_id, "Enter"],
             ignore_missing=ignore_missing,
         )
 

--- a/cafleet/src/cafleet/multiplexer/tmux.py
+++ b/cafleet/src/cafleet/multiplexer/tmux.py
@@ -144,15 +144,10 @@ class TmuxMultiplexer:
         _run(["tmux", "select-layout", "-t", target_window_id, layout])
 
     def send_exit(self, *, target_pane_id: str, ignore_missing: bool = False) -> None:
-        """Send literal ``/exit`` + Enter + trailing Enter, swallowing pane-gone errors when requested."""
+        """Send ``/exit`` + Enter, swallowing pane-gone errors when requested."""
         _send_literal_then_enter(
             target_pane_id=target_pane_id,
             payload="/exit",
-            ignore_missing=ignore_missing,
-        )
-        time.sleep(_SUBMIT_DELAY)
-        _run_tolerating_pane_gone(
-            ["tmux", "send-keys", "-t", target_pane_id, "Enter"],
             ignore_missing=ignore_missing,
         )
 

--- a/cafleet/tests/multiplexer/test_tmux.py
+++ b/cafleet/tests/multiplexer/test_tmux.py
@@ -124,47 +124,206 @@ def test_split_window__argv_construction(monkeypatch, run_recorder):
     assert appended.index("-d") < appended.index("my-binary")
 
 
+_PANE_GONE_FAILURE = (
+    "tmux command failed: tmux send-keys -t %99 Enter\nstderr: can't find pane: %99"
+)
+_NON_PANE_GONE_FAILURE = "tmux command failed: server exited unexpectedly"
+
+
 @pytest.mark.parametrize(
-    ("scenario", "mock_error", "ignore_missing", "expect_raise_match"),
+    (
+        "scenario",
+        "error_by_call",
+        "ignore_missing",
+        "expect_raise_match",
+        "expected_call_count",
+    ),
     [
-        ("success", None, False, None),
+        ("success_three_invocations", {}, False, None, 3),
         (
-            "failure_raises",
-            TmuxError("tmux command failed: server exited unexpectedly"),
-            False,
-            "server exited unexpectedly",
-        ),
-        (
-            "ignore_missing_swallows_pane_gone",
-            TmuxError(
-                "tmux command failed: tmux send-keys -t %99 /exit Enter\n"
-                "stderr: can't find pane: %99"
-            ),
+            "ignore_missing_swallows_pane_gone_on_every_invocation",
+            {0: _PANE_GONE_FAILURE, 1: _PANE_GONE_FAILURE, 2: _PANE_GONE_FAILURE},
             True,
             None,
+            3,
         ),
         (
-            "ignore_missing_does_not_swallow_other_errors",
-            TmuxError("tmux command failed: server crashed"),
+            "pane_dies_after_literal_send",
+            {1: _PANE_GONE_FAILURE, 2: _PANE_GONE_FAILURE},
             True,
-            "server crashed",
+            None,
+            3,
+        ),
+        (
+            "pane_dies_after_first_enter",
+            {2: _PANE_GONE_FAILURE},
+            True,
+            None,
+            3,
+        ),
+        (
+            "non_pane_gone_error_propagates_despite_ignore_missing",
+            {0: _NON_PANE_GONE_FAILURE},
+            True,
+            "server exited unexpectedly",
+            1,
+        ),
+        (
+            "pane_gone_on_first_invocation_raises_without_ignore_missing",
+            {0: _PANE_GONE_FAILURE},
+            False,
+            "can't find pane",
+            1,
+        ),
+        (
+            "pane_gone_mid_sequence_raises_without_ignore_missing",
+            {1: _PANE_GONE_FAILURE},
+            False,
+            "can't find pane",
+            2,
         ),
     ],
 )
 def test_send_exit__success_and_ignore_missing_semantics(
-    monkeypatch, scenario, mock_error, ignore_missing, expect_raise_match
+    monkeypatch,
+    scenario,
+    error_by_call,
+    ignore_missing,
+    expect_raise_match,
+    expected_call_count,
 ):
+    captured: list[list[str]] = []
+    sleeps: list[float] = []
+
     def mock_run(args, **_kwargs):
-        if mock_error is not None:
-            raise mock_error
+        call_index = len(captured)
+        captured.append(list(args))
+        if call_index in error_by_call:
+            raise TmuxError(error_by_call[call_index])
         return ""
 
     monkeypatch.setattr(multiplexer_tmux, "_run", mock_run)
-    if expect_raise_match is None:
-        _tmux.send_exit(target_pane_id="%7", ignore_missing=ignore_missing)
-    else:
+    monkeypatch.setattr("time.sleep", lambda secs: sleeps.append(secs))
+
+    if expect_raise_match is not None:
         with pytest.raises(TmuxError, match=expect_raise_match):
             _tmux.send_exit(target_pane_id="%7", ignore_missing=ignore_missing)
+    else:
+        _tmux.send_exit(target_pane_id="%7", ignore_missing=ignore_missing)
+        assert captured == [
+            ["tmux", "send-keys", "-t", "%7", "-l", "/exit"],
+            ["tmux", "send-keys", "-t", "%7", "Enter"],
+            ["tmux", "send-keys", "-t", "%7", "Enter"],
+        ]
+        assert sleeps == [
+            multiplexer_tmux._SUBMIT_DELAY,
+            multiplexer_tmux._SUBMIT_DELAY,
+        ]
+    assert len(captured) == expected_call_count
+
+
+@pytest.mark.parametrize(
+    (
+        "scenario",
+        "error_by_call",
+        "ignore_missing_kwargs",
+        "expect_raise_match",
+        "expected_call_count",
+    ),
+    [
+        (
+            "default_false_raises_on_pane_gone_literal_send",
+            {0: _PANE_GONE_FAILURE},
+            {},
+            "can't find pane",
+            1,
+        ),
+        (
+            "default_false_raises_on_pane_gone_enter",
+            {1: _PANE_GONE_FAILURE},
+            {},
+            "can't find pane",
+            2,
+        ),
+        (
+            "explicit_false_raises_on_pane_gone",
+            {0: _PANE_GONE_FAILURE},
+            {"ignore_missing": False},
+            "can't find pane",
+            1,
+        ),
+        (
+            "true_swallows_pane_gone_on_literal_send",
+            {0: _PANE_GONE_FAILURE},
+            {"ignore_missing": True},
+            None,
+            2,
+        ),
+        (
+            "true_swallows_pane_gone_on_enter",
+            {1: _PANE_GONE_FAILURE},
+            {"ignore_missing": True},
+            None,
+            2,
+        ),
+        (
+            "true_does_not_swallow_other_errors",
+            {0: _NON_PANE_GONE_FAILURE},
+            {"ignore_missing": True},
+            "server exited unexpectedly",
+            1,
+        ),
+    ],
+)
+def test_send_literal_then_enter__ignore_missing_semantics(
+    monkeypatch,
+    scenario,
+    error_by_call,
+    ignore_missing_kwargs,
+    expect_raise_match,
+    expected_call_count,
+):
+    captured: list[list[str]] = []
+
+    def mock_run(args, **_kwargs):
+        call_index = len(captured)
+        captured.append(list(args))
+        if call_index in error_by_call:
+            raise TmuxError(error_by_call[call_index])
+        return ""
+
+    monkeypatch.setattr(multiplexer_tmux, "_run", mock_run)
+    monkeypatch.setattr("time.sleep", lambda _secs: None)
+
+    if expect_raise_match is not None:
+        with pytest.raises(TmuxError, match=expect_raise_match):
+            multiplexer_tmux._send_literal_then_enter(
+                target_pane_id="%7", payload="hello", **ignore_missing_kwargs
+            )
+    else:
+        multiplexer_tmux._send_literal_then_enter(
+            target_pane_id="%7", payload="hello", **ignore_missing_kwargs
+        )
+        assert captured == [
+            ["tmux", "send-keys", "-t", "%7", "-l", "hello"],
+            ["tmux", "send-keys", "-t", "%7", "Enter"],
+        ]
+    assert len(captured) == expected_call_count
+
+
+def test_send_literal_then_enter__forwards_timeout_to_run(monkeypatch):
+    captured_timeouts: list[float | None] = []
+
+    def mock_run(args, *, timeout=None, **_kwargs):
+        captured_timeouts.append(timeout)
+        return ""
+
+    monkeypatch.setattr(multiplexer_tmux, "_run", mock_run)
+    monkeypatch.setattr("time.sleep", lambda _secs: None)
+    multiplexer_tmux._send_literal_then_enter(
+        target_pane_id="%7", payload="hello", timeout=5
+    )
+    assert captured_timeouts == [5, 5]
 
 
 @pytest.mark.parametrize(

--- a/cafleet/tests/multiplexer/test_tmux.py
+++ b/cafleet/tests/multiplexer/test_tmux.py
@@ -139,27 +139,20 @@ _NON_PANE_GONE_FAILURE = "tmux command failed: server exited unexpectedly"
         "expected_call_count",
     ),
     [
-        ("success_three_invocations", {}, False, None, 3),
+        ("success_two_invocations", {}, False, None, 2),
         (
             "ignore_missing_swallows_pane_gone_on_every_invocation",
-            {0: _PANE_GONE_FAILURE, 1: _PANE_GONE_FAILURE, 2: _PANE_GONE_FAILURE},
+            {0: _PANE_GONE_FAILURE, 1: _PANE_GONE_FAILURE},
             True,
             None,
-            3,
+            2,
         ),
         (
             "pane_dies_after_literal_send",
-            {1: _PANE_GONE_FAILURE, 2: _PANE_GONE_FAILURE},
+            {1: _PANE_GONE_FAILURE},
             True,
             None,
-            3,
-        ),
-        (
-            "pane_dies_after_first_enter",
-            {2: _PANE_GONE_FAILURE},
-            True,
-            None,
-            3,
+            2,
         ),
         (
             "non_pane_gone_error_propagates_despite_ignore_missing",
@@ -213,12 +206,8 @@ def test_send_exit__success_and_ignore_missing_semantics(
         assert captured == [
             ["tmux", "send-keys", "-t", "%7", "-l", "/exit"],
             ["tmux", "send-keys", "-t", "%7", "Enter"],
-            ["tmux", "send-keys", "-t", "%7", "Enter"],
         ]
-        assert sleeps == [
-            multiplexer_tmux._SUBMIT_DELAY,
-            multiplexer_tmux._SUBMIT_DELAY,
-        ]
+        assert sleeps == [multiplexer_tmux._SUBMIT_DELAY]
     assert len(captured) == expected_call_count
 
 

--- a/design-docs/0000086-opencode-send-exit-keystroke-race/design-doc.md
+++ b/design-docs/0000086-opencode-send-exit-keystroke-race/design-doc.md
@@ -1,20 +1,20 @@
 # Fix opencode `/exit` Keystroke Race in `TmuxMultiplexer.send_exit`
 
 **Status**: Approved
-**Progress**: 10/13 tasks complete
+**Progress**: 5/13 tasks complete
 **Last Updated**: 2026-06-12
 
 ## Overview
 
-`TmuxMultiplexer.send_exit` sends `/exit` and Enter in a single fused `tmux send-keys` call with zero delay, which races against opencode's slash-command autocomplete popup: the Enter is consumed before the input state settles, `/exit` never submits, and the default `cafleet member delete` path times out (exit 2), forcing operators to rerun with `--force`. This change routes `send_exit` through the existing `_send_literal_then_enter` helper (literal-mode send, `_SUBMIT_DELAY` gap, separate Enter) plus a trailing second Enter, with pane-gone tolerance on every keystroke.
+`TmuxMultiplexer.send_exit` sends `/exit` and Enter in a single fused `tmux send-keys` call with zero delay, which races against opencode's slash-command autocomplete popup: the Enter is consumed before the input state settles, `/exit` never submits, and the default `cafleet member delete` path times out (exit 2), forcing operators to rerun with `--force`. This change routes `send_exit` through the existing `_send_literal_then_enter` helper (literal-mode send, `_SUBMIT_DELAY` gap, separate Enter), with pane-gone tolerance on both keystrokes.
 
 ## Success Criteria
 
 - [ ] A live opencode member is deletable via the default `cafleet member delete` path with exit 0 (no `--force`)
 - [ ] Live claude and codex members still delete cleanly via the default path (exit 0) with the new keystroke sequence
-- [ ] `send_exit` issues three separate `tmux send-keys` invocations — literal `/exit`, Enter, trailing Enter — each separated by `_SUBMIT_DELAY` and each pane-gone-tolerant when `ignore_missing=True`
-- [ ] `_send_literal_then_enter`'s new `ignore_missing` parameter defaults to `False`, leaving the four other callers (`send_poll_trigger`, `send_inline_preview`, `send_bash_command`, `send_freetext_and_submit`) behaviorally unchanged
-- [ ] `_run_tolerating_pane_gone` keeps its pane-gone-marker swallowing behavior (its new `timeout` parameter is optional and backward compatible for existing callers); `kill_pane` and all three `send_exit` call sites keep their existing contracts
+- [ ] `send_exit` issues two separate `tmux send-keys` invocations — literal `/exit`, then Enter after a `_SUBMIT_DELAY` gap — each pane-gone-tolerant when `ignore_missing=True`
+- [x] `_send_literal_then_enter`'s new `ignore_missing` parameter defaults to `False`, leaving the four other callers (`send_poll_trigger`, `send_inline_preview`, `send_bash_command`, `send_freetext_and_submit`) behaviorally unchanged
+- [x] `_run_tolerating_pane_gone` keeps its pane-gone-marker swallowing behavior (its new `timeout` parameter is optional and backward compatible for existing callers); `kill_pane` and all three `send_exit` call sites keep their existing contracts
 - [ ] `mise //cafleet:test`, `mise //cafleet:lint`, and `mise //cafleet:typecheck` pass
 
 ---
@@ -23,7 +23,7 @@
 
 Reproduced live on 2026-06-12 (fleets 31 and 32): opencode's TUI opens a slash-command autocomplete popup on `/`, and the Enter fused into the same `send-keys` call (`cafleet/src/cafleet/multiplexer/tmux.py:137`) is consumed before the input line settles. The pane stays alive with `/exit` unsubmitted, `wait_for_pane_gone` times out after 15 s, and `member delete` exits 2. A single bare Enter sent afterwards exited opencode immediately.
 
-The fix sequence was validated by hand: literal-mode text (`tmux send-keys -l "/exit"`) followed by a separate delayed Enter exits opencode cleanly on the **first** Enter — two Enters are not required when the gap is long enough. The hand test used multi-second gaps, so `_SUBMIT_DELAY` (0.12 s) is unvalidated against opencode's popup render time; the trailing second Enter below is insurance for that gap and is harmless on claude/codex.
+The fix sequence was validated by hand: literal-mode text (`tmux send-keys -l "/exit"`) followed by a separate delayed Enter exits opencode cleanly on the **first** Enter. The hand test used multi-second gaps, so `_SUBMIT_DELAY` (0.12 s) must be validated against opencode's popup render time by the Step 4 live verification; if it proves insufficient, the fallbacks are bumping the exit-path delay or the unchanged `--force` path.
 
 ---
 
@@ -31,20 +31,19 @@ The fix sequence was validated by hand: literal-mode text (`tmux send-keys -l "/
 
 ### New keystroke sequence
 
-`send_exit` switches from one fused invocation to three separate invocations:
+`send_exit` switches from one fused invocation to two separate invocations:
 
 | # | tmux invocation | Gap after | Pane-gone tolerance |
 |---|---|---|---|
 | 1 | `tmux send-keys -t <pane> -l "/exit"` | `_SUBMIT_DELAY` (0.12 s) | per `ignore_missing` |
-| 2 | `tmux send-keys -t <pane> Enter` | `_SUBMIT_DELAY` (0.12 s) | per `ignore_missing` |
-| 3 | `tmux send-keys -t <pane> Enter` | — | per `ignore_missing` |
+| 2 | `tmux send-keys -t <pane> Enter` | — | per `ignore_missing` |
 
 Decision rationale:
 
-- **Literal `-l` send + delayed separate Enter** is the hand-validated fix: the delay lets opencode's popup/input state settle so the first Enter submits.
-- **Trailing second Enter** (instead of bumping the delay): keeps `_SUBMIT_DELAY` at its codex-validated 0.12 s while covering the unvalidated case where opencode's popup render outlasts 0.12 s. On claude/codex the first Enter already submits `/exit`, so the trailing Enter lands in a closing or already-gone pane and is swallowed by pane-gone tolerance.
+- **Literal `-l` send + delayed separate Enter** is the hand-validated fix: the delay lets opencode's popup/input state settle so the Enter submits.
+- **Delay-only, no extra keystrokes**: the sequence is exactly the helper's standard two-invocation shape, so `send_exit` collapses to a single `_send_literal_then_enter` call. The 0.12 s settle gap is validated against opencode's popup render by the Step 4 live verification; the fallbacks if it ever proves insufficient are bumping the exit-path delay or the unchanged `--force` path.
 - **Backend-agnostic**: the sequence is identical for claude, codex, and opencode. No backend plumbing into `send_exit`.
-- **Latency**: the sequence adds 0.24 s of sleeps per `send_exit`, negligible against the 15 s `wait_for_pane_gone` budget. The 15 s timeout, polling interval, and `--force` path are unchanged.
+- **Latency**: the sequence adds 0.12 s of sleep per `send_exit`, negligible against the 15 s `wait_for_pane_gone` budget. The 15 s timeout, polling interval, and `--force` path are unchanged.
 
 ### Code changes (`cafleet/src/cafleet/multiplexer/tmux.py`)
 
@@ -89,15 +88,10 @@ def _send_literal_then_enter(
 
 ```python
 def send_exit(self, *, target_pane_id: str, ignore_missing: bool = False) -> None:
-    """Send literal ``/exit`` + Enter + trailing Enter, swallowing pane-gone errors when requested."""
+    """Send ``/exit`` + Enter, swallowing pane-gone errors when requested."""
     _send_literal_then_enter(
         target_pane_id=target_pane_id,
         payload="/exit",
-        ignore_missing=ignore_missing,
-    )
-    time.sleep(_SUBMIT_DELAY)
-    _run_tolerating_pane_gone(
-        ["tmux", "send-keys", "-t", target_pane_id, "Enter"],
         ignore_missing=ignore_missing,
     )
 ```
@@ -106,8 +100,8 @@ The `_SUBMIT_DELAY` comment is extended to name both settle cases it now covers:
 
 ### `ignore_missing` semantics
 
-- With `ignore_missing=True`, **every** keystroke in the exit sequence is pane-gone-tolerant. A pane dying mid-sequence (e.g. right after the first Enter exits the agent) is success, not error: each subsequent invocation fails with a pane-gone marker and is swallowed independently.
-- With `ignore_missing=False`, any `TmuxError` propagates from whichever invocation raised it. **Behavioral delta vs. today**: the old fused single invocation cannot fail after its keystroke is delivered, but the three-invocation sequence adds new failure windows — a pane dying between the first Enter and the trailing Enter (the normal claude/codex case once `/exit` submits) now raises `TmuxError` where the old code returned success. This is acceptable because all three in-repo call sites (`member.py:215`, `:223`, `:302`) pass `ignore_missing=True`, so no production path is affected.
+- With `ignore_missing=True`, **both** keystrokes in the exit sequence are pane-gone-tolerant. A pane dying mid-sequence (between the literal send and the Enter) is success, not error: the later invocation fails with a pane-gone marker and is swallowed independently.
+- With `ignore_missing=False`, any `TmuxError` propagates from whichever invocation raised it. **Behavioral delta vs. today**: the old fused single invocation cannot fail after its keystroke is delivered, but the two-invocation sequence adds a new failure window — a pane dying between the literal send and the Enter now raises `TmuxError` where the old code returned success. This is acceptable because all three in-repo call sites (`member.py:215`, `:223`, `:302`) pass `ignore_missing=True`, so no production path is affected.
 - Non-pane-gone errors (e.g. tmux server crash) propagate regardless of the flag, exactly as `_run_tolerating_pane_gone` behaves today.
 
 ### Out of scope
@@ -125,22 +119,22 @@ The `_SUBMIT_DELAY` comment is extended to name both settle cases it now covers:
 
 ### Step 1: Documentation
 
-- [x] Update `docs/spec/cli-options.md` § `member delete` default-path description (~line 560): replace "sends `/exit` via `tmux send-keys`" with the three-invocation sequence (literal `/exit`, 0.12 s gap, Enter, 0.12 s gap, trailing Enter) and a one-line rationale (opencode slash-popup settle; trailing Enter harmless on claude/codex) <!-- completed: 2026-06-12T10:35 -->
+- [ ] Update `docs/spec/cli-options.md` § `member delete` default-path description (~line 560): replace "sends `/exit` via `tmux send-keys`" with the two-invocation sequence (literal `/exit`, 0.12 s gap, Enter) and a one-line rationale (opencode slash-popup settle) <!-- completed: -->
 - [x] Update `docs/concepts/member-lifecycle.md` default-path wording (~line 57) if it implies a single fused keystroke; keep the altitude conceptual <!-- completed: 2026-06-12T10:35 -->
 
 ### Step 2: Code
 
 - [x] Add `timeout: float | None = None` pass-through to `_run_tolerating_pane_gone` <!-- completed: 2026-06-12T10:41 -->
 - [x] Add `ignore_missing: bool = False` to `_send_literal_then_enter` and route both invocations through `_run_tolerating_pane_gone` <!-- completed: 2026-06-12T10:41 -->
-- [x] Rewrite `send_exit` per the Specification (helper call + delayed trailing tolerant Enter) <!-- completed: 2026-06-12T10:41 -->
+- [ ] Rewrite `send_exit` per the Specification (single `_send_literal_then_enter` call) <!-- completed: -->
 - [x] Extend the `_SUBMIT_DELAY` comment to cover the opencode slash-popup settle case alongside codex bracketed-paste <!-- completed: 2026-06-12T10:41 -->
 
 ### Step 3: Tests
 
-- [x] Rework `test_send_exit__success_and_ignore_missing_semantics` in `tests/multiplexer/test_tmux.py`: assert the three-invocation argv sequence (`-l /exit`, `Enter`, `Enter`), per-invocation pane-gone tolerance with `ignore_missing=True` (including pane dying mid-sequence), propagation of non-pane-gone errors, and propagation of pane-gone with `ignore_missing=False`; monkeypatch `time.sleep` to avoid real delays <!-- completed: 2026-06-12T10:37 -->
+- [ ] Rework `test_send_exit__success_and_ignore_missing_semantics` in `tests/multiplexer/test_tmux.py`: assert the two-invocation argv sequence (`-l /exit`, `Enter`) with a single `_SUBMIT_DELAY` sleep, per-invocation pane-gone tolerance with `ignore_missing=True` (including pane dying mid-sequence), propagation of non-pane-gone errors, and propagation of pane-gone with `ignore_missing=False`; monkeypatch `time.sleep` to avoid real delays <!-- completed: -->
 - [x] Add `_send_literal_then_enter` `ignore_missing` coverage: default `False` still raises on pane-gone (existing caller behavior pinned); `True` swallows pane-gone on either invocation <!-- completed: 2026-06-12T10:37 -->
 - [x] Confirm `tests/cli/test_member_delete.py` and `tests/cli/test_member.py` still pass — they mock `send_exit` at method level and assert kwargs only, so no changes are expected <!-- completed: 2026-06-12T10:43 -->
-- [x] Run `mise //cafleet:test`, `mise //cafleet:lint`, `mise //cafleet:typecheck` <!-- completed: 2026-06-12T10:43 -->
+- [ ] Run `mise //cafleet:test`, `mise //cafleet:lint`, `mise //cafleet:typecheck` <!-- completed: -->
 
 ### Step 4: Live verification (one member per backend)
 
@@ -155,3 +149,4 @@ The `_SUBMIT_DELAY` comment is extended to name both settle cases it now covers:
 | Date | Changes |
 |------|---------|
 | 2026-06-12 | Initial draft |
+| 2026-06-12 | Dropped the trailing second Enter (user decision): `send_exit` is a single `_send_literal_then_enter` call; affected docs, code, test, and live-verification tasks reopened |

--- a/design-docs/0000086-opencode-send-exit-keystroke-race/design-doc.md
+++ b/design-docs/0000086-opencode-send-exit-keystroke-race/design-doc.md
@@ -1,6 +1,6 @@
 # Fix opencode `/exit` Keystroke Race in `TmuxMultiplexer.send_exit`
 
-**Status**: Approved
+**Status**: Complete
 **Progress**: 13/13 tasks complete
 **Last Updated**: 2026-06-12
 
@@ -150,3 +150,4 @@ The `_SUBMIT_DELAY` comment is extended to name both settle cases it now covers:
 |------|---------|
 | 2026-06-12 | Initial draft |
 | 2026-06-12 | Dropped the trailing second Enter (user decision): `send_exit` is a single `_send_literal_then_enter` call; affected docs, code, test, and live-verification tasks reopened |
+| 2026-06-12 | Implementation complete: all 13 tasks and 6 success criteria verified; live-verified on claude/codex/opencode (4 opencode rounds); PR #112 reviewed clean by Copilot |

--- a/design-docs/0000086-opencode-send-exit-keystroke-race/design-doc.md
+++ b/design-docs/0000086-opencode-send-exit-keystroke-race/design-doc.md
@@ -1,7 +1,7 @@
 # Fix opencode `/exit` Keystroke Race in `TmuxMultiplexer.send_exit`
 
 **Status**: Approved
-**Progress**: 7/13 tasks complete
+**Progress**: 13/13 tasks complete
 **Last Updated**: 2026-06-12
 
 ## Overview
@@ -10,12 +10,12 @@
 
 ## Success Criteria
 
-- [ ] A live opencode member is deletable via the default `cafleet member delete` path with exit 0 (no `--force`)
-- [ ] Live claude and codex members still delete cleanly via the default path (exit 0) with the new keystroke sequence
-- [ ] `send_exit` issues two separate `tmux send-keys` invocations — literal `/exit`, then Enter after a `_SUBMIT_DELAY` gap — each pane-gone-tolerant when `ignore_missing=True`
+- [x] A live opencode member is deletable via the default `cafleet member delete` path with exit 0 (no `--force`)
+- [x] Live claude and codex members still delete cleanly via the default path (exit 0) with the new keystroke sequence
+- [x] `send_exit` issues two separate `tmux send-keys` invocations — literal `/exit`, then Enter after a `_SUBMIT_DELAY` gap — each pane-gone-tolerant when `ignore_missing=True`
 - [x] `_send_literal_then_enter`'s new `ignore_missing` parameter defaults to `False`, leaving the four other callers (`send_poll_trigger`, `send_inline_preview`, `send_bash_command`, `send_freetext_and_submit`) behaviorally unchanged
 - [x] `_run_tolerating_pane_gone` keeps its pane-gone-marker swallowing behavior (its new `timeout` parameter is optional and backward compatible for existing callers); `kill_pane` and all three `send_exit` call sites keep their existing contracts
-- [ ] `mise //cafleet:test`, `mise //cafleet:lint`, and `mise //cafleet:typecheck` pass
+- [x] `mise //cafleet:test`, `mise //cafleet:lint`, and `mise //cafleet:typecheck` pass
 
 ---
 
@@ -131,16 +131,16 @@ The `_SUBMIT_DELAY` comment is extended to name both settle cases it now covers:
 
 ### Step 3: Tests
 
-- [ ] Rework `test_send_exit__success_and_ignore_missing_semantics` in `tests/multiplexer/test_tmux.py`: assert the two-invocation argv sequence (`-l /exit`, `Enter`) with a single `_SUBMIT_DELAY` sleep, per-invocation pane-gone tolerance with `ignore_missing=True` (including pane dying mid-sequence), propagation of non-pane-gone errors, and propagation of pane-gone with `ignore_missing=False`; monkeypatch `time.sleep` to avoid real delays <!-- completed: -->
+- [x] Rework `test_send_exit__success_and_ignore_missing_semantics` in `tests/multiplexer/test_tmux.py`: assert the two-invocation argv sequence (`-l /exit`, `Enter`) with a single `_SUBMIT_DELAY` sleep, per-invocation pane-gone tolerance with `ignore_missing=True` (including pane dying mid-sequence), propagation of non-pane-gone errors, and propagation of pane-gone with `ignore_missing=False`; monkeypatch `time.sleep` to avoid real delays <!-- completed: 2026-06-12T10:52 -->
 - [x] Add `_send_literal_then_enter` `ignore_missing` coverage: default `False` still raises on pane-gone (existing caller behavior pinned); `True` swallows pane-gone on either invocation <!-- completed: 2026-06-12T10:37 -->
 - [x] Confirm `tests/cli/test_member_delete.py` and `tests/cli/test_member.py` still pass — they mock `send_exit` at method level and assert kwargs only, so no changes are expected <!-- completed: 2026-06-12T10:43 -->
-- [ ] Run `mise //cafleet:test`, `mise //cafleet:lint`, `mise //cafleet:typecheck` <!-- completed: -->
+- [x] Run `mise //cafleet:test`, `mise //cafleet:lint`, `mise //cafleet:typecheck` <!-- completed: 2026-06-12T10:58 -->
 
 ### Step 4: Live verification (one member per backend)
 
-- [ ] claude: `cafleet member create` + default `cafleet member delete` exits 0 <!-- completed: -->
-- [ ] codex: `cafleet member create` + default `cafleet member delete` exits 0 <!-- completed: -->
-- [ ] opencode: `cafleet member create` + default `cafleet member delete` exits 0 without `--force` <!-- completed: -->
+- [x] claude: `cafleet member create` + default `cafleet member delete` exits 0 <!-- completed: 2026-06-12T10:58 -->
+- [x] codex: `cafleet member create` + default `cafleet member delete` exits 0 <!-- completed: 2026-06-12T10:59 -->
+- [x] opencode: `cafleet member create` + default `cafleet member delete` exits 0 without `--force` <!-- completed: 2026-06-12T10:57 -->
 
 ---
 

--- a/design-docs/0000086-opencode-send-exit-keystroke-race/design-doc.md
+++ b/design-docs/0000086-opencode-send-exit-keystroke-race/design-doc.md
@@ -1,7 +1,7 @@
 # Fix opencode `/exit` Keystroke Race in `TmuxMultiplexer.send_exit`
 
 **Status**: Approved
-**Progress**: 6/13 tasks complete
+**Progress**: 10/13 tasks complete
 **Last Updated**: 2026-06-12
 
 ## Overview
@@ -137,10 +137,10 @@ The `_SUBMIT_DELAY` comment is extended to name both settle cases it now covers:
 
 ### Step 3: Tests
 
-- [ ] Rework `test_send_exit__success_and_ignore_missing_semantics` in `tests/multiplexer/test_tmux.py`: assert the three-invocation argv sequence (`-l /exit`, `Enter`, `Enter`), per-invocation pane-gone tolerance with `ignore_missing=True` (including pane dying mid-sequence), propagation of non-pane-gone errors, and propagation of pane-gone with `ignore_missing=False`; monkeypatch `time.sleep` to avoid real delays <!-- completed: -->
-- [ ] Add `_send_literal_then_enter` `ignore_missing` coverage: default `False` still raises on pane-gone (existing caller behavior pinned); `True` swallows pane-gone on either invocation <!-- completed: -->
-- [ ] Confirm `tests/cli/test_member_delete.py` and `tests/cli/test_member.py` still pass — they mock `send_exit` at method level and assert kwargs only, so no changes are expected <!-- completed: -->
-- [ ] Run `mise //cafleet:test`, `mise //cafleet:lint`, `mise //cafleet:typecheck` <!-- completed: -->
+- [x] Rework `test_send_exit__success_and_ignore_missing_semantics` in `tests/multiplexer/test_tmux.py`: assert the three-invocation argv sequence (`-l /exit`, `Enter`, `Enter`), per-invocation pane-gone tolerance with `ignore_missing=True` (including pane dying mid-sequence), propagation of non-pane-gone errors, and propagation of pane-gone with `ignore_missing=False`; monkeypatch `time.sleep` to avoid real delays <!-- completed: 2026-06-12T10:37 -->
+- [x] Add `_send_literal_then_enter` `ignore_missing` coverage: default `False` still raises on pane-gone (existing caller behavior pinned); `True` swallows pane-gone on either invocation <!-- completed: 2026-06-12T10:37 -->
+- [x] Confirm `tests/cli/test_member_delete.py` and `tests/cli/test_member.py` still pass — they mock `send_exit` at method level and assert kwargs only, so no changes are expected <!-- completed: 2026-06-12T10:43 -->
+- [x] Run `mise //cafleet:test`, `mise //cafleet:lint`, `mise //cafleet:typecheck` <!-- completed: 2026-06-12T10:43 -->
 
 ### Step 4: Live verification (one member per backend)
 

--- a/design-docs/0000086-opencode-send-exit-keystroke-race/design-doc.md
+++ b/design-docs/0000086-opencode-send-exit-keystroke-race/design-doc.md
@@ -1,7 +1,7 @@
 # Fix opencode `/exit` Keystroke Race in `TmuxMultiplexer.send_exit`
 
 **Status**: Approved
-**Progress**: 2/13 tasks complete
+**Progress**: 6/13 tasks complete
 **Last Updated**: 2026-06-12
 
 ## Overview
@@ -130,10 +130,10 @@ The `_SUBMIT_DELAY` comment is extended to name both settle cases it now covers:
 
 ### Step 2: Code
 
-- [ ] Add `timeout: float | None = None` pass-through to `_run_tolerating_pane_gone` <!-- completed: -->
-- [ ] Add `ignore_missing: bool = False` to `_send_literal_then_enter` and route both invocations through `_run_tolerating_pane_gone` <!-- completed: -->
-- [ ] Rewrite `send_exit` per the Specification (helper call + delayed trailing tolerant Enter) <!-- completed: -->
-- [ ] Extend the `_SUBMIT_DELAY` comment to cover the opencode slash-popup settle case alongside codex bracketed-paste <!-- completed: -->
+- [x] Add `timeout: float | None = None` pass-through to `_run_tolerating_pane_gone` <!-- completed: 2026-06-12T10:41 -->
+- [x] Add `ignore_missing: bool = False` to `_send_literal_then_enter` and route both invocations through `_run_tolerating_pane_gone` <!-- completed: 2026-06-12T10:41 -->
+- [x] Rewrite `send_exit` per the Specification (helper call + delayed trailing tolerant Enter) <!-- completed: 2026-06-12T10:41 -->
+- [x] Extend the `_SUBMIT_DELAY` comment to cover the opencode slash-popup settle case alongside codex bracketed-paste <!-- completed: 2026-06-12T10:41 -->
 
 ### Step 3: Tests
 

--- a/design-docs/0000086-opencode-send-exit-keystroke-race/design-doc.md
+++ b/design-docs/0000086-opencode-send-exit-keystroke-race/design-doc.md
@@ -1,7 +1,7 @@
 # Fix opencode `/exit` Keystroke Race in `TmuxMultiplexer.send_exit`
 
 **Status**: Approved
-**Progress**: 5/13 tasks complete
+**Progress**: 7/13 tasks complete
 **Last Updated**: 2026-06-12
 
 ## Overview
@@ -119,14 +119,14 @@ The `_SUBMIT_DELAY` comment is extended to name both settle cases it now covers:
 
 ### Step 1: Documentation
 
-- [ ] Update `docs/spec/cli-options.md` § `member delete` default-path description (~line 560): replace "sends `/exit` via `tmux send-keys`" with the two-invocation sequence (literal `/exit`, 0.12 s gap, Enter) and a one-line rationale (opencode slash-popup settle) <!-- completed: -->
+- [x] Update `docs/spec/cli-options.md` § `member delete` default-path description (~line 560): replace "sends `/exit` via `tmux send-keys`" with the two-invocation sequence (literal `/exit`, 0.12 s gap, Enter) and a one-line rationale (opencode slash-popup settle) <!-- completed: 2026-06-12T10:57 -->
 - [x] Update `docs/concepts/member-lifecycle.md` default-path wording (~line 57) if it implies a single fused keystroke; keep the altitude conceptual <!-- completed: 2026-06-12T10:35 -->
 
 ### Step 2: Code
 
 - [x] Add `timeout: float | None = None` pass-through to `_run_tolerating_pane_gone` <!-- completed: 2026-06-12T10:41 -->
 - [x] Add `ignore_missing: bool = False` to `_send_literal_then_enter` and route both invocations through `_run_tolerating_pane_gone` <!-- completed: 2026-06-12T10:41 -->
-- [ ] Rewrite `send_exit` per the Specification (single `_send_literal_then_enter` call) <!-- completed: -->
+- [x] Rewrite `send_exit` per the Specification (single `_send_literal_then_enter` call) <!-- completed: 2026-06-12T10:57 -->
 - [x] Extend the `_SUBMIT_DELAY` comment to cover the opencode slash-popup settle case alongside codex bracketed-paste <!-- completed: 2026-06-12T10:41 -->
 
 ### Step 3: Tests

--- a/design-docs/0000086-opencode-send-exit-keystroke-race/design-doc.md
+++ b/design-docs/0000086-opencode-send-exit-keystroke-race/design-doc.md
@@ -1,0 +1,157 @@
+# Fix opencode `/exit` Keystroke Race in `TmuxMultiplexer.send_exit`
+
+**Status**: Approved
+**Progress**: 2/13 tasks complete
+**Last Updated**: 2026-06-12
+
+## Overview
+
+`TmuxMultiplexer.send_exit` sends `/exit` and Enter in a single fused `tmux send-keys` call with zero delay, which races against opencode's slash-command autocomplete popup: the Enter is consumed before the input state settles, `/exit` never submits, and the default `cafleet member delete` path times out (exit 2), forcing operators to rerun with `--force`. This change routes `send_exit` through the existing `_send_literal_then_enter` helper (literal-mode send, `_SUBMIT_DELAY` gap, separate Enter) plus a trailing second Enter, with pane-gone tolerance on every keystroke.
+
+## Success Criteria
+
+- [ ] A live opencode member is deletable via the default `cafleet member delete` path with exit 0 (no `--force`)
+- [ ] Live claude and codex members still delete cleanly via the default path (exit 0) with the new keystroke sequence
+- [ ] `send_exit` issues three separate `tmux send-keys` invocations — literal `/exit`, Enter, trailing Enter — each separated by `_SUBMIT_DELAY` and each pane-gone-tolerant when `ignore_missing=True`
+- [ ] `_send_literal_then_enter`'s new `ignore_missing` parameter defaults to `False`, leaving the four other callers (`send_poll_trigger`, `send_inline_preview`, `send_bash_command`, `send_freetext_and_submit`) behaviorally unchanged
+- [ ] `_run_tolerating_pane_gone` keeps its pane-gone-marker swallowing behavior (its new `timeout` parameter is optional and backward compatible for existing callers); `kill_pane` and all three `send_exit` call sites keep their existing contracts
+- [ ] `mise //cafleet:test`, `mise //cafleet:lint`, and `mise //cafleet:typecheck` pass
+
+---
+
+## Background
+
+Reproduced live on 2026-06-12 (fleets 31 and 32): opencode's TUI opens a slash-command autocomplete popup on `/`, and the Enter fused into the same `send-keys` call (`cafleet/src/cafleet/multiplexer/tmux.py:137`) is consumed before the input line settles. The pane stays alive with `/exit` unsubmitted, `wait_for_pane_gone` times out after 15 s, and `member delete` exits 2. A single bare Enter sent afterwards exited opencode immediately.
+
+The fix sequence was validated by hand: literal-mode text (`tmux send-keys -l "/exit"`) followed by a separate delayed Enter exits opencode cleanly on the **first** Enter — two Enters are not required when the gap is long enough. The hand test used multi-second gaps, so `_SUBMIT_DELAY` (0.12 s) is unvalidated against opencode's popup render time; the trailing second Enter below is insurance for that gap and is harmless on claude/codex.
+
+---
+
+## Specification
+
+### New keystroke sequence
+
+`send_exit` switches from one fused invocation to three separate invocations:
+
+| # | tmux invocation | Gap after | Pane-gone tolerance |
+|---|---|---|---|
+| 1 | `tmux send-keys -t <pane> -l "/exit"` | `_SUBMIT_DELAY` (0.12 s) | per `ignore_missing` |
+| 2 | `tmux send-keys -t <pane> Enter` | `_SUBMIT_DELAY` (0.12 s) | per `ignore_missing` |
+| 3 | `tmux send-keys -t <pane> Enter` | — | per `ignore_missing` |
+
+Decision rationale:
+
+- **Literal `-l` send + delayed separate Enter** is the hand-validated fix: the delay lets opencode's popup/input state settle so the first Enter submits.
+- **Trailing second Enter** (instead of bumping the delay): keeps `_SUBMIT_DELAY` at its codex-validated 0.12 s while covering the unvalidated case where opencode's popup render outlasts 0.12 s. On claude/codex the first Enter already submits `/exit`, so the trailing Enter lands in a closing or already-gone pane and is swallowed by pane-gone tolerance.
+- **Backend-agnostic**: the sequence is identical for claude, codex, and opencode. No backend plumbing into `send_exit`.
+- **Latency**: the sequence adds 0.24 s of sleeps per `send_exit`, negligible against the 15 s `wait_for_pane_gone` budget. The 15 s timeout, polling interval, and `--force` path are unchanged.
+
+### Code changes (`cafleet/src/cafleet/multiplexer/tmux.py`)
+
+`_run_tolerating_pane_gone` gains a pass-through `timeout` parameter (default `None`, backward compatible). The pass-through exists solely so `_send_literal_then_enter` keeps honoring the `timeout=5` passed by `send_poll_trigger` / `send_inline_preview` after rerouting through `_run_tolerating_pane_gone`:
+
+```python
+def _run_tolerating_pane_gone(
+    args: list[str], *, ignore_missing: bool, timeout: float | None = None
+) -> None:
+    try:
+        _run(args, timeout=timeout)
+    except TmuxError as exc:
+        if ignore_missing and any(m in str(exc).lower() for m in _PANE_GONE_MARKERS):
+            return
+        raise
+```
+
+`_send_literal_then_enter` gains `ignore_missing: bool = False` and routes both invocations through `_run_tolerating_pane_gone`. With `ignore_missing=False` the wrapper re-raises every `TmuxError`, so the four existing callers see identical behavior:
+
+```python
+def _send_literal_then_enter(
+    *,
+    target_pane_id: str,
+    payload: str,
+    timeout: float | None = None,
+    ignore_missing: bool = False,
+) -> None:
+    _run_tolerating_pane_gone(
+        ["tmux", "send-keys", "-t", target_pane_id, "-l", payload],
+        ignore_missing=ignore_missing,
+        timeout=timeout,
+    )
+    time.sleep(_SUBMIT_DELAY)
+    _run_tolerating_pane_gone(
+        ["tmux", "send-keys", "-t", target_pane_id, "Enter"],
+        ignore_missing=ignore_missing,
+        timeout=timeout,
+    )
+```
+
+`send_exit` keeps its public signature (`target_pane_id`, `ignore_missing: bool = False`) and becomes:
+
+```python
+def send_exit(self, *, target_pane_id: str, ignore_missing: bool = False) -> None:
+    """Send literal ``/exit`` + Enter + trailing Enter, swallowing pane-gone errors when requested."""
+    _send_literal_then_enter(
+        target_pane_id=target_pane_id,
+        payload="/exit",
+        ignore_missing=ignore_missing,
+    )
+    time.sleep(_SUBMIT_DELAY)
+    _run_tolerating_pane_gone(
+        ["tmux", "send-keys", "-t", target_pane_id, "Enter"],
+        ignore_missing=ignore_missing,
+    )
+```
+
+The `_SUBMIT_DELAY` comment is extended to name both settle cases it now covers: codex bracketed-paste finalization and opencode slash-popup settling.
+
+### `ignore_missing` semantics
+
+- With `ignore_missing=True`, **every** keystroke in the exit sequence is pane-gone-tolerant. A pane dying mid-sequence (e.g. right after the first Enter exits the agent) is success, not error: each subsequent invocation fails with a pane-gone marker and is swallowed independently.
+- With `ignore_missing=False`, any `TmuxError` propagates from whichever invocation raised it. **Behavioral delta vs. today**: the old fused single invocation cannot fail after its keystroke is delivered, but the three-invocation sequence adds new failure windows — a pane dying between the first Enter and the trailing Enter (the normal claude/codex case once `/exit` submits) now raises `TmuxError` where the old code returned success. This is acceptable because all three in-repo call sites (`member.py:215`, `:223`, `:302`) pass `ignore_missing=True`, so no production path is affected.
+- Non-pane-gone errors (e.g. tmux server crash) propagate regardless of the flag, exactly as `_run_tolerating_pane_gone` behaves today.
+
+### Out of scope
+
+- Other keystroke paths (`send_poll_trigger`, `send_inline_preview`, `send_bash_command`, `send_freetext_and_submit`) keep their current two-invocation sequence and non-tolerant behavior.
+- `kill_pane`, the three `send_exit` call sites (`cafleet/src/cafleet/cli/member.py:215`, `:223`, `:302`), the 15 s `wait_for_pane_gone` timeout, and the `--force` path are unchanged.
+- The `_SUBMIT_DELAY` value (0.12 s) is unchanged.
+
+---
+
+## Implementation
+
+> Task format: `- [x] Done task <!-- completed: 2026-02-13T14:30 -->`
+> When completing a task, check the box and record the timestamp in the same edit.
+
+### Step 1: Documentation
+
+- [x] Update `docs/spec/cli-options.md` § `member delete` default-path description (~line 560): replace "sends `/exit` via `tmux send-keys`" with the three-invocation sequence (literal `/exit`, 0.12 s gap, Enter, 0.12 s gap, trailing Enter) and a one-line rationale (opencode slash-popup settle; trailing Enter harmless on claude/codex) <!-- completed: 2026-06-12T10:35 -->
+- [x] Update `docs/concepts/member-lifecycle.md` default-path wording (~line 57) if it implies a single fused keystroke; keep the altitude conceptual <!-- completed: 2026-06-12T10:35 -->
+
+### Step 2: Code
+
+- [ ] Add `timeout: float | None = None` pass-through to `_run_tolerating_pane_gone` <!-- completed: -->
+- [ ] Add `ignore_missing: bool = False` to `_send_literal_then_enter` and route both invocations through `_run_tolerating_pane_gone` <!-- completed: -->
+- [ ] Rewrite `send_exit` per the Specification (helper call + delayed trailing tolerant Enter) <!-- completed: -->
+- [ ] Extend the `_SUBMIT_DELAY` comment to cover the opencode slash-popup settle case alongside codex bracketed-paste <!-- completed: -->
+
+### Step 3: Tests
+
+- [ ] Rework `test_send_exit__success_and_ignore_missing_semantics` in `tests/multiplexer/test_tmux.py`: assert the three-invocation argv sequence (`-l /exit`, `Enter`, `Enter`), per-invocation pane-gone tolerance with `ignore_missing=True` (including pane dying mid-sequence), propagation of non-pane-gone errors, and propagation of pane-gone with `ignore_missing=False`; monkeypatch `time.sleep` to avoid real delays <!-- completed: -->
+- [ ] Add `_send_literal_then_enter` `ignore_missing` coverage: default `False` still raises on pane-gone (existing caller behavior pinned); `True` swallows pane-gone on either invocation <!-- completed: -->
+- [ ] Confirm `tests/cli/test_member_delete.py` and `tests/cli/test_member.py` still pass — they mock `send_exit` at method level and assert kwargs only, so no changes are expected <!-- completed: -->
+- [ ] Run `mise //cafleet:test`, `mise //cafleet:lint`, `mise //cafleet:typecheck` <!-- completed: -->
+
+### Step 4: Live verification (one member per backend)
+
+- [ ] claude: `cafleet member create` + default `cafleet member delete` exits 0 <!-- completed: -->
+- [ ] codex: `cafleet member create` + default `cafleet member delete` exits 0 <!-- completed: -->
+- [ ] opencode: `cafleet member create` + default `cafleet member delete` exits 0 without `--force` <!-- completed: -->
+
+---
+
+## Changelog
+
+| Date | Changes |
+|------|---------|
+| 2026-06-12 | Initial draft |

--- a/design-docs/0000086-opencode-send-exit-keystroke-race/prompts/drafter-20260612T101600Z.md
+++ b/design-docs/0000086-opencode-send-exit-keystroke-race/prompts/drafter-20260612T101600Z.md
@@ -1,0 +1,24 @@
+You are the Drafter in a design document creation team (CAFleet-native).
+
+ROLE DEFINITION: Open /home/himkt/.claude/skills/cafleet-design-doc-create/roles/drafter.md with the Read tool BEFORE any other action. That file is your authoritative role definition. Re-read it whenever you are unsure of protocol.
+
+Load these skills at startup:
+- the `cafleet` skill — for communication with the Director
+- the `cafleet-design-doc` skill — for template and guidelines
+
+FLEET ID: {fleet_id}
+DIRECTOR AGENT ID: {director_agent_id}
+YOUR AGENT ID: {agent_id}
+BASE: /home/himkt/work/himkt/cafleet/design-docs/0000086-opencode-send-exit-keystroke-race
+OUTPUT PATH: /home/himkt/work/himkt/cafleet/design-docs/0000086-opencode-send-exit-keystroke-race/design-doc.md
+
+The user's request: Fix the cafleet member delete /exit keystroke race on the opencode backend. TmuxMultiplexer.send_exit (cafleet/src/cafleet/multiplexer/tmux.py:137) sends "/exit" and Enter in a single fused tmux send-keys call with zero delay. opencode's TUI opens a slash-command autocomplete popup on "/" and the immediate Enter is consumed before the input state settles, so the command never submits, the pane stays alive, wait_for_pane_gone times out after 15 s, and member delete exits 2 (forcing operators to rerun with --force). Reproduced live on 2026-06-12 (fleets 31 and 32): the default delete timed out with the popup open and "/exit" unsubmitted in the input line; a single bare Enter sent afterwards exited opencode immediately. The fix sequence was validated by hand: literal-mode text (tmux send-keys -l "/exit") followed by a separate delayed Enter exits opencode cleanly on the FIRST Enter — two Enters are NOT required. Proposed direction: route send_exit through the existing _send_literal_then_enter helper (literal -l send, _SUBMIT_DELAY 0.12 s, separate Enter), extending pane-gone tolerance (ignore_missing via _run_tolerating_pane_gone) to both tmux invocations — e.g. add an ignore_missing parameter to _send_literal_then_enter. Constraint: _run_tolerating_pane_gone must NOT be removed — kill_pane (member delete --force idempotency contract) and all three send_exit call sites (cli/member.py:215 and :223 create-rollback paths; :302 default delete of a possibly-crashed member) depend on it. Open question to settle in the doc: whether _SUBMIT_DELAY 0.12 s is sufficient for opencode's popup render (the hand test used multi-second gaps); mitigation options include bumping the delay for the exit path or sending a trailing second Enter (harmless on claude/codex). Verification criteria: after the change, a real opencode member must be deletable via the default cafleet member delete path with exit 0 (no --force), and the claude and codex backends must keep working with the new keystroke sequence. Tests under cafleet/tests covering send_exit / member delete must be updated accordingly.
+
+COMMUNICATION PROTOCOL:
+- Report to Director: cafleet --fleet-id {fleet_id} message send --agent-id {agent_id} --to {director_agent_id} --text "your report"
+- When you see cafleet message poll output with a message from the Director, act on those instructions.
+
+IMPORTANT: You MUST ask clarifying questions BEFORE writing any design document file.
+Send your questions to the Director who will relay them to the user.
+Start by reading the target codebase for context, then send your clarifying questions.
+Do NOT create any design document file until you have received answers.

--- a/design-docs/0000086-opencode-send-exit-keystroke-race/prompts/programmer-20260612T103330Z.md
+++ b/design-docs/0000086-opencode-send-exit-keystroke-race/prompts/programmer-20260612T103330Z.md
@@ -1,0 +1,23 @@
+You are the Programmer in a design document execution team (CAFleet-native).
+
+ROLE DEFINITION: Open /home/himkt/.claude/skills/cafleet-design-doc-execute/roles/programmer.md with the Read tool BEFORE any other action. That file is your authoritative role definition. Re-read it whenever you are unsure of protocol.
+
+Load these skills at startup:
+- the `cafleet` skill — for communication with the Director
+- the `cafleet-design-doc` skill — for template and guidelines
+
+FLEET ID: {fleet_id}
+DIRECTOR AGENT ID: {director_agent_id}
+YOUR AGENT ID: {agent_id}
+BASE: /home/himkt/work/himkt/cafleet/design-docs/0000086-opencode-send-exit-keystroke-race
+DESIGN DOCUMENT: /home/himkt/work/himkt/cafleet/design-docs/0000086-opencode-send-exit-keystroke-race/design-doc.md
+
+COMMUNICATION PROTOCOL:
+- Report to Director: cafleet --fleet-id {fleet_id} message send --agent-id {agent_id} --to {director_agent_id} --text "your report"
+- When you see cafleet message poll output with a message from the Director, act on those instructions.
+
+IMPORTANT: Do NOT commit code yourself. The Director handles all git operations.
+IMPORTANT: If blocked, send a message to the Director immediately instead of assuming.
+IMPORTANT: Read and follow .claude/rules/bash-tool.md (CAFleet-member Bash protocol) and ~/.claude/rules/bash-command.md (general Bash hygiene) for all Bash commands.
+
+Start by reading the design document. Then wait for the Director to assign your first step.

--- a/design-docs/0000086-opencode-send-exit-keystroke-race/prompts/reviewer-20260612T101600Z.md
+++ b/design-docs/0000086-opencode-send-exit-keystroke-race/prompts/reviewer-20260612T101600Z.md
@@ -1,0 +1,19 @@
+You are the Reviewer in a design document creation team (CAFleet-native).
+
+ROLE DEFINITION: Open /home/himkt/.claude/skills/cafleet-design-doc-create/roles/reviewer.md with the Read tool BEFORE any other action. That file is your authoritative role definition. Re-read it whenever you are unsure of protocol.
+
+Load these skills at startup:
+- the `cafleet` skill — for communication with the Director
+- the `cafleet-design-doc` skill — for template and guidelines
+
+FLEET ID: {fleet_id}
+DIRECTOR AGENT ID: {director_agent_id}
+YOUR AGENT ID: {agent_id}
+BASE: /home/himkt/work/himkt/cafleet/design-docs/0000086-opencode-send-exit-keystroke-race
+DESIGN DOCUMENT: /home/himkt/work/himkt/cafleet/design-docs/0000086-opencode-send-exit-keystroke-race/design-doc.md
+
+COMMUNICATION PROTOCOL:
+- Report to Director: cafleet --fleet-id {fleet_id} message send --agent-id {agent_id} --to {director_agent_id} --text "your report"
+- When you see cafleet message poll output with a message from the Director, act on those instructions.
+
+Wait for the Director to assign a document for review (cafleet body: `ready (doc)`). When you receive that message, the `doc` pointer refers to the DESIGN DOCUMENT path above — read that file and provide specific, actionable feedback per the role definition.

--- a/design-docs/0000086-opencode-send-exit-keystroke-race/prompts/tester-20260612T103330Z.md
+++ b/design-docs/0000086-opencode-send-exit-keystroke-race/prompts/tester-20260612T103330Z.md
@@ -1,0 +1,24 @@
+You are the Tester in a design document execution team (CAFleet-native).
+
+ROLE DEFINITION: Open /home/himkt/.claude/skills/cafleet-design-doc-execute/roles/tester.md with the Read tool BEFORE any other action. That file is your authoritative role definition. Re-read it whenever you are unsure of protocol.
+
+Load these skills at startup:
+- the `cafleet` skill — for communication with the Director
+- the `cafleet-design-doc` skill — for template and guidelines
+
+FLEET ID: {fleet_id}
+DIRECTOR AGENT ID: {director_agent_id}
+YOUR AGENT ID: {agent_id}
+BASE: /home/himkt/work/himkt/cafleet/design-docs/0000086-opencode-send-exit-keystroke-race
+DESIGN DOCUMENT: /home/himkt/work/himkt/cafleet/design-docs/0000086-opencode-send-exit-keystroke-race/design-doc.md
+
+COMMUNICATION PROTOCOL:
+- Report to Director: cafleet --fleet-id {fleet_id} message send --agent-id {agent_id} --to {director_agent_id} --text "your report"
+- When you see cafleet message poll output with a message from the Director, act on those instructions.
+
+IMPORTANT: Do NOT commit code yourself. The Director handles all git operations.
+IMPORTANT: Do NOT write implementation code — only test code.
+IMPORTANT: If blocked, send a message to the Director immediately instead of assuming.
+IMPORTANT: Read and follow .claude/rules/bash-tool.md (CAFleet-member Bash protocol) and ~/.claude/rules/bash-command.md (general Bash hygiene) for all Bash commands.
+
+Start by reading the design document. Then wait for the Director to assign your first step.

--- a/design-docs/0000086-opencode-send-exit-keystroke-race/prompts/verifier-20260612T103330Z.md
+++ b/design-docs/0000086-opencode-send-exit-keystroke-race/prompts/verifier-20260612T103330Z.md
@@ -1,0 +1,26 @@
+You are the Verifier in a design document execution team (CAFleet-native).
+
+ROLE DEFINITION: Open /home/himkt/.claude/skills/cafleet-design-doc-execute/roles/verifier.md with the Read tool BEFORE any other action. That file is your authoritative role definition. Re-read it whenever you are unsure of protocol.
+
+Load these skills at startup:
+- the `cafleet` skill — for communication with the Director
+- the `cafleet-design-doc` skill — for template and guidelines
+
+FLEET ID: {fleet_id}
+DIRECTOR AGENT ID: {director_agent_id}
+YOUR AGENT ID: {agent_id}
+BASE: /home/himkt/work/himkt/cafleet/design-docs/0000086-opencode-send-exit-keystroke-race
+DESIGN DOCUMENT: /home/himkt/work/himkt/cafleet/design-docs/0000086-opencode-send-exit-keystroke-race/design-doc.md
+
+COMMUNICATION PROTOCOL:
+- Report to Director: cafleet --fleet-id {fleet_id} message send --agent-id {agent_id} --to {director_agent_id} --text "your report"
+- When you see cafleet message poll output with a message from the Director, act on those instructions.
+
+IMPORTANT: Do NOT commit code or modify implementation/test files.
+IMPORTANT: If blocked, send a message to the Director immediately instead of assuming.
+IMPORTANT: Read and follow .claude/rules/bash-tool.md (CAFleet-member Bash protocol) and ~/.claude/rules/bash-command.md (general Bash hygiene) for all Bash commands.
+
+Verification context for this design doc: Step 4 (live verification) requires spawning one member per backend (claude, codex, opencode) and confirming the default cafleet member delete path exits 0 without --force. You may create a dedicated test fleet with cafleet fleet create from your own pane for this purpose; tear it down completely afterwards (member delete each member, then fleet delete).
+
+Start by reading the design document and discovering available tools.
+Then wait for the Director to assign your first verification task.

--- a/docs/concepts/member-lifecycle.md
+++ b/docs/concepts/member-lifecycle.md
@@ -54,10 +54,11 @@ created without stealing focus, so the Director's active window is unchanged.
 
 ## Delete ordering
 
-Default path: send `/exit`, poll `list-panes` until the pane disappears
-(15 s timeout), then deregister. On timeout, capture the pane tail and fail
-loudly with exit code 2; the operator reruns with `--force` for an atomic
-kill+deregister.
+Default path: type `/exit` and submit it (separate keystrokes with short
+settle gaps, so every backend's input line registers the command before
+Enter), poll `list-panes` until the pane disappears (15 s timeout), then
+deregister. On timeout, capture the pane tail and fail loudly with exit
+code 2; the operator reruns with `--force` for an atomic kill+deregister.
 
 ## Spawn-prompt input modes
 

--- a/docs/concepts/member-lifecycle.md
+++ b/docs/concepts/member-lifecycle.md
@@ -54,8 +54,8 @@ created without stealing focus, so the Director's active window is unchanged.
 
 ## Delete ordering
 
-Default path: type `/exit` and submit it (separate keystrokes with short
-settle gaps, so every backend's input line registers the command before
+Default path: type `/exit` and submit it (separate keystrokes with a short
+settle gap, so every backend's input line registers the command before
 Enter), poll `list-panes` until the pane disappears (15 s timeout), then
 deregister. On timeout, capture the pane tail and fail loudly with exit
 code 2; the operator reruns with `--force` for an atomic kill+deregister.

--- a/docs/spec/cli-options.md
+++ b/docs/spec/cli-options.md
@@ -557,7 +557,7 @@ The only boundary is fleet isolation: a `--member-id` that does not belong to `-
 
 #### Polling contract (default path)
 
-The default path sends `/exit` via `tmux send-keys`, then polls `tmux list-panes -a -F "#{pane_id}"` for the target pane every **500 ms** until the pane disappears or a **15.0 s** timeout elapses. A typical coding-agent `/exit` completes in 1–3 s; operators who need faster escalation pass `--force`. On timeout, the pane buffer tail (last 80 lines) is captured via `tmux capture-pane` and printed on stderr, followed by a recovery hint, and the command exits **2**. The timeout output shape:
+The default path sends `/exit` as three separate `tmux send-keys` invocations — literal `/exit` (`-l`), a 0.12 s gap, Enter, another 0.12 s gap, then a trailing Enter — because opencode's slash-command autocomplete popup needs the gap to settle before Enter submits; the trailing Enter covers a slow popup render and is harmless on claude/codex. It then polls `tmux list-panes -a -F "#{pane_id}"` for the target pane every **500 ms** until the pane disappears or a **15.0 s** timeout elapses. A typical coding-agent `/exit` completes in 1–3 s; operators who need faster escalation pass `--force`. On timeout, the pane buffer tail (last 80 lines) is captured via `tmux capture-pane` and printed on stderr, followed by a recovery hint, and the command exits **2**. The timeout output shape:
 
 ```
 Error: pane %7 did not close within 15.0s after /exit.

--- a/docs/spec/cli-options.md
+++ b/docs/spec/cli-options.md
@@ -557,7 +557,7 @@ The only boundary is fleet isolation: a `--member-id` that does not belong to `-
 
 #### Polling contract (default path)
 
-The default path sends `/exit` as three separate `tmux send-keys` invocations — literal `/exit` (`-l`), a 0.12 s gap, Enter, another 0.12 s gap, then a trailing Enter — because opencode's slash-command autocomplete popup needs the gap to settle before Enter submits; the trailing Enter covers a slow popup render and is harmless on claude/codex. It then polls `tmux list-panes -a -F "#{pane_id}"` for the target pane every **500 ms** until the pane disappears or a **15.0 s** timeout elapses. A typical coding-agent `/exit` completes in 1–3 s; operators who need faster escalation pass `--force`. On timeout, the pane buffer tail (last 80 lines) is captured via `tmux capture-pane` and printed on stderr, followed by a recovery hint, and the command exits **2**. The timeout output shape:
+The default path sends `/exit` as two separate `tmux send-keys` invocations — literal `/exit` (`-l`), a 0.12 s gap, then Enter — because opencode's slash-command autocomplete popup needs the gap to settle before Enter submits. It then polls `tmux list-panes -a -F "#{pane_id}"` for the target pane every **500 ms** until the pane disappears or a **15.0 s** timeout elapses. A typical coding-agent `/exit` completes in 1–3 s; operators who need faster escalation pass `--force`. On timeout, the pane buffer tail (last 80 lines) is captured via `tmux capture-pane` and printed on stderr, followed by a recovery hint, and the command exits **2**. The timeout output shape:
 
 ```
 Error: pane %7 did not close within 15.0s after /exit.


### PR DESCRIPTION
- **docs: describe three-invocation member delete exit keystroke sequence**
- **test: add tests for three-invocation send_exit and ignore_missing semantics**
- **feat: route send_exit through literal-then-enter helper with trailing tolerant Enter**
- **docs: check off Step 3 test tasks in design doc 0000086**
- **docs: revise design doc 0000086 to delay-only two-invocation exit sequence**
- **test: rework send_exit expectations to two-invocation delay-only sequence**
- **feat: collapse send_exit to a single literal-then-enter call**
- **docs: check off verified success criteria and reopened tasks for 0000086**
