### PR TITLE
feat/0000105 restore workflow auto invocation

### DIFF
--- a/design-docs/0000105-restore-workflow-auto-invocation/design-doc.md
+++ b/design-docs/0000105-restore-workflow-auto-invocation/design-doc.md
@@ -1,6 +1,6 @@
 # Restore Workflow Auto-Invocation for the CAFleet Design-Doc and Research Skills
 
-**Status**: Approved
+**Status**: Complete
 **Progress**: 11/11 tasks complete
 **Last Updated**: 2026-06-21
 
@@ -151,3 +151,4 @@ The intro paragraph, the coding-agent-overlay note, and the teammates-load-by-na
 |------|---------|
 | 2026-06-21 | Initial draft |
 | 2026-06-21 | Reviewer round 1: triggers lead both descriptions (orchestration mechanics moved to body only); added behavioral-validation gate (Step 4); recorded rationale for affirmative-only vs. the rule-endorsed paired form; preserved the research chaining-context sentence; stated the frontmatter preservation invariant (corrected — no `metadata` block in the on-disk source). |
+| 2026-06-21 | Execution complete (Steps 1–4): both `SKILL.md` rewritten; drift audit found no doc edits; behavioral gate passed after `gh skill install` deploy (both skills auto-invoke and route monitor-first from non-cafleet prompts). Opus review round (ship-as-is + closing-line tightening). Copilot review on PR #138: applied the quality-loop wording generalization; declined 4 stylistic nits as out-of-spec; loop ended by user termination. |

--- a/design-docs/0000105-restore-workflow-auto-invocation/design-doc.md
+++ b/design-docs/0000105-restore-workflow-auto-invocation/design-doc.md
@@ -1,7 +1,7 @@
 # Restore Workflow Auto-Invocation for the CAFleet Design-Doc and Research Skills
 
 **Status**: Approved
-**Progress**: 9/11 tasks complete
+**Progress**: 10/11 tasks complete
 **Last Updated**: 2026-06-21
 
 ## Overview
@@ -134,7 +134,7 @@ The intro paragraph, the coding-agent-overlay note, and the teammates-load-by-na
 
 ### Step 3: Drift audit (docs)
 
-- [ ] Re-read both rewritten `SKILL.md` files and confirm: triggers lead the description, language is affirmative-only, dispatch is scenario-linked, and the full-team statement is present in the body. Then audit `README.md`, `docs/get-started/*`, and `docs/how-to/design-doc-development.md` for trigger-statement drift; edit a doc only if it actually drifted (expectation: no edits needed, since those surfaces reference the skills by name and by workflow). <!-- completed: -->
+- [x] Re-read both rewritten `SKILL.md` files and confirm: triggers lead the description, language is affirmative-only, dispatch is scenario-linked, and the full-team statement is present in the body. Then audit `README.md`, `docs/get-started/*`, and `docs/how-to/design-doc-development.md` for trigger-statement drift; edit a doc only if it actually drifted (expectation: no edits needed, since those surfaces reference the skills by name and by workflow). <!-- completed: 2026-06-21T05:36 -->
 
 ### Step 4: Behavioral validation (gate for completion)
 

--- a/design-docs/0000105-restore-workflow-auto-invocation/design-doc.md
+++ b/design-docs/0000105-restore-workflow-auto-invocation/design-doc.md
@@ -1,7 +1,7 @@
 # Restore Workflow Auto-Invocation for the CAFleet Design-Doc and Research Skills
 
 **Status**: Approved
-**Progress**: 10/11 tasks complete
+**Progress**: 11/11 tasks complete
 **Last Updated**: 2026-06-21
 
 ## Overview
@@ -10,14 +10,14 @@ The `cafleet-design-doc` and `cafleet-research` umbrella skills no longer reliab
 
 ## Success Criteria
 
-- [ ] Each umbrella `SKILL.md` frontmatter `description` leads with crisp, scenario-keyed triggers phrased in the user's own likely wording, so the coding agent auto-invokes the skill without an explicit "use cafleet" instruction.
-- [ ] **Behavioral validation passes**: in a fresh coding-agent session, a triggering prompt that does NOT mention cafleet (e.g. "create a design doc for X", "research topic Y") causes the agent to (a) auto-invoke the matching skill and (b) route into the workflow such that the dedicated monitoring member is spawned first-in. This behavioral outcome — not a structural re-read — is the gate for marking the work complete.
-- [ ] Each `SKILL.md` body presents an **imperative, scenario-linked dispatch** that names, for each scenario, the affirmative action (invoke this skill and run the matching workflow as a full CAFleet team) and the link to the workflow body.
-- [ ] Both `SKILL.md` files state affirmatively that routing into a workflow means executing its **entire** orchestration: the dedicated monitoring member spawned first-in, then the role team, then the message-broker quality loop — so the "full orchestration once entered" half of the bug is addressed at the dispatch point.
-- [ ] All trigger and dispatch language is **affirmative-only** (positive spec, no named "Do NOT write directly / Do NOT use EnterPlanMode / Do NOT web-search-and-summarize" prohibitions), per `affirmative-writing.md`.
-- [ ] The base instructions stay backend-neutral: the coding-agent overlay note and the "teammates load this skill by its name … via their backend's skill-loader" note are retained unchanged in intent, per `.claude/rules/coding-agent-overlay.md`.
-- [ ] The fix surface is the **two `SKILL.md` files only** — no workflow body (`create`/`execute`/`interview`/`report`/`presentation`), no role file, and no `reference/*` page is modified.
-- [ ] No documentation drift: `README.md`, `docs/get-started/*`, and `docs/how-to/design-doc-development.md` continue to describe the skills accurately after the rewrite; a doc is edited only if a trigger statement in it actually drifts.
+- [x] Each umbrella `SKILL.md` frontmatter `description` leads with crisp, scenario-keyed triggers phrased in the user's own likely wording, so the coding agent auto-invokes the skill without an explicit "use cafleet" instruction.
+- [x] **Behavioral validation passes**: in a fresh coding-agent session, a triggering prompt that does NOT mention cafleet (e.g. "create a design doc for X", "research topic Y") causes the agent to (a) auto-invoke the matching skill and (b) route into the workflow such that the dedicated monitoring member is spawned first-in. This behavioral outcome — not a structural re-read — is the gate for marking the work complete.
+- [x] Each `SKILL.md` body presents an **imperative, scenario-linked dispatch** that names, for each scenario, the affirmative action (invoke this skill and run the matching workflow as a full CAFleet team) and the link to the workflow body.
+- [x] Both `SKILL.md` files state affirmatively that routing into a workflow means executing its **entire** orchestration: the dedicated monitoring member spawned first-in, then the role team, then the message-broker quality loop — so the "full orchestration once entered" half of the bug is addressed at the dispatch point.
+- [x] All trigger and dispatch language is **affirmative-only** (positive spec, no named "Do NOT write directly / Do NOT use EnterPlanMode / Do NOT web-search-and-summarize" prohibitions), per `affirmative-writing.md`.
+- [x] The base instructions stay backend-neutral: the coding-agent overlay note and the "teammates load this skill by its name … via their backend's skill-loader" note are retained unchanged in intent, per `.claude/rules/coding-agent-overlay.md`.
+- [x] The fix surface is the **two `SKILL.md` files only** — no workflow body (`create`/`execute`/`interview`/`report`/`presentation`), no role file, and no `reference/*` page is modified.
+- [x] No documentation drift: `README.md`, `docs/get-started/*`, and `docs/how-to/design-doc-development.md` continue to describe the skills accurately after the rewrite; a doc is edited only if a trigger statement in it actually drifts.
 
 ## Background
 
