### PR TITLE
feat/0000108 upload skills artifacts on release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,6 +29,4 @@ jobs:
       - name: Upload skills archive to the release
         env:
           GH_TOKEN: ${{ github.token }}
-        run: >
-          gh release upload "${{ github.event.release.tag_name }}"
-          "cafleet-skills-v${{ github.event.release.tag_name }}.zip" --clobber
+        run: gh release upload "${{ github.event.release.tag_name }}" "cafleet-skills-v${{ github.event.release.tag_name }}.zip" --clobber

--- a/design-docs/0000108-upload-skills-artifacts-on-release/design-doc.md
+++ b/design-docs/0000108-upload-skills-artifacts-on-release/design-doc.md
@@ -1,6 +1,6 @@
 # Upload skills artifacts on release
 
-**Status**: Approved
+**Status**: Complete
 **Progress**: 3/3 tasks complete
 **Last Updated**: 2026-06-22
 
@@ -126,3 +126,4 @@ No README, `docs/`, or `SKILL.md` changes are made — a deliberate scoping deci
 |------|---------|
 | 2026-06-22 | Initial draft |
 | 2026-06-22 | Implemented; collapsed the upload step's `run:` to a single line per Administrator PR review on #144 |
+| 2026-06-22 | Marked complete |

--- a/design-docs/0000108-upload-skills-artifacts-on-release/design-doc.md
+++ b/design-docs/0000108-upload-skills-artifacts-on-release/design-doc.md
@@ -95,9 +95,7 @@ jobs:
       - name: Upload skills archive to the release
         env:
           GH_TOKEN: ${{ github.token }}
-        run: >
-          gh release upload "${{ github.event.release.tag_name }}"
-          "cafleet-skills-v${{ github.event.release.tag_name }}.zip" --clobber
+        run: gh release upload "${{ github.event.release.tag_name }}" "cafleet-skills-v${{ github.event.release.tag_name }}.zip" --clobber
 ```
 
 ### Documentation surface
@@ -127,3 +125,4 @@ No README, `docs/`, or `SKILL.md` changes are made — a deliberate scoping deci
 | Date | Changes |
 |------|---------|
 | 2026-06-22 | Initial draft |
+| 2026-06-22 | Implemented; collapsed the upload step's `run:` to a single line per Administrator PR review on #144 |


### PR DESCRIPTION
- **feat: add upload-skills job to publish workflow**
- **docs: validate publish workflow and mark Step 2 complete**
- **docs: check off success criteria for design doc 0000108**
- **chore: add reviewer spawn-prompt audit file for design doc 0000108**
- **fix: collapse upload-skills run step to single line per PR review**
- **docs: mark design doc as complete**