@@ -138,7 +138,12 @@ The intro paragraph, the coding-agent-overlay note, and the teammates-load-by-na
 
 ### Step 4: Behavioral validation (gate for completion)
 
-- [ ] In a fresh coding-agent session, issue a triggering prompt for each skill that does NOT mention cafleet — e.g. "create a design doc for <X>" and "research <Y>" — and confirm the agent (a) auto-invokes the matching skill and (b) routes into the workflow such that the dedicated monitoring member is the first `cafleet member create`. Record the outcome. This behavioral pass — not the Step 3 structural re-read — is what authorizes marking the design complete. <!-- completed: -->
+- [x] In a fresh coding-agent session, issue a triggering prompt for each skill that does NOT mention cafleet — e.g. "create a design doc for <X>" and "research <Y>" — and confirm the agent (a) auto-invokes the matching skill and (b) routes into the workflow such that the dedicated monitoring member is the first `cafleet member create`. Record the outcome. This behavioral pass — not the Step 3 structural re-read — is what authorizes marking the design complete. <!-- completed: 2026-06-21T06:03 -->
+
+**Step 4 outcome (recorded).** Prerequisite caught during execution: the repo `SKILL.md` edits are not loaded by agents until synced to `~/.claude/skills/` via `gh skill install` (`mise //:skill-install`). The validation below was run only after that deploy, against the live new descriptions. Two fresh coding-agent sessions were issued non-cafleet triggering prompts ("create a design doc for a per-client rate-limiting feature" and "create a multi-source research report on WebAssembly component model adoption"):
+
+> - **design-doc**: auto-invoked `cafleet-design-doc` from the bare prompt → create workflow; confirmed the first `cafleet member create` is the monitoring member (`--role monitor --model haiku`) gating the Drafter/Reviewer. No "use cafleet" cue needed; the agent cited the new dispatch line "without waiting for the user to say 'use cafleet'".
+> - **research**: saw both `cafleet-research` and the competing generic `deep-research`, and chose `cafleet-research` on the trigger match → report workflow; confirmed the first `cafleet member create` is the monitoring member (`--role monitor --model haiku`) gating all spawns. No "use cafleet" cue needed.
 
 ## Changelog
 

--- a/design-docs/0000105-restore-workflow-auto-invocation/design-doc.md
+++ b/design-docs/0000105-restore-workflow-auto-invocation/design-doc.md
@@ -1,7 +1,7 @@
 # Restore Workflow Auto-Invocation for the CAFleet Design-Doc and Research Skills
 
 **Status**: Approved
-**Progress**: 4/11 tasks complete
+**Progress**: 9/11 tasks complete
 **Last Updated**: 2026-06-21
 
 ## Overview
@@ -126,11 +126,11 @@ The intro paragraph, the coding-agent-overlay note, and the teammates-load-by-na
 
 ### Step 2: Rewrite `cafleet-research/SKILL.md`
 
-- [ ] Replace the frontmatter `description` with the affirmative, scenario-keyed, trigger-leading text per the Specification, applying the frontmatter preservation invariant from Step 1. <!-- completed: -->
-- [ ] Replace the passive "## When to use" table with the imperative scenario-linked dispatch section (team workflows table + utility references), including the "routing = full team orchestration" statement for the report and presentation workflows. <!-- completed: -->
-- [ ] Fold the preserved research chaining-context sentence in under the dispatch tables (per Specification § Preserve the research chaining context). <!-- completed: -->
-- [ ] Convert the residual "Do NOT do a quick web search and summarize — route through the workflows above" phrasing to its affirmative equivalent and remove the prohibition phrasing. <!-- completed: -->
-- [ ] Confirm the coding-agent-overlay note and the members-load-by-name note are retained and unchanged in intent. <!-- completed: -->
+- [x] Replace the frontmatter `description` with the affirmative, scenario-keyed, trigger-leading text per the Specification, applying the frontmatter preservation invariant from Step 1. <!-- completed: 2026-06-21T05:34 -->
+- [x] Replace the passive "## When to use" table with the imperative scenario-linked dispatch section (team workflows table + utility references), including the "routing = full team orchestration" statement for the report and presentation workflows. <!-- completed: 2026-06-21T05:34 -->
+- [x] Fold the preserved research chaining-context sentence in under the dispatch tables (per Specification § Preserve the research chaining context). <!-- completed: 2026-06-21T05:34 -->
+- [x] Convert the residual "Do NOT do a quick web search and summarize — route through the workflows above" phrasing to its affirmative equivalent and remove the prohibition phrasing. <!-- completed: 2026-06-21T05:34 -->
+- [x] Confirm the coding-agent-overlay note and the members-load-by-name note are retained and unchanged in intent. <!-- completed: 2026-06-21T05:34 -->
 
 ### Step 3: Drift audit (docs)
 

--- a/design-docs/0000105-restore-workflow-auto-invocation/design-doc.md
+++ b/design-docs/0000105-restore-workflow-auto-invocation/design-doc.md
@@ -1,0 +1,148 @@
+# Restore Workflow Auto-Invocation for the CAFleet Design-Doc and Research Skills
+
+**Status**: Approved
+**Progress**: 4/11 tasks complete
+**Last Updated**: 2026-06-21
+
+## Overview
+
+The `cafleet-design-doc` and `cafleet-research` umbrella skills no longer reliably auto-invoke: a coding agent reading them is not compelled to (a) enter the matching team workflow when the user asks for the matching task, nor (b) run the full CAFleet team orchestration once entered. This design rewrites the two umbrella `SKILL.md` entry points so an agent reliably invokes the matching workflow and executes its full team — **without the user having to say "use cafleet"** — restoring the trigger strength the pre-collapse constellation skills had, while keeping the consolidated two-skill structure and the current monitoring-member mechanism intact.
+
+## Success Criteria
+
+- [ ] Each umbrella `SKILL.md` frontmatter `description` leads with crisp, scenario-keyed triggers phrased in the user's own likely wording, so the coding agent auto-invokes the skill without an explicit "use cafleet" instruction.
+- [ ] **Behavioral validation passes**: in a fresh coding-agent session, a triggering prompt that does NOT mention cafleet (e.g. "create a design doc for X", "research topic Y") causes the agent to (a) auto-invoke the matching skill and (b) route into the workflow such that the dedicated monitoring member is spawned first-in. This behavioral outcome — not a structural re-read — is the gate for marking the work complete.
+- [ ] Each `SKILL.md` body presents an **imperative, scenario-linked dispatch** that names, for each scenario, the affirmative action (invoke this skill and run the matching workflow as a full CAFleet team) and the link to the workflow body.
+- [ ] Both `SKILL.md` files state affirmatively that routing into a workflow means executing its **entire** orchestration: the dedicated monitoring member spawned first-in, then the role team, then the message-broker quality loop — so the "full orchestration once entered" half of the bug is addressed at the dispatch point.
+- [ ] All trigger and dispatch language is **affirmative-only** (positive spec, no named "Do NOT write directly / Do NOT use EnterPlanMode / Do NOT web-search-and-summarize" prohibitions), per `affirmative-writing.md`.
+- [ ] The base instructions stay backend-neutral: the coding-agent overlay note and the "teammates load this skill by its name … via their backend's skill-loader" note are retained unchanged in intent, per `.claude/rules/coding-agent-overlay.md`.
+- [ ] The fix surface is the **two `SKILL.md` files only** — no workflow body (`create`/`execute`/`interview`/`report`/`presentation`), no role file, and no `reference/*` page is modified.
+- [ ] No documentation drift: `README.md`, `docs/get-started/*`, and `docs/how-to/design-doc-development.md` continue to describe the skills accurately after the rewrite; a doc is edited only if a trigger statement in it actually drifts.
+
+## Background
+
+### Current state
+
+The two umbrella skills are thin dispatchers. Each `SKILL.md` consists of an intro paragraph, a coding-agent-overlay note, a "teammates load by name" note, and a passive **"## When to use"** routing table that maps "You want to… → Go to <link>". The detailed workflow bodies (`create/create.md`, `execute/execute.md`, `interview/interview.md`, `report/report.md`, `presentation/presentation.md`) and the role files are correct and complete — including the current, correct orchestration mechanism in which the **first** `cafleet member create` is the dedicated monitoring member (`--role monitor`, running `cafleet monitor start`), which gates the rest of the team behind its `ready: monitor live` handshake.
+
+### How the regression was introduced
+
+At reference commit `9eed5bb` the design-doc and research skills were a **constellation** of separate, single-purpose auto-triggering skills, each with a crisp imperative `description` that named both the trigger and the desired behavior. Verified examples:
+
+- `cafleet-design-doc-create`: *"Create a new design document using CAFleet-native orchestration (Director/Drafter/Reviewer team). Use when the user asks to create a design doc, design document, specification, or technical spec. Do NOT write the doc directly with Write or use EnterPlanMode — always invoke this skill."*
+- `cafleet-design-doc-execute`: *"Implement features based on a design document… Use when the user asks to implement or execute a design document. … Do NOT implement a design document by reading it and coding manually — always invoke this skill instead."*
+- `cafleet-design-doc-interview`: *"Validate an existing design document through fine-grained multi-round Q&A… Use after the cafleet-design-doc-create skill and before the cafleet-design-doc-execute skill. … Do NOT use this to create or execute design documents — use the dedicated skills instead."*
+- `cafleet-research-report`: *"Create a comprehensive research report… Do NOT do a quick web search and summarize — invoke this skill for thorough, multi-source research."*
+- `cafleet-research-presentation`: *"Create a Slidev presentation and reading transcript from an existing research report folder… Do NOT use for research — use the cafleet-research-report skill for that."*
+
+Designs 0000103 and 0000104 collapsed that constellation into the current two umbrella dispatchers. The collapse was intentional and is **not** being reverted; it removed skill-list clutter and centralized routing. The unintended side effect is that the per-workflow imperative trigger language no longer lives where the agent first reads it. The umbrella `description` now spans three (design-doc) or four (research) scenarios at once, and the entry-point body is a passive routing table. The result, observed in practice: agents write design docs or do research freeform, with no monitoring member and no team.
+
+### What is in scope vs. not
+
+- **In scope**: the entry-point trigger and dispatch language in `skills/cafleet-design-doc/SKILL.md` and `skills/cafleet-research/SKILL.md`.
+- **Not in scope** (confirmed with the user): re-expanding to a constellation; modifying any workflow body, role file, or `reference/*` page; the monitoring mechanism (current and correct); and any new `docs/concepts` page.
+
+## Specification
+
+### Design decisions (confirmed with the user)
+
+1. **Keep the two umbrella skills; strengthen them in place.** Rewrite each frontmatter `description` and restructure each `SKILL.md` body so routing is unambiguous and scenario-linked.
+2. **Fix surface = the two `SKILL.md` files only.** Workflow bodies, role files, and `reference/*` pages are untouched. Because the bodies are off-limits, the "execute the full team once entered" imperative is carried at the **dispatch point in `SKILL.md`** (it states that routing into a workflow means running its entire orchestration), rather than by editing the body openings.
+3. **Affirmative-only language.** State the positive spec — *always invoke this skill and route into the matching workflow; routing runs the full CAFleet team*. Do not add named-behavior prohibitions ("Do NOT write directly", "Do NOT use EnterPlanMode", "Do NOT web-search-and-summarize"). The existing residual prohibition phrasings in both files (e.g. *"Do NOT write or implement design docs freeform — route through this skill's workflows"*) are **converted to their affirmative equivalents** and the prohibition phrasing is removed entirely (no deprecation residue, per `removal.md`).
+
+   **Why affirmative-only, not the rule-endorsed paired form.** `affirmative-writing.md` does not ban prohibitions; it explicitly blesses the *paired* form for a genuine hard constraint (*"strongest paired with the affirmative instruction it enforces — 'always use X' alongside 'never use Y'"*), and the empirically-working constellation descriptions used exactly that paired form (*"Do NOT write the doc directly … — always invoke this skill"*). The user nonetheless directed affirmative-only here, so the paired form is set aside by explicit instruction, not because the rule forbids it. The trade-off this records: dropping the rule-blessed prohibition half removes language that demonstrably triggered, so the affirmative half must be made strong and unambiguous enough to carry the trigger on its own (the trigger-leading description of decision below, plus the imperative dispatch and the behavioral-validation gate, are how this design compensates). A future reader should read "affirmative-only" as a deliberate, user-confirmed choice — not as a claim that `affirmative-writing.md` bans prohibitions.
+4. **Backend neutrality preserved.** The trigger and dispatch language is backend-neutral; the coding-agent-overlay note and the teammates-load-by-name note remain. Backend specifics continue to live only in `reference/coding-agent/<name>.md`.
+5. **Minimal docs.** No new `docs/concepts` page. A doc outside the two skills is edited only if a trigger statement in it actually drifts after the rewrite (audit confirms whether any edit is required).
+
+### Target frontmatter `description` — `cafleet-design-doc`
+
+The new `description` **leads with the trigger phrasings** (in the user's likely wording), keyed to each scenario, then states the affirmative directive as a short tag. Per the model the working constellation descriptions used (lead with action+object), the first words after "Use when" are trigger keywords. Orchestration mechanics (monitoring member, role team, quality loop) are deliberately kept OUT of the description and carried only by the body dispatch section (Body structure item 2 below) — the description's job is skill selection, and adding orchestration detail there both lengthens the trigger surface and duplicates the body. Proposed text (the execute team may refine wording within these constraints):
+
+> Use when the user asks to create a design doc, design document, specification, or technical spec (create workflow → Director/Drafter/Reviewer team); to validate, review, or interview an existing design doc through multi-round Q&A (interview workflow); or to implement or execute a design doc (execute workflow → TDD team). Also the standardized format spec — consult the template and guidelines when editing a design doc. Always invoke this skill and route into the matching workflow, orchestrated as a CAFleet team. Teammates in agent teams load this skill by its name cafleet-design-doc via their backend's skill-loader.
+
+### Target frontmatter `description` — `cafleet-research`
+
+Same construction: triggers lead, the "always invoke / CAFleet team" framing follows as a short tag, and orchestration mechanics live only in the body dispatch.
+
+> Use when the user asks to research a topic or create a multi-source research report (report workflow → Director/Manager/Researcher team writing to researches/<topic>/); to build a presentation, slide deck, or reading transcript from a report (presentation workflow); to create a chart, plot, graph, figure, or data visualization (visualization reference); or to author slides with the custom Slidev theme (slidev reference). Always invoke this skill and route into the matching workflow, orchestrated as a CAFleet team. Members in agent teams load this skill by its name cafleet-research via their backend's skill-loader.
+
+### Target `SKILL.md` body structure (both files)
+
+Replace the passive **"## When to use"** table with an imperative, scenario-linked **dispatch** section. The section MUST:
+
+1. Open with an affirmative directive: when the user's request matches a scenario below, invoke this skill and run the linked workflow as a full CAFleet team — proactively, without waiting for the user to say "use cafleet".
+2. State that **routing into a workflow means executing its entire orchestration**: the monitoring member is spawned first-in, then the role team, then the quality loop iterates to approval (the linked body is the authoritative procedure).
+3. Present the scenarios as a table whose rows pair the **user-phrasing trigger** with the **affirmative action + link** (the team workflow), kept separate from a secondary "consult, no team" table for the format/utility reference pages.
+
+Proposed dispatch table for `cafleet-design-doc` (team workflows):
+
+| When the user wants to… | Invoke this skill and run |
+|:--|:--|
+| Create a design doc / specification / technical spec | the **create** workflow ([create/create.md](create/create.md)) — Director/Drafter/Reviewer team |
+| Validate / review / interview an existing design doc | the **interview** workflow ([interview/interview.md](interview/interview.md)) — multi-round Q&A |
+| Implement / execute a design doc | the **execute** workflow ([execute/execute.md](execute/execute.md)) — TDD team |
+
+Secondary "consult (no team)" table for `cafleet-design-doc`: the template, guidelines, and coordination reference pages (unchanged links).
+
+Proposed dispatch table for `cafleet-research` (team workflows + utility references):
+
+| When the user wants to… | Invoke this skill and run |
+|:--|:--|
+| Research a topic / create a multi-source research report | the **report** workflow ([report/report.md](report/report.md)) — Director/Manager/Researcher team → `researches/<topic>/` |
+| Build a presentation / slide deck / reading transcript from a report | the **presentation** workflow ([presentation/presentation.md](presentation/presentation.md)) |
+| Create a chart / plot / graph / figure or visualize data | the **visualization** reference ([reference/visualization.md](reference/visualization.md)) |
+| Author slides with the custom Slidev theme | the **slidev** reference ([reference/slidev.md](reference/slidev.md)) |
+
+**Preserve the research chaining context.** The current `cafleet-research` body carries an informational sentence that is routing context, not a prohibition: *"The report workflow chains into the presentation workflow after user approval. The two reference pages are standalone utilities the presentation workflow also reads."* The restructure MUST preserve this (folded in immediately under the `cafleet-research` dispatch tables) — it tells the agent the two workflows chain and that the reference pages are shared utilities. The `cafleet-design-doc` body has no equivalent sentence, so this applies to the research file only.
+
+The intro paragraph, the coding-agent-overlay note, and the teammates-load-by-name note are retained (the latter two backend-neutral, per the overlay rule). The closing residual-prohibition sentence in each file is converted to an affirmative restatement (e.g. *"Always route design-doc work through the workflow bodies above — each runs the full CAFleet team."*) with the prohibition phrasing removed.
+
+### Why this addresses both halves of the bug
+
+- **Entering the workflow**: the frontmatter `description` now leads with the user's likely phrasings keyed to each scenario, restoring the auto-trigger strength of the constellation while keeping one skill per family.
+- **Full orchestration once entered**: the dispatch section affirmatively equates "routing into a workflow" with "executing its full team orchestration (monitoring member first-in, role team, quality loop)", so an agent that reads the entry point understands that invoking is not freeform writing/researching but running the team defined in the linked body.
+
+### Constraints honored
+
+- `affirmative-writing.md`: affirmative-only positive spec; no reactive prohibition residue.
+- `removal.md`: residual "Do NOT … freeform" phrasings are removed (not deprecated in place) as they are replaced by the affirmative spec.
+- `.claude/rules/coding-agent-overlay.md`: base stays backend-neutral; overlay note retained; no backend specifics added to the base.
+- `design-doc-numbering.md`: `SKILL.md` files are first-class documentation targets and are the documentation updated in this cycle; README/docs are audited for drift in the same cycle.
+
+## Implementation
+
+> Task format: `- [x] Done task <!-- completed: 2026-02-13T14:30 -->`
+> When completing a task, check the box and record the timestamp in the same edit.
+> Per `design-doc-numbering.md`, documentation is updated first. Here the two `SKILL.md` files ARE the documentation-and-artifact target; README/docs are audited for drift in the same cycle.
+
+### Step 1: Rewrite `cafleet-design-doc/SKILL.md`
+
+**Frontmatter preservation invariant (both steps).** Replace ONLY the `description` value; preserve every other frontmatter key verbatim. In the on-disk source files the only other keys are `name` and `allowed-tools` (no `metadata`/`local-path` block is present), but the invariant is stated generally so that any key present at implementation time — including one injected by packaging — survives the description swap untouched.
+
+- [x] Replace the frontmatter `description` with the affirmative, scenario-keyed, trigger-leading text per the Specification, applying the frontmatter preservation invariant above. <!-- completed: 2026-06-21T05:32 -->
+- [x] Replace the passive "## When to use" table with the imperative scenario-linked dispatch section: opening affirmative directive, the "routing = full team orchestration (monitoring member first-in, role team, quality loop)" statement, the team-workflow table, and the secondary consult-only references table. <!-- completed: 2026-06-21T05:32 -->
+- [x] Convert the residual "Do NOT … freeform — route through this skill's workflows" phrasing (frontmatter and body) to its affirmative equivalent and remove the prohibition phrasing. <!-- completed: 2026-06-21T05:32 -->
+- [x] Confirm the coding-agent-overlay note and the teammates-load-by-name note are retained and unchanged in intent. <!-- completed: 2026-06-21T05:32 -->
+
+### Step 2: Rewrite `cafleet-research/SKILL.md`
+
+- [ ] Replace the frontmatter `description` with the affirmative, scenario-keyed, trigger-leading text per the Specification, applying the frontmatter preservation invariant from Step 1. <!-- completed: -->
+- [ ] Replace the passive "## When to use" table with the imperative scenario-linked dispatch section (team workflows table + utility references), including the "routing = full team orchestration" statement for the report and presentation workflows. <!-- completed: -->
+- [ ] Fold the preserved research chaining-context sentence in under the dispatch tables (per Specification § Preserve the research chaining context). <!-- completed: -->
+- [ ] Convert the residual "Do NOT do a quick web search and summarize — route through the workflows above" phrasing to its affirmative equivalent and remove the prohibition phrasing. <!-- completed: -->
+- [ ] Confirm the coding-agent-overlay note and the members-load-by-name note are retained and unchanged in intent. <!-- completed: -->
+
+### Step 3: Drift audit (docs)
+
+- [ ] Re-read both rewritten `SKILL.md` files and confirm: triggers lead the description, language is affirmative-only, dispatch is scenario-linked, and the full-team statement is present in the body. Then audit `README.md`, `docs/get-started/*`, and `docs/how-to/design-doc-development.md` for trigger-statement drift; edit a doc only if it actually drifted (expectation: no edits needed, since those surfaces reference the skills by name and by workflow). <!-- completed: -->
+
+### Step 4: Behavioral validation (gate for completion)
+
+- [ ] In a fresh coding-agent session, issue a triggering prompt for each skill that does NOT mention cafleet — e.g. "create a design doc for <X>" and "research <Y>" — and confirm the agent (a) auto-invokes the matching skill and (b) routes into the workflow such that the dedicated monitoring member is the first `cafleet member create`. Record the outcome. This behavioral pass — not the Step 3 structural re-read — is what authorizes marking the design complete. <!-- completed: -->
+
+## Changelog
+
+| Date | Changes |
+|------|---------|
+| 2026-06-21 | Initial draft |
+| 2026-06-21 | Reviewer round 1: triggers lead both descriptions (orchestration mechanics moved to body only); added behavioral-validation gate (Step 4); recorded rationale for affirmative-only vs. the rule-endorsed paired form; preserved the research chaining-context sentence; stated the frontmatter preservation invariant (corrected — no `metadata` block in the on-disk source). |

--- a/design-docs/0000105-restore-workflow-auto-invocation/prompts/drafter-20260621T043010Z.md
+++ b/design-docs/0000105-restore-workflow-auto-invocation/prompts/drafter-20260621T043010Z.md
@@ -1,0 +1,40 @@
+You are the Drafter in a design document creation team (CAFleet-native).
+
+ROLE DEFINITION: Open /home/himkt/.claude/skills/cafleet-design-doc/create/roles/drafter.md with the Read tool BEFORE any other action. That file is your authoritative role definition. Re-read it whenever you are unsure of protocol.
+
+Load these skills at startup:
+- the cafleet skill — for communication with the Director; also Read its reference/base-dir.md
+- the cafleet-design-doc skill — for the design-doc template and guidelines
+
+FLEET ID: {fleet_id}
+DIRECTOR AGENT ID: {director_agent_id}
+YOUR AGENT ID: {agent_id}
+BASE: /home/himkt/work/himkt/cafleet/design-docs/0000105-restore-workflow-auto-invocation
+CODING AGENT: claude
+OUTPUT PATH: /home/himkt/work/himkt/cafleet/design-docs/0000105-restore-workflow-auto-invocation/design-doc.md
+
+The user's request: The CAFleet design-doc and research skills have regressed. In practice, coding agents no longer reliably (a) invoke these skills' team workflows when the user asks for the matching task, and (b) when a workflow IS entered, actually run the full CAFleet team orchestration (the dedicated monitoring member first-in, the Director/Drafter/Reviewer or Director/Manager/Researcher team, the message-broker quality loop). Instead agents tend to write design docs or do research freeform, with no monitoring and no team. The user is frustrated: "Nothing monitoring happens, nothing design doc process happens."
+
+Root-cause analysis already gathered (verify it, do not just trust it):
+- At reference commit 9eed5bb59195a0354c1d0b3b0aff4d083033b9b2 the skills were a CONSTELLATION of separate auto-triggering skills, each with a crisp imperative description: cafleet-design-doc-create, cafleet-design-doc-execute, cafleet-design-doc-interview, cafleet-research-report, cafleet-research-presentation, cafleet-create-figure, cafleet-my-slidev, plus cafleet, cafleet-agent-team-monitoring, cafleet-agent-team-supervision, cafleet-base-dir. For example cafleet-design-doc-create had description: "Create a new design document using CAFleet-native orchestration (Director/Drafter/Reviewer team). Use when the user asks to create a design doc, design document, specification, or technical spec. Do NOT write the doc directly with Write or use EnterPlanMode — always invoke this skill." cafleet-research-report likewise had a strong "Do NOT do a quick web search and summarize — invoke this skill" trigger.
+- Design docs 0000103 and 0000104 (collapse-skill-constellation-into-cafleet, collapse-design-doc-and-research-skill-constellations) collapsed those many skills into TWO thin umbrella dispatcher skills: cafleet-design-doc and cafleet-research. The umbrella SKILL.md is now a passive "When to use" routing TABLE rather than per-workflow imperative triggers.
+- The collapse is the suspected regression: a passive routing table does not compel the coding agent to (1) recognize the trigger and enter the workflow, nor (2) execute the FULL orchestration once entered. The strong "Do NOT write the doc directly — always invoke" prohibitions and the explicit "spawn the team / monitoring member" imperatives no longer live where the agent first reads them.
+- The monitor MECHANISM itself is NOT the regression and must NOT be reverted: the old /loop-based monitoring evolved (designs 0000087/0000090/0000095/0000096/0000097) into a dedicated monitoring MEMBER spawned first-in via cafleet member create --role monitor, running cafleet monitor start. That is the current, correct mechanism. The bug is that the workflow is never ENTERED, so the monitoring member is never spawned.
+
+Scope of the design doc you will write:
+- Target artifacts: skills/cafleet-design-doc/SKILL.md and skills/cafleet-research/SKILL.md (the two umbrella dispatchers). The workflow BODIES (create/create.md, execute/execute.md, interview/interview.md, report/report.md, presentation/presentation.md) and the role files are already detailed and largely correct — confirm this by reading them. The fix surface is primarily the entry-point SKILL.md files and possibly the opening sections of each workflow body, so that a coding agent reading them is COMPELLED to enter and fully execute the orchestration WITHOUT the user having to explicitly say "use cafleet".
+- CRITICAL user requirement: the design doc MUST include the improvement that makes a coding agent reliably invoke the cafleet workflow WITHOUT explicit instruction. The user explicitly said: "You didn't use cafleet workflow without explicit instructions. Include the improvement to let you use cafleet in a design doc." Treat strengthening auto-invocation (both the frontmatter description triggers AND the in-body imperative-to-execute-the-team language) as a primary, non-negotiable deliverable.
+- Respect the repo rules: removal.md (no deprecation residue; this is improvement not removal, but keep surfaces clean), affirmative-writing.md (prescribe the desired behavior; the strong "always invoke / do NOT freeform" prohibition is legitimate when paired with the affirmative spec), design-doc-numbering.md (documentation-first ordering: docs/concepts, docs/, README.md, every affected SKILL.md updated in the same cycle), and the coding-agent overlay neutrality rule (.claude/rules/coding-agent-overlay.md — base instructions stay backend-neutral, backend specifics live in reference/coding-agent/<name>.md).
+- The design-doc directory is 0000105-restore-workflow-auto-invocation. Write to the OUTPUT PATH above.
+
+Read the actual current files to ground every claim: skills/cafleet-design-doc/SKILL.md, skills/cafleet-research/SKILL.md, both skills' workflow bodies, and how the frontmatter description fields read today versus the reference commit. You may use WebFetch against the raw.githubusercontent.com URLs at commit 9eed5bb to read reference-commit files if helpful.
+
+COMMUNICATION PROTOCOL:
+- Report to Director: cafleet message send --fleet-id {fleet_id} --agent-id {agent_id} --to {director_agent_id} --text "your report or numbered question list"
+- When you see cafleet message poll output with a message from the Director, act on those instructions.
+
+IMPORTANT: You MUST ask clarifying questions BEFORE writing any design document file. Send your questions to the Director who will relay them to the user.
+IMPORTANT: Start by reading the target codebase for context, then send your clarifying questions.
+IMPORTANT: Do NOT create any design document file until you have received answers.
+
+Start by reading the target codebase for context, then send your clarifying questions.

--- a/design-docs/0000105-restore-workflow-auto-invocation/prompts/monitor-20260621T042904Z.md
+++ b/design-docs/0000105-restore-workflow-auto-invocation/prompts/monitor-20260621T042904Z.md
@@ -1,0 +1,22 @@
+You are the Monitoring Member in a design document creation team (CAFleet-native).
+
+ROLE DEFINITION: Open /home/himkt/.claude/skills/cafleet/roles/monitor.md with the Read tool BEFORE any other action. That file is your authoritative role definition. Re-read it whenever you are unsure of protocol.
+
+Load these skills at startup:
+- the cafleet skill — for the broker primitives and the supervision heartbeat
+
+FLEET ID: {fleet_id}
+DIRECTOR AGENT ID: {director_agent_id}
+YOUR AGENT ID: {agent_id}
+BASE: /home/himkt/work/himkt/cafleet/design-docs/0000105-restore-workflow-auto-invocation
+CODING AGENT: {coding_agent}
+
+COMMUNICATION PROTOCOL:
+- Report to Director: cafleet message send --fleet-id {fleet_id} --agent-id {agent_id} --to {director_agent_id} --text "ready: monitor live"
+- When you see cafleet message poll output or a wake nudge, act on it per your role definition.
+
+IMPORTANT: You are the fleet's single dedicated monitoring member. Follow the Startup section of roles/monitor.md exactly and in order: (1) send the "ready: monitoring member" signal; (2) launch cafleet monitor start --fleet-id {fleet_id} as a background task in THIS pane; (3) confirm with cafleet monitor status --fleet-id {fleet_id}; (4) only after status shows running, send "ready: monitor live" to the Director. That last message gates the Director's first ordinary member create.
+
+IMPORTANT: Your on-wake routine acts through exactly two member commands — cafleet member capture (read-only) and cafleet member nudge (re-engage the idle Director). Never keystroke task instructions into an ordinary member's pane.
+
+Start by reading your role definition, then execute the Startup actions in order.

--- a/design-docs/0000105-restore-workflow-auto-invocation/prompts/monitor-20260621T052903Z.md
+++ b/design-docs/0000105-restore-workflow-auto-invocation/prompts/monitor-20260621T052903Z.md
@@ -1,0 +1,22 @@
+You are the Monitoring Member in a design document execution team (CAFleet-native) — the fleet's single dedicated monitoring member.
+
+ROLE DEFINITION: Open the cafleet skill's roles/monitor.md with the Read tool BEFORE any other action. That file is your authoritative role definition. Re-read it whenever you are unsure of protocol.
+
+Load these skills at startup:
+- the `cafleet` skill — for the broker primitives and the heartbeat/monitoring mechanism
+
+FLEET ID: {fleet_id}
+DIRECTOR AGENT ID: {director_agent_id}
+YOUR AGENT ID: {agent_id}
+BASE: /home/himkt/work/himkt/cafleet/design-docs/0000105-restore-workflow-auto-invocation
+CODING AGENT: {coding_agent}
+
+COMMUNICATION PROTOCOL:
+- Report to Director: cafleet message send --fleet-id {fleet_id} --agent-id {agent_id} --to {director_agent_id} --text "ready: monitor live"
+- When you see cafleet message poll output with a message from the Director, act on those instructions.
+
+EXECUTE-WORKFLOW DELTA (extended idle-nudge): When your on-wake routine finds the Director IDLE, nudge it UNCONDITIONALLY via cafleet member nudge — do NOT gate the nudge on naming un-acked inbox items or stalled members. This unconditional idle-nudge grants the Director a re-poll turn during a quiet Copilot wait (Step 7), so its silence counter can advance even when the inbox is empty and members have already reported. This replaces the canonical conditional-nudge behavior in roles/monitor.md for this fleet only.
+
+IMPORTANT: Your routine is read-only and acts through exactly two member commands: cafleet member capture and cafleet member nudge. You never keystroke task instructions into an ordinary member's pane.
+
+Start by performing your Startup actions in order: send the "ready: monitoring member" signal, launch cafleet monitor start as a background task in this pane, confirm with cafleet monitor status, then send "ready: monitor live" to the Director.

--- a/design-docs/0000105-restore-workflow-auto-invocation/prompts/programmer-20260621T052949Z.md
+++ b/design-docs/0000105-restore-workflow-auto-invocation/prompts/programmer-20260621T052949Z.md
@@ -1,0 +1,25 @@
+You are the Programmer in a design document execution team (CAFleet-native).
+
+ROLE DEFINITION: Open /home/himkt/work/himkt/cafleet/skills/cafleet-design-doc/execute/roles/programmer.md with the Read tool BEFORE any other action. That file is your authoritative role definition. Re-read it whenever you are unsure of protocol.
+
+Load these skills at startup:
+- the `cafleet` skill — for communication with the Director; also Read its reference/base-dir.md for the no-bypass write protocol and BASE-derived path conventions
+- the `cafleet-design-doc` skill — for template and guidelines
+
+FLEET ID: {fleet_id}
+DIRECTOR AGENT ID: {director_agent_id}
+YOUR AGENT ID: {agent_id}
+BASE: /home/himkt/work/himkt/cafleet/design-docs/0000105-restore-workflow-auto-invocation
+CODING AGENT: {coding_agent}
+DESIGN DOCUMENT: /home/himkt/work/himkt/cafleet/design-docs/0000105-restore-workflow-auto-invocation/design-doc.md
+
+COMMUNICATION PROTOCOL:
+- Report to Director: cafleet message send --fleet-id {fleet_id} --agent-id {agent_id} --to {director_agent_id} --text "your report"
+- When you see cafleet message poll output with a message from the Director, act on those instructions.
+- On spawn, send the ready signal as your first Bash call: cafleet message send --fleet-id {fleet_id} --agent-id {agent_id} --to {director_agent_id} --text "ready"
+
+IMPORTANT: Do NOT commit code yourself. The Director handles all git operations.
+IMPORTANT: If blocked, send a message to the Director immediately instead of assuming.
+IMPORTANT: Read and follow .claude/rules/bash-tool.md (CAFleet-member Bash protocol) and ~/.claude/rules/bash-command.md (general Bash hygiene) for all Bash commands.
+
+Start by reading the design document. Then wait for the Director to assign your first step.

--- a/design-docs/0000105-restore-workflow-auto-invocation/prompts/reviewer-20260621T043010Z.md
+++ b/design-docs/0000105-restore-workflow-auto-invocation/prompts/reviewer-20260621T043010Z.md
@@ -1,0 +1,22 @@
+You are the Reviewer in a design document creation team (CAFleet-native).
+
+ROLE DEFINITION: Open /home/himkt/.claude/skills/cafleet-design-doc/create/roles/reviewer.md with the Read tool BEFORE any other action. That file is your authoritative role definition. Re-read it whenever you are unsure of protocol.
+
+Load these skills at startup:
+- the cafleet skill — for communication with the Director; also Read its reference/base-dir.md
+- the cafleet-design-doc skill — for the design-doc template and guidelines
+
+FLEET ID: {fleet_id}
+DIRECTOR AGENT ID: {director_agent_id}
+YOUR AGENT ID: {agent_id}
+BASE: /home/himkt/work/himkt/cafleet/design-docs/0000105-restore-workflow-auto-invocation
+CODING AGENT: claude
+DESIGN DOCUMENT: /home/himkt/work/himkt/cafleet/design-docs/0000105-restore-workflow-auto-invocation/design-doc.md
+
+COMMUNICATION PROTOCOL:
+- Report to Director: cafleet message send --fleet-id {fleet_id} --agent-id {agent_id} --to {director_agent_id} --text "complete (doc) — N issues" or "approved (doc)"
+- When you see cafleet message poll output with a message from the Director, act on those instructions.
+
+IMPORTANT: Record each finding as an inline COMMENT(reviewer): [TAG] <body> marker at the affected section of the design doc — never put finding text in the cafleet body. Pay special attention to: rule compliance (removal.md, affirmative-writing.md, design-doc-numbering.md documentation-first ordering, coding-agent overlay neutrality), whether the proposed SKILL.md changes will actually compel a coding agent to auto-invoke and fully execute the team orchestration without explicit instruction, and that implementation steps are concrete and actionable.
+
+Wait for the Director to assign a document for review (cafleet body: ready (doc)). When you receive that message, the doc pointer refers to the DESIGN DOCUMENT path above — read that file and provide specific, actionable feedback per the role definition.

--- a/design-docs/0000105-restore-workflow-auto-invocation/prompts/reviewer-20260621T060747Z.md
+++ b/design-docs/0000105-restore-workflow-auto-invocation/prompts/reviewer-20260621T060747Z.md
@@ -1,0 +1,33 @@
+You are the Reviewer in a design document execution team (CAFleet-native) — a thorough, adversarial reviewer spawned to scrutinize a completed documentation change BEFORE it is finalized.
+
+Load these skills at startup:
+- the `cafleet` skill — for communication with the Director
+- the `cafleet-design-doc` skill — for the design-doc template, guidelines, and the affirmative-writing/removal rules you will judge against
+
+FLEET ID: {fleet_id}
+DIRECTOR AGENT ID: {director_agent_id}
+YOUR AGENT ID: {agent_id}
+BASE: /home/himkt/work/himkt/cafleet/design-docs/0000105-restore-workflow-auto-invocation
+CODING AGENT: {coding_agent}
+DESIGN DOCUMENT: /home/himkt/work/himkt/cafleet/design-docs/0000105-restore-workflow-auto-invocation/design-doc.md
+
+REVIEW TARGETS (the only two files changed by this design):
+- /home/himkt/work/himkt/cafleet/skills/cafleet-design-doc/SKILL.md
+- /home/himkt/work/himkt/cafleet/skills/cafleet-research/SKILL.md
+
+COMMUNICATION PROTOCOL:
+- Report to Director: cafleet message send --fleet-id {fleet_id} --agent-id {agent_id} --to {director_agent_id} --text "your findings"
+- When you see cafleet message poll output with a message from the Director, act on those instructions.
+- On spawn, send the ready signal as your first Bash call: cafleet message send --fleet-id {fleet_id} --agent-id {agent_id} --to {director_agent_id} --text "ready"
+
+YOUR REVIEW MANDATE — two axes, both demanding:
+1. FLAWS — read the design doc Specification and Success Criteria, then read both SKILL.md files and find any defect: spec non-compliance, frontmatter key loss, broken or wrong relative links, factually wrong dispatch claims (e.g. a workflow that does NOT spawn a monitor first being described as if it does), residual prohibition phrasing that should have been converted (affirmative-writing.md / removal.md), lost backend-neutral notes (coding-agent-overlay note, load-by-name note), drift between the two files, or anything that would weaken auto-invocation.
+2. SIMPLICITY — judge whether the dispatch sections are as simple as they can be while still carrying the trigger. Flag redundancy, over-long descriptions, duplicated statements between frontmatter and body, awkward phrasing, or any structure a future reader would find heavier than necessary. Recommend concrete simplifications.
+
+Compare the two files against each other for consistency, and verify every relative link resolves to a real file under the skill directory.
+
+IMPORTANT: Do NOT edit any file, do NOT commit, and do NOT modify the design doc. You only review and report.
+IMPORTANT: If blocked, send a message to the Director immediately instead of assuming.
+IMPORTANT: Read and follow .claude/rules/bash-tool.md (CAFleet-member Bash protocol) and ~/.claude/rules/bash-command.md (general Bash hygiene) for all Bash commands.
+
+Start by reading the design document and both review-target files. Then send the Director a single prioritized findings report: for each finding give a severity (blocker / should-fix / nit), the file and location, what is wrong or heavier-than-needed, and a concrete recommended fix. If you find nothing actionable on an axis, say so explicitly. End the report with an overall verdict: ship-as-is, or fix-then-ship with the specific items.

--- a/skills/cafleet-design-doc/SKILL.md
+++ b/skills/cafleet-design-doc/SKILL.md
@@ -25,7 +25,7 @@ This skill is the umbrella for the full design-document lifecycle: the standardi
 
 When the user's request matches a scenario below, invoke this skill and run the linked workflow as a full CAFleet team — proactively, the moment the request matches, without waiting for the user to say "use cafleet".
 
-**Routing into a workflow means executing its entire orchestration.** The dedicated monitoring member is spawned first-in (`cafleet member create --role monitor`, gating the team behind its `ready: monitor live` handshake), then the role team, then the message-broker quality loop iterates to approval. The linked workflow body is the authoritative procedure.
+**Routing into a workflow means executing its entire orchestration.** The dedicated monitoring member is spawned first-in (`cafleet member create --role monitor`, gating the team behind its `ready: monitor live` handshake), then the role team, then the workflow body's review and revision rounds run through to approval. The linked workflow body is the authoritative procedure.
 
 | When the user wants to… | Invoke this skill and run |
 |:--|:--|

--- a/skills/cafleet-design-doc/SKILL.md
+++ b/skills/cafleet-design-doc/SKILL.md
@@ -41,4 +41,4 @@ Consult these reference pages directly (no team):
 | Section guidelines, quality standards, and formatting rules | [reference/guidelines.md](reference/guidelines.md) |
 | The inter-agent coordination protocol (verb + pointer schema, `COMMENT(role)` markers) | [reference/coordination.md](reference/coordination.md) |
 
-Always route design-doc creation and implementation through the workflow bodies above — each runs the full CAFleet team.
+Always route design-doc work through the workflow bodies above — each runs the full CAFleet team.

--- a/skills/cafleet-design-doc/SKILL.md
+++ b/skills/cafleet-design-doc/SKILL.md
@@ -1,14 +1,15 @@
 ---
 name: cafleet-design-doc
 description: >-
-  Design document format spec plus CAFleet-native orchestration to create,
-  validate, and implement design docs. Consult the template/guidelines when
-  editing an existing design doc; or create a new design doc / specification /
-  technical spec (Director/Drafter/Reviewer), validate/interview an existing one
-  through multi-round Q&A, or implement/execute one with a TDD team. Teammates in
-  agent teams must always load this skill by its name cafleet-design-doc via
-  their backend's skill-loader. Do NOT write or implement design docs freeform —
-  route through this skill's workflows.
+  Use when the user asks to create a design doc, design document, specification,
+  or technical spec (create workflow → Director/Drafter/Reviewer team); to
+  validate, review, or interview an existing design doc through multi-round Q&A
+  (interview workflow); or to implement or execute a design doc (execute workflow
+  → TDD team). Also the standardized format spec — consult the template and
+  guidelines when editing a design doc. Always invoke this skill and route into
+  the matching workflow, orchestrated as a CAFleet team. Teammates in agent teams
+  load this skill by its name cafleet-design-doc via their backend's
+  skill-loader.
 allowed-tools: Read, Write, Edit, Glob, Grep, Bash, WebSearch, WebFetch, AskUserQuestion
 ---
 
@@ -20,15 +21,24 @@ This skill is the umbrella for the full design-document lifecycle: the standardi
 
 **Teammates in agent teams** must always load this skill by its name `cafleet-design-doc` via their backend's skill-loader — never by reading the skill files directly.
 
-## When to use
+## Dispatch
 
-| You want to… | Go to |
+When the user's request matches a scenario below, invoke this skill and run the linked workflow as a full CAFleet team — proactively, the moment the request matches, without waiting for the user to say "use cafleet".
+
+**Routing into a workflow means executing its entire orchestration.** The dedicated monitoring member is spawned first-in (`cafleet member create --role monitor`, gating the team behind its `ready: monitor live` handshake), then the role team, then the message-broker quality loop iterates to approval. The linked workflow body is the authoritative procedure.
+
+| When the user wants to… | Invoke this skill and run |
 |:--|:--|
-| Consult the document template | [reference/template.md](reference/template.md) |
-| Consult section guidelines, quality standards, and formatting rules | [reference/guidelines.md](reference/guidelines.md) |
-| Consult the inter-agent coordination protocol (verb + pointer schema, `COMMENT(role)` markers) | [reference/coordination.md](reference/coordination.md) |
-| Create a new design doc / specification / technical spec (Director/Drafter/Reviewer team) | [create/create.md](create/create.md) |
-| Validate / interview an existing design doc through multi-round Q&A | [interview/interview.md](interview/interview.md) |
-| Implement / execute a design doc with a TDD team | [execute/execute.md](execute/execute.md) |
+| Create a design doc / specification / technical spec | the **create** workflow ([create/create.md](create/create.md)) — Director/Drafter/Reviewer team |
+| Validate / review / interview an existing design doc | the **interview** workflow ([interview/interview.md](interview/interview.md)) — multi-round Q&A |
+| Implement / execute a design doc | the **execute** workflow ([execute/execute.md](execute/execute.md)) — TDD team |
 
-Do NOT write or implement design documents freeform — always route through the workflow bodies above.
+Consult these reference pages directly (no team):
+
+| When the user wants to… | Consult |
+|:--|:--|
+| The document template | [reference/template.md](reference/template.md) |
+| Section guidelines, quality standards, and formatting rules | [reference/guidelines.md](reference/guidelines.md) |
+| The inter-agent coordination protocol (verb + pointer schema, `COMMENT(role)` markers) | [reference/coordination.md](reference/coordination.md) |
+
+Always route design-doc creation and implementation through the workflow bodies above — each runs the full CAFleet team.

--- a/skills/cafleet-research/SKILL.md
+++ b/skills/cafleet-research/SKILL.md
@@ -1,14 +1,15 @@
 ---
 name: cafleet-research
 description: >-
-  Comprehensive multi-source research reports, Slidev presentations, charts, and
-  data visualizations. Use to create a research report (multi-agent
-  Director/Manager/Researcher team writing to researches/<topic>/), build a
-  Slidev presentation / slide deck / reading transcript from a report, create a
-  chart / plot / graph / figure or visualize data with matplotlib, or author
-  slides with the custom Slidev theme. Members in agent teams load this skill by
-  its name cafleet-research via their backend's skill-loader. Do NOT do a quick
-  web search and summarize — route through this skill's workflows.
+  Use when the user asks to research a topic or create a multi-source research
+  report (report workflow → Director/Manager/Researcher team writing to
+  researches/<topic>/); to build a presentation, slide deck, or reading
+  transcript from a report (presentation workflow); to create a chart, plot,
+  graph, figure, or data visualization (visualization reference); or to author
+  slides with the custom Slidev theme (slidev reference). Always invoke this
+  skill and route into the matching workflow, orchestrated as a CAFleet team.
+  Members in agent teams load this skill by its name cafleet-research via their
+  backend's skill-loader.
 allowed-tools: Read, Write, Edit, Glob, Grep, Bash, WebSearch, WebFetch, Agent, TaskCreate, TaskUpdate, TaskList, TaskGet, TaskStop
 ---
 
@@ -20,13 +21,22 @@ This skill is the umbrella for research and presentation media: two CAFleet-nati
 
 **Teammates in agent teams** that need this skill load it by its name `cafleet-research` via their backend's skill-loader — never by reading the skill files directly.
 
-## When to use
+## Dispatch
 
-| You want to… | Go to |
+When the user's request matches a scenario below, invoke this skill and run the linked workflow as a full CAFleet team — proactively, the moment the request matches, without waiting for the user to say "use cafleet".
+
+**Routing into the report or presentation workflow means executing its entire orchestration.** The dedicated monitoring member is spawned first-in (`cafleet member create --role monitor`, gating the team behind its `ready: monitor live` handshake), then the role team, then the message-broker quality loop iterates to approval. The linked workflow body is the authoritative procedure.
+
+| When the user wants to… | Invoke this skill and run |
 |:--|:--|
-| Create a comprehensive multi-source research report (Director/Manager/Researcher team → `researches/<topic>/`) | [report/report.md](report/report.md) |
-| Build a Slidev presentation / slide deck / reading transcript from an approved report | [presentation/presentation.md](presentation/presentation.md) |
-| Create a chart / plot / graph / figure or visualize data with matplotlib | [reference/visualization.md](reference/visualization.md) |
-| Author slides with the custom Slidev theme (layouts, components, techniques) | [reference/slidev.md](reference/slidev.md) |
+| Research a topic / create a multi-source research report | the **report** workflow ([report/report.md](report/report.md)) — Director/Manager/Researcher team → `researches/<topic>/` |
+| Build a presentation / slide deck / reading transcript from a report | the **presentation** workflow ([presentation/presentation.md](presentation/presentation.md)) |
 
-The report workflow chains into the presentation workflow after user approval. The two reference pages are standalone utilities the presentation workflow also reads. Do NOT do a quick web search and summarize — route through the workflows above.
+Consult these reference pages directly (no team):
+
+| When the user wants to… | Consult |
+|:--|:--|
+| Create a chart / plot / graph / figure or visualize data | the **visualization** reference ([reference/visualization.md](reference/visualization.md)) |
+| Author slides with the custom Slidev theme (layouts, components, techniques) | the **slidev** reference ([reference/slidev.md](reference/slidev.md)) |
+
+The report workflow chains into the presentation workflow after user approval. The two reference pages are standalone utilities the presentation workflow also reads. Always route research and report work through the workflow bodies above — each runs the full CAFleet team.

--- a/skills/cafleet-research/SKILL.md
+++ b/skills/cafleet-research/SKILL.md
@@ -25,7 +25,7 @@ This skill is the umbrella for research and presentation media: two CAFleet-nati
 
 When the user's request matches a scenario below, invoke this skill and run the linked workflow as a full CAFleet team — proactively, the moment the request matches, without waiting for the user to say "use cafleet".
 
-**Routing into the report or presentation workflow means executing its entire orchestration.** The dedicated monitoring member is spawned first-in (`cafleet member create --role monitor`, gating the team behind its `ready: monitor live` handshake), then the role team, then the message-broker quality loop iterates to approval. The linked workflow body is the authoritative procedure.
+**Routing into the report or presentation workflow means executing its entire orchestration.** The dedicated monitoring member is spawned first-in (`cafleet member create --role monitor`, gating the team behind its `ready: monitor live` handshake), then the role team, then the workflow body's review and revision rounds run through to approval. The linked workflow body is the authoritative procedure.
 
 | When the user wants to… | Invoke this skill and run |
 |:--|:--|

--- a/skills/cafleet-research/SKILL.md
+++ b/skills/cafleet-research/SKILL.md
@@ -39,4 +39,4 @@ Consult these reference pages directly (no team):
 | Create a chart / plot / graph / figure or visualize data | the **visualization** reference ([reference/visualization.md](reference/visualization.md)) |
 | Author slides with the custom Slidev theme (layouts, components, techniques) | the **slidev** reference ([reference/slidev.md](reference/slidev.md)) |
 
-The report workflow chains into the presentation workflow after user approval. The two reference pages are standalone utilities the presentation workflow also reads. Always route research and report work through the workflow bodies above — each runs the full CAFleet team.
+The report workflow chains into the presentation workflow after user approval. The two reference pages are standalone utilities the presentation workflow also reads. Always route research work through the workflow bodies above — each runs the full CAFleet team.


### PR DESCRIPTION
- **docs: rewrite cafleet-design-doc SKILL.md for reliable workflow auto-invocation (design 0000105 Step 1)**
- **docs: rewrite cafleet-research SKILL.md for reliable workflow auto-invocation (design 0000105 Step 2)**
- **docs: drift audit confirms no doc edits needed (design 0000105 Step 3)**
- **docs: tighten SKILL.md closing lines to cover all workflows (design 0000105 Opus review)**
- **docs: record Step 4 behavioral validation outcome and check success criteria (design 0000105)**
