### PR TITLE
feat/0000109 cafleet setup command

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,43 +12,20 @@ Agent Teams reinvented for collaborative coding across multiple coding-agent bac
 
 ## 2. Install
 
-CAFleet works with three coding agents: `claude` (Claude Code), `codex` (OpenAI Codex CLI), and `opencode`.
-Install the plugin in whichever one you use — the broker CLI is shared.
+CAFleet works with three coding agents: `claude` (Claude Code), `codex` (OpenAI Codex CLI), and `opencode`. The broker CLI is shared by all three; the skills are installed per backend you use.
 
-### 2.1. CAFleet skills
-
-Use your favorite tool to install skills (for example, GitHub CLI `gh skill`, vercel `skills`, or the marketplace of each coding agent).
-
-#### (a) GitHub CLI (recommended)
-
-```bash
-gh skill install himkt/cafleet --agent claude-code
-gh skill install himkt/cafleet --agent codex
-gh skill install himkt/cafleet --agent opencode
-```
-
-#### (b) Claude Code marketplace (if you prefer)
-
-```text
-/plugin marketplace add himkt/cafleet
-/plugin install cafleet@cafleet
-```
-
-#### (c) Codex (if you prefer)
-
-```bash
-codex plugin marketplace add himkt/cafleet
-```
-
-
-### 2.2. CAFleet CLI (required for CAFleet to function)
+The recommended end-user path is two commands:
 
 ```bash
 uv tool install cafleet     # or: pip install cafleet
-cafleet db init             # apply schema migrations (idempotent; rerun after upgrades)
+cafleet setup               # install the skills + migrate the database
 ```
 
+`cafleet setup` installs the skills matching your installed `cafleet` version into every detected coding-agent home (`~/.claude`, `~/.codex`, `~/.config/opencode`) and migrates the database to head — the same migration code path as `cafleet db init`. Scope the skills install to specific agents with `--agent claude|codex|opencode` (repeatable). Re-run it after upgrading the package to refresh the skills and apply new migrations.
+
 The default database is `~/.local/share/cafleet/cafleet.db`. Override with `CAFLEET_DATABASE_URL` (use an absolute path — SQLAlchemy does not expand `~` in SQLite URLs).
+
+Contributors working from a clone install the skills from the working tree instead with `mise //:skill-install` (or `gh skill install` / a coding-agent marketplace from the published repo). Full install details, including the upgrade warning for pre-integer-PK databases, are on the Install page: <https://himkt.github.io/cafleet/get-started/install/>.
 
 Per-coding-agent config (Claude `permissions.allow`, Codex `config.toml` + rules, opencode) lives on the Configure page: <https://himkt.github.io/cafleet/get-started/configure/>.
 

--- a/cafleet/src/cafleet/cli/__init__.py
+++ b/cafleet/src/cafleet/cli/__init__.py
@@ -10,6 +10,7 @@ from cafleet.cli.member import member
 from cafleet.cli.message import message
 from cafleet.cli.monitor import monitor
 from cafleet.cli.server import server
+from cafleet.cli.setup import setup as setup_command
 
 
 @click.group()
@@ -32,3 +33,4 @@ cli.add_command(member)
 cli.add_command(monitor)
 cli.add_command(server)
 cli.add_command(doctor)
+cli.add_command(setup_command)

--- a/cafleet/src/cafleet/cli/__init__.py
+++ b/cafleet/src/cafleet/cli/__init__.py
@@ -3,7 +3,7 @@
 import click
 
 from cafleet.cli.agent import agent
-from cafleet.cli.db import db
+from cafleet.cli.db import db as db_group
 from cafleet.cli.doctor import doctor
 from cafleet.cli.fleet import fleet
 from cafleet.cli.member import member
@@ -24,7 +24,7 @@ def cli(ctx, json_output):
     ctx.obj["json_output"] = json_output
 
 
-cli.add_command(db)
+cli.add_command(db_group)
 cli.add_command(fleet)
 cli.add_command(agent)
 cli.add_command(message)

--- a/cafleet/src/cafleet/cli/db.py
+++ b/cafleet/src/cafleet/cli/db.py
@@ -23,8 +23,7 @@ def db() -> None:
     """Database schema management commands."""
 
 
-@db.command("init")
-def init() -> None:
+def run_db_init() -> None:
     """Initialize or migrate the registry database to the head revision."""
     sync_url = _sync_db_url()
     db_file_str = make_url(sync_url).database
@@ -90,3 +89,9 @@ def init() -> None:
                 click.echo(f"Upgraded from {old_rev} to {head_rev}.")
         finally:
             engine.dispose()
+
+
+@db.command("init")
+def init() -> None:
+    """Initialize or migrate the registry database to the head revision."""
+    run_db_init()

--- a/cafleet/src/cafleet/cli/setup.py
+++ b/cafleet/src/cafleet/cli/setup.py
@@ -67,9 +67,13 @@ def _resolve_download_url(cli_version: str) -> str:
         ) from exc
 
     asset_name = f"cafleet-skills-v{cli_version}.zip"
-    for asset in json.loads(body)["assets"]:
-        if asset["name"] == asset_name:
-            return asset["browser_download_url"]
+    try:
+        assets = json.loads(body)["assets"]
+        for asset in assets:
+            if asset["name"] == asset_name:
+                return asset["browser_download_url"]
+    except (json.JSONDecodeError, KeyError, TypeError) as exc:
+        raise click.ClickException("could not parse the GitHub API response") from exc
     raise click.ClickException(f"asset {asset_name} not found in release {cli_version}")
 
 
@@ -105,7 +109,7 @@ def _download_and_extract(download_url: str, dest_root: Path) -> Path:
                         "rejecting the archive"
                     )
             zf.extractall(extract_root)
-    except zipfile.BadZipFile as exc:
+    except (zipfile.BadZipFile, OSError) as exc:
         raise click.ClickException("release asset is malformed") from exc
 
     skills_root = extract_root / "skills"

--- a/cafleet/src/cafleet/cli/setup.py
+++ b/cafleet/src/cafleet/cli/setup.py
@@ -1,0 +1,182 @@
+"""``cafleet setup`` — one-step onboarding: install skills + migrate the DB."""
+
+import importlib.metadata
+import json
+import shutil
+import socket
+import tempfile
+import urllib.error
+import urllib.request
+import zipfile
+from pathlib import Path, PurePosixPath
+
+import click
+
+from cafleet.cli.db import run_db_init
+
+GITHUB_REPO = "himkt/cafleet"
+SKILL_DIRS = ("cafleet", "cafleet-design-doc", "cafleet-research")
+HTTP_TIMEOUT = 30  # seconds; applied to every urlopen (release lookup + download)
+
+AGENT_SKILLS_DIRS = {
+    "claude": Path("~/.claude/skills"),
+    "codex": Path("~/.codex/skills"),
+    "opencode": Path("~/.config/opencode/skills"),
+}
+
+
+def _resolve_targets(agents: tuple[str, ...]) -> list[str]:
+    """Resolve the skills targets from ``--agent`` or by auto-detection."""
+    if agents:
+        return list(dict.fromkeys(agents))
+
+    detected = [
+        agent
+        for agent, skills_dir in AGENT_SKILLS_DIRS.items()
+        if skills_dir.expanduser().parent.exists()
+    ]
+    if not detected:
+        raise click.ClickException(
+            "no coding-agent homes detected (looked for ~/.claude, ~/.codex, "
+            "~/.config/opencode); install a coding agent first, or pass --agent"
+        )
+    return detected
+
+
+def _resolve_download_url(cli_version: str) -> str:
+    """Look up the release for ``cli_version`` and return its skills asset URL."""
+    api_url = (
+        f"https://api.github.com/repos/{GITHUB_REPO}/releases/tags/{cli_version}"
+    )
+    req = urllib.request.Request(
+        api_url,
+        headers={"Accept": "application/vnd.github+json", "User-Agent": "cafleet"},
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=HTTP_TIMEOUT) as resp:
+            body = resp.read()
+    except urllib.error.HTTPError as exc:
+        if exc.code == 404:
+            raise click.ClickException(
+                f"no release found for version {cli_version}"
+            ) from exc
+        raise click.ClickException(
+            f"could not reach the GitHub API ({exc.reason})"
+        ) from exc
+    except (urllib.error.URLError, socket.timeout) as exc:
+        reason = getattr(exc, "reason", exc)
+        raise click.ClickException(
+            f"could not reach the GitHub API ({reason})"
+        ) from exc
+
+    asset_name = f"cafleet-skills-v{cli_version}.zip"
+    for asset in json.loads(body)["assets"]:
+        if asset["name"] == asset_name:
+            return asset["browser_download_url"]
+    raise click.ClickException(
+        f"asset {asset_name} not found in release {cli_version}"
+    )
+
+
+def _download_and_extract(download_url: str, dest_root: Path) -> Path:
+    """Download the asset, reject unsafe members, extract, and validate layout.
+
+    Returns the extracted ``skills/`` directory. Raises ``click.ClickException``
+    on any network or archive failure, before the caller removes any target.
+    """
+    archive_path = dest_root / "skills.zip"
+    req = urllib.request.Request(download_url, headers={"User-Agent": "cafleet"})
+    try:
+        with urllib.request.urlopen(req, timeout=HTTP_TIMEOUT) as resp:
+            archive_path.write_bytes(resp.read())
+    except urllib.error.HTTPError as exc:
+        raise click.ClickException(
+            f"could not reach the GitHub API ({exc.reason})"
+        ) from exc
+    except (urllib.error.URLError, socket.timeout) as exc:
+        reason = getattr(exc, "reason", exc)
+        raise click.ClickException(
+            f"could not reach the GitHub API ({reason})"
+        ) from exc
+
+    extract_root = dest_root / "extracted"
+    try:
+        with zipfile.ZipFile(archive_path) as zf:
+            for member in zf.namelist():
+                parts = PurePosixPath(member)
+                if parts.is_absolute() or ".." in parts.parts:
+                    raise click.ClickException(
+                        f"archive member '{member}' has an unsafe path; "
+                        "rejecting the archive"
+                    )
+            zf.extractall(extract_root)
+    except zipfile.BadZipFile as exc:
+        raise click.ClickException("release asset is malformed") from exc
+
+    skills_root = extract_root / "skills"
+    if not skills_root.is_dir():
+        raise click.ClickException("release asset is malformed")
+    entries = list(skills_root.iterdir())
+    if {entry.name for entry in entries} != set(SKILL_DIRS) or not all(
+        entry.is_dir() for entry in entries
+    ):
+        raise click.ClickException("release asset is malformed")
+    return skills_root
+
+
+def _install_skills(targets: list[str], cli_version: str) -> None:
+    """Run the full skills half: resolve, download, validate, and install."""
+    download_url = _resolve_download_url(cli_version)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        skills_root = _download_and_extract(download_url, Path(tmpdir))
+
+        for agent in targets:
+            skills_dir = AGENT_SKILLS_DIRS[agent].expanduser()
+            try:
+                for name in SKILL_DIRS:
+                    dest = skills_dir / name
+                    dest.parent.mkdir(parents=True, exist_ok=True)
+                    if dest.exists():
+                        shutil.rmtree(dest)
+                    shutil.copytree(skills_root / name, dest)
+            except OSError as exc:
+                raise click.ClickException(
+                    f"failed to install skills into {skills_dir}: {exc}"
+                ) from exc
+            click.echo(
+                f"{agent}: installed {', '.join(SKILL_DIRS)} "
+                f"(v{cli_version}) -> {AGENT_SKILLS_DIRS[agent]}"
+            )
+
+
+@click.command("setup")
+@click.option(
+    "--agent",
+    "agents",
+    type=click.Choice(["claude", "codex", "opencode"]),
+    multiple=True,
+    help="Scope the skills install to the named agent(s); repeatable. "
+    "Omit to auto-detect every coding-agent home that exists.",
+)
+def setup(agents: tuple[str, ...]) -> None:
+    """Install the coding-agent skills and migrate the database in one step."""
+    cli_version = importlib.metadata.version("cafleet")
+
+    failures: list[str] = []
+
+    try:
+        targets = _resolve_targets(agents)
+        _install_skills(targets, cli_version)
+    except click.ClickException as exc:
+        click.echo(f"skills half failed: {exc.format_message()}")
+        failures.append("skills")
+
+    try:
+        run_db_init()
+    except click.ClickException as exc:
+        click.echo(f"db half failed: {exc.format_message()}")
+        failures.append("db")
+
+    if failures:
+        raise click.ClickException(f"{' and '.join(failures)} half failed")

--- a/cafleet/src/cafleet/cli/setup.py
+++ b/cafleet/src/cafleet/cli/setup.py
@@ -3,7 +3,6 @@
 import importlib.metadata
 import json
 import shutil
-import socket
 import tempfile
 import urllib.error
 import urllib.request
@@ -45,9 +44,7 @@ def _resolve_targets(agents: tuple[str, ...]) -> list[str]:
 
 def _resolve_download_url(cli_version: str) -> str:
     """Look up the release for ``cli_version`` and return its skills asset URL."""
-    api_url = (
-        f"https://api.github.com/repos/{GITHUB_REPO}/releases/tags/{cli_version}"
-    )
+    api_url = f"https://api.github.com/repos/{GITHUB_REPO}/releases/tags/{cli_version}"
     req = urllib.request.Request(
         api_url,
         headers={"Accept": "application/vnd.github+json", "User-Agent": "cafleet"},
@@ -63,7 +60,7 @@ def _resolve_download_url(cli_version: str) -> str:
         raise click.ClickException(
             f"could not reach the GitHub API ({exc.reason})"
         ) from exc
-    except (urllib.error.URLError, socket.timeout) as exc:
+    except (urllib.error.URLError, TimeoutError) as exc:
         reason = getattr(exc, "reason", exc)
         raise click.ClickException(
             f"could not reach the GitHub API ({reason})"
@@ -73,9 +70,7 @@ def _resolve_download_url(cli_version: str) -> str:
     for asset in json.loads(body)["assets"]:
         if asset["name"] == asset_name:
             return asset["browser_download_url"]
-    raise click.ClickException(
-        f"asset {asset_name} not found in release {cli_version}"
-    )
+    raise click.ClickException(f"asset {asset_name} not found in release {cli_version}")
 
 
 def _download_and_extract(download_url: str, dest_root: Path) -> Path:
@@ -93,7 +88,7 @@ def _download_and_extract(download_url: str, dest_root: Path) -> Path:
         raise click.ClickException(
             f"could not reach the GitHub API ({exc.reason})"
         ) from exc
-    except (urllib.error.URLError, socket.timeout) as exc:
+    except (urllib.error.URLError, TimeoutError) as exc:
         reason = getattr(exc, "reason", exc)
         raise click.ClickException(
             f"could not reach the GitHub API ({reason})"

--- a/cafleet/tests/cli/test_setup.py
+++ b/cafleet/tests/cli/test_setup.py
@@ -390,6 +390,37 @@ def test_network_error_folded(homes, registry_db, monkeypatch, api_error):
     assert "could not reach the github api" in result.output.lower()
 
 
+@pytest.mark.parametrize(
+    "download_error",
+    [
+        urllib.error.URLError("connection reset"),
+        urllib.error.HTTPError(
+            url=DOWNLOAD_URL, code=403, msg="expired", hdrs=None, fp=None
+        ),
+        urllib.error.HTTPError(
+            url=DOWNLOAD_URL, code=500, msg="server error", hdrs=None, fp=None
+        ),
+    ],
+    ids=["urlerror", "http-403", "http-500"],
+)
+def test_download_network_error_folded(homes, registry_db, monkeypatch, download_error):
+    """A network failure on the asset download folds into the same message.
+
+    The release lookup succeeds; the failure happens while streaming the asset,
+    so this exercises the second ``urlopen`` call (step 4), distinct from the
+    release-lookup path covered by ``test_network_error_folded``.
+    """
+    _make_home(homes["claude"])
+    _mock_release(
+        monkeypatch, zip_bytes=_make_skills_zip(), download_error=download_error
+    )
+
+    result = _run_setup(["--agent", "claude"])
+
+    assert result.exit_code == 1, result.output
+    assert "could not reach the github api" in result.output.lower()
+
+
 # --------------------------------------------------------------------------- #
 # Install-time filesystem errors                                             #
 # --------------------------------------------------------------------------- #

--- a/cafleet/tests/cli/test_setup.py
+++ b/cafleet/tests/cli/test_setup.py
@@ -69,8 +69,13 @@ def _mock_release(
     assets=None,
     api_error=None,
     download_error=None,
+    release_body=None,
 ):
-    """Patch the version lookup and ``urlopen`` for the skills-half network calls."""
+    """Patch the version lookup and ``urlopen`` for the skills-half network calls.
+
+    ``release_body`` overrides the API response payload with raw bytes (used to
+    inject unparseable / non-assets JSON); otherwise it is built from ``assets``.
+    """
     real_version = importlib.metadata.version
 
     def fake_version(package):
@@ -78,9 +83,10 @@ def _mock_release(
 
     monkeypatch.setattr(importlib.metadata, "version", fake_version)
 
-    if assets is None:
-        assets = [{"name": ASSET_NAME, "browser_download_url": DOWNLOAD_URL}]
-    release_body = json.dumps({"tag_name": version, "assets": assets}).encode()
+    if release_body is None:
+        if assets is None:
+            assets = [{"name": ASSET_NAME, "browser_download_url": DOWNLOAD_URL}]
+        release_body = json.dumps({"tag_name": version, "assets": assets}).encode()
 
     def fake_urlopen(req, timeout=None):
         url = req.full_url if hasattr(req, "full_url") else req
@@ -326,6 +332,26 @@ def test_bad_zip_is_malformed(homes, registry_db, monkeypatch):
     assert "malformed" in result.output.lower()
 
 
+def test_extractall_oserror_is_malformed(homes, registry_db, monkeypatch):
+    """An ``OSError`` raised mid-extraction is reported as the malformed-asset error.
+
+    The archive passes the zip-slip and bad-zip pre-checks; the failure happens
+    inside ``ZipFile.extractall`` (e.g. a filesystem error during extraction).
+    """
+    _make_home(homes["claude"])
+    _mock_release(monkeypatch, zip_bytes=_make_skills_zip())
+
+    def boom(self, *args, **kwargs):
+        raise OSError("extraction failed")
+
+    monkeypatch.setattr(zipfile.ZipFile, "extractall", boom)
+
+    result = _run_setup(["--agent", "claude"])
+
+    assert result.exit_code == 1, result.output
+    assert "malformed" in result.output.lower()
+
+
 # --------------------------------------------------------------------------- #
 # Release / network resolution                                               #
 # --------------------------------------------------------------------------- #
@@ -344,6 +370,22 @@ def test_missing_asset_message(homes, registry_db, monkeypatch):
     assert result.exit_code == 1, result.output
     assert ASSET_NAME in result.output
     assert "not found" in result.output.lower()
+
+
+@pytest.mark.parametrize(
+    "release_body",
+    [b"this is not json", b'{"tag_name": "0.12.2"}'],
+    ids=["non-json", "no-assets-key"],
+)
+def test_unparseable_api_response(homes, registry_db, monkeypatch, release_body):
+    """A 200 body that is not JSON, or lacks the ``assets`` array, is rejected."""
+    _make_home(homes["claude"])
+    _mock_release(monkeypatch, release_body=release_body)
+
+    result = _run_setup(["--agent", "claude"])
+
+    assert result.exit_code == 1, result.output
+    assert "could not parse the github api response" in result.output.lower()
 
 
 def test_no_release_for_version(homes, registry_db, monkeypatch):

--- a/cafleet/tests/cli/test_setup.py
+++ b/cafleet/tests/cli/test_setup.py
@@ -19,7 +19,6 @@ Contract notes for the implementation under test (``cafleet.cli.setup``):
 import importlib.metadata
 import io
 import json
-import socket
 import sqlite3
 import urllib.error
 import urllib.request
@@ -171,9 +170,7 @@ def test_autodetect_installs_only_present_homes(homes, registry_db, monkeypatch)
     assert _installed_skill_dirs(homes["claude"]) == set(SKILL_DIR_NAMES)
     assert _installed_skill_dirs(homes["opencode"]) == set(SKILL_DIR_NAMES)
     assert not homes["codex"].exists()
-    assert {"fleets", "agents", "tasks", "alembic_version"} <= _table_names(
-        registry_db
-    )
+    assert {"fleets", "agents", "tasks", "alembic_version"} <= _table_names(registry_db)
 
 
 def test_agent_flag_scopes_targets_and_dedupes(homes, registry_db, monkeypatch):
@@ -248,15 +245,13 @@ def test_replace_idempotency_second_run_clean_tree(homes, registry_db, monkeypat
     assert first.exit_code == 0, first.output
     assert not stale.exists()  # replaced, not merged
     tree_after_first = sorted(
-        p.relative_to(homes["claude"]).as_posix()
-        for p in homes["claude"].rglob("*")
+        p.relative_to(homes["claude"]).as_posix() for p in homes["claude"].rglob("*")
     )
 
     second = _run_setup(["--agent", "claude"])
     assert second.exit_code == 0, second.output
     tree_after_second = sorted(
-        p.relative_to(homes["claude"]).as_posix()
-        for p in homes["claude"].rglob("*")
+        p.relative_to(homes["claude"]).as_posix() for p in homes["claude"].rglob("*")
     )
     assert tree_after_second == tree_after_first
 
@@ -380,7 +375,7 @@ def test_no_release_for_version(homes, registry_db, monkeypatch):
         urllib.error.HTTPError(
             url="https://api", code=500, msg="server error", hdrs=None, fp=None
         ),
-        socket.timeout("timed out"),
+        TimeoutError("timed out"),
     ],
     ids=["urlerror", "http-403", "http-500", "timeout"],
 )

--- a/cafleet/tests/cli/test_setup.py
+++ b/cafleet/tests/cli/test_setup.py
@@ -1,0 +1,465 @@
+"""Tests for the ``cafleet setup`` CLI command.
+
+The skills half is exercised entirely offline: ``importlib.metadata.version``,
+the ``GET /releases/tags/<version>`` lookup and the asset download are all
+monkeypatched, and ``AGENT_SKILLS_DIRS`` is redirected to ``tmp_path`` homes.
+Every ``cafleet setup`` run also drives the database half, so an autouse
+fixture redirects the registry at a temp SQLite file.
+
+Contract notes for the implementation under test (``cafleet.cli.setup``):
+
+* The installed version is read via a module-qualified
+  ``importlib.metadata.version("cafleet")`` call.
+* Both the release lookup and the asset download go through
+  ``urllib.request.urlopen``.
+* ``shutil.copytree`` performs the per-skill install.
+* ``AGENT_SKILLS_DIRS`` is a module-level dict of ``{agent: Path}``.
+"""
+
+import importlib.metadata
+import io
+import json
+import socket
+import sqlite3
+import urllib.error
+import urllib.request
+import zipfile
+
+import pytest
+from click.testing import CliRunner
+
+from cafleet import config
+
+SKILL_DIR_NAMES = ("cafleet", "cafleet-design-doc", "cafleet-research")
+CLI_VERSION = "0.12.2"
+ASSET_NAME = f"cafleet-skills-v{CLI_VERSION}.zip"
+DOWNLOAD_URL = f"https://example.invalid/download/{ASSET_NAME}"
+_RELEASE_API_FRAGMENT = "/releases/tags/"
+
+
+def _make_skills_zip(
+    *, skill_dirs=SKILL_DIR_NAMES, extra_dirs=(), extra_files=(), raw_members=None
+) -> bytes:
+    """Build an in-memory skills archive.
+
+    ``raw_members`` bypasses the canonical layout and writes the named members
+    verbatim (used for zip-slip cases). Otherwise the archive unpacks to
+    ``skills/<name>/...`` for each entry in ``skill_dirs`` plus any ``extra_*``.
+    """
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        if raw_members is not None:
+            for member in raw_members:
+                zf.writestr(member, "x\n")
+        else:
+            for name in skill_dirs:
+                zf.writestr(f"skills/{name}/SKILL.md", f"# {name}\n")
+                zf.writestr(f"skills/{name}/reference/page.md", "ref\n")
+            for name in extra_dirs:
+                zf.writestr(f"skills/{name}/SKILL.md", "x\n")
+            for name in extra_files:
+                zf.writestr(f"skills/{name}", "x\n")
+    return buf.getvalue()
+
+
+def _mock_release(
+    monkeypatch,
+    *,
+    version=CLI_VERSION,
+    zip_bytes=None,
+    assets=None,
+    api_error=None,
+    download_error=None,
+):
+    """Patch the version lookup and ``urlopen`` for the skills-half network calls."""
+    real_version = importlib.metadata.version
+
+    def fake_version(package):
+        return version if package == "cafleet" else real_version(package)
+
+    monkeypatch.setattr(importlib.metadata, "version", fake_version)
+
+    if assets is None:
+        assets = [{"name": ASSET_NAME, "browser_download_url": DOWNLOAD_URL}]
+    release_body = json.dumps({"tag_name": version, "assets": assets}).encode()
+
+    def fake_urlopen(req, timeout=None):
+        url = req.full_url if hasattr(req, "full_url") else req
+        if _RELEASE_API_FRAGMENT in url:
+            if api_error is not None:
+                raise api_error
+            return io.BytesIO(release_body)
+        if url == DOWNLOAD_URL:
+            if download_error is not None:
+                raise download_error
+            return io.BytesIO(zip_bytes if zip_bytes is not None else b"")
+        raise AssertionError(f"unexpected URL: {url}")
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+
+
+@pytest.fixture(autouse=True)
+def registry_db(tmp_path, monkeypatch):
+    """Redirect the DB half at a temp SQLite so no test touches the real registry."""
+    db_path = tmp_path / "registry" / "cafleet.db"
+    monkeypatch.setattr(
+        config.settings, "database_url", f"sqlite+aiosqlite:///{db_path}"
+    )
+    return db_path
+
+
+@pytest.fixture
+def homes(tmp_path, monkeypatch):
+    """Point every agent's skills dir at an isolated ``tmp_path`` home.
+
+    Returns the ``{agent: skills_dir}`` mapping; the home (the skills dir's
+    parent) is created on demand by ``_make_home``.
+    """
+    from cafleet.cli import setup as setup_module
+
+    mapping = {
+        "claude": tmp_path / "h_claude" / ".claude" / "skills",
+        "codex": tmp_path / "h_codex" / ".codex" / "skills",
+        "opencode": tmp_path / "h_opencode" / ".config" / "opencode" / "skills",
+    }
+    monkeypatch.setattr(setup_module, "AGENT_SKILLS_DIRS", dict(mapping))
+    return mapping
+
+
+def _make_home(skills_dir):
+    skills_dir.parent.mkdir(parents=True, exist_ok=True)
+
+
+def _installed_skill_dirs(skills_dir):
+    if not skills_dir.exists():
+        return set()
+    return {p.name for p in skills_dir.iterdir() if p.is_dir()}
+
+
+def _table_names(db_path):
+    conn = sqlite3.connect(str(db_path))
+    try:
+        rows = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table'"
+        ).fetchall()
+        return {row[0] for row in rows}
+    finally:
+        conn.close()
+
+
+def _run_setup(args=()):
+    from cafleet.cli import cli
+
+    return CliRunner().invoke(cli, ["setup", *args])
+
+
+# --------------------------------------------------------------------------- #
+# Target resolution: auto-detect and --agent scoping                          #
+# --------------------------------------------------------------------------- #
+
+
+def test_autodetect_installs_only_present_homes(homes, registry_db, monkeypatch):
+    """Auto-detect installs only where the agent home exists."""
+    _make_home(homes["claude"])
+    _make_home(homes["opencode"])
+    # codex home intentionally absent
+    _mock_release(monkeypatch, zip_bytes=_make_skills_zip())
+
+    result = _run_setup()
+
+    assert result.exit_code == 0, result.output
+    assert _installed_skill_dirs(homes["claude"]) == set(SKILL_DIR_NAMES)
+    assert _installed_skill_dirs(homes["opencode"]) == set(SKILL_DIR_NAMES)
+    assert not homes["codex"].exists()
+    assert {"fleets", "agents", "tasks", "alembic_version"} <= _table_names(
+        registry_db
+    )
+
+
+def test_agent_flag_scopes_targets_and_dedupes(homes, registry_db, monkeypatch):
+    """--agent limits the skills targets; repeated values are deduped silently."""
+    for skills_dir in homes.values():
+        _make_home(skills_dir)
+    _mock_release(monkeypatch, zip_bytes=_make_skills_zip())
+
+    result = _run_setup(["--agent", "claude", "--agent", "claude"])
+
+    assert result.exit_code == 0, result.output
+    assert _installed_skill_dirs(homes["claude"]) == set(SKILL_DIR_NAMES)
+    assert _installed_skill_dirs(homes["codex"]) == set()
+    assert _installed_skill_dirs(homes["opencode"]) == set()
+    # silent dedupe: claude is installed/reported exactly once
+    assert result.output.count("claude:") == 1
+
+
+def test_agent_flag_db_half_still_runs(homes, registry_db, monkeypatch):
+    """The database half runs even when --agent scopes the skills half."""
+    _make_home(homes["codex"])
+    _mock_release(monkeypatch, zip_bytes=_make_skills_zip())
+
+    result = _run_setup(["--agent", "codex"])
+
+    assert result.exit_code == 0, result.output
+    assert _installed_skill_dirs(homes["codex"]) == set(SKILL_DIR_NAMES)
+    assert {"alembic_version", "fleets"} <= _table_names(registry_db)
+
+
+def test_agent_flag_creates_missing_home(homes, registry_db, monkeypatch):
+    """An explicitly named agent whose home is absent gets its tree created."""
+    # no homes pre-created
+    _mock_release(monkeypatch, zip_bytes=_make_skills_zip())
+
+    result = _run_setup(["--agent", "claude"])
+
+    assert result.exit_code == 0, result.output
+    assert _installed_skill_dirs(homes["claude"]) == set(SKILL_DIR_NAMES)
+
+
+def test_zero_homes_detected(homes, registry_db, monkeypatch):
+    """Auto-detect with no homes fails the skills half listing the searched paths."""
+    _mock_release(monkeypatch, zip_bytes=_make_skills_zip())
+
+    result = _run_setup()
+
+    assert result.exit_code == 1, result.output
+    out = result.output.lower()
+    assert "no coding-agent homes detected" in out
+    assert ".claude" in result.output
+    assert ".codex" in result.output
+    assert "opencode" in result.output
+    # the database half still ran despite the skills-half failure
+    assert "alembic_version" in _table_names(registry_db)
+
+
+# --------------------------------------------------------------------------- #
+# Replace semantics / idempotency                                             #
+# --------------------------------------------------------------------------- #
+
+
+def test_replace_idempotency_second_run_clean_tree(homes, registry_db, monkeypatch):
+    """Each run replaces the skill dirs; re-running yields the same clean tree."""
+    _make_home(homes["claude"])
+    stale = homes["claude"] / "cafleet" / "STALE.md"
+    stale.parent.mkdir(parents=True)
+    stale.write_text("old")
+    _mock_release(monkeypatch, zip_bytes=_make_skills_zip())
+
+    first = _run_setup(["--agent", "claude"])
+    assert first.exit_code == 0, first.output
+    assert not stale.exists()  # replaced, not merged
+    tree_after_first = sorted(
+        p.relative_to(homes["claude"]).as_posix()
+        for p in homes["claude"].rglob("*")
+    )
+
+    second = _run_setup(["--agent", "claude"])
+    assert second.exit_code == 0, second.output
+    tree_after_second = sorted(
+        p.relative_to(homes["claude"]).as_posix()
+        for p in homes["claude"].rglob("*")
+    )
+    assert tree_after_second == tree_after_first
+
+
+# --------------------------------------------------------------------------- #
+# Archive integrity                                                           #
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize("evil_member", ["../evil.txt", "/abs/evil.txt"])
+def test_zip_slip_member_rejected_nothing_extracted(
+    homes, registry_db, monkeypatch, evil_member
+):
+    """A ``..``/absolute member is rejected before extraction; targets untouched."""
+    _make_home(homes["claude"])
+    sentinel = homes["claude"] / "cafleet" / "SENTINEL.md"
+    sentinel.parent.mkdir(parents=True)
+    sentinel.write_text("keep")
+    members = [f"skills/{name}/SKILL.md" for name in SKILL_DIR_NAMES] + [evil_member]
+    _mock_release(monkeypatch, zip_bytes=_make_skills_zip(raw_members=members))
+
+    result = _run_setup(["--agent", "claude"])
+
+    assert result.exit_code == 1, result.output
+    assert sentinel.exists()  # nothing extracted, nothing removed
+    assert sentinel.read_text() == "keep"
+
+
+@pytest.mark.parametrize(
+    "zip_bytes",
+    [
+        _make_skills_zip(extra_dirs=("rogue",)),
+        _make_skills_zip(extra_files=("README.md",)),
+    ],
+    ids=["extra-dir", "stray-file"],
+)
+def test_extra_entry_under_skills_is_malformed(
+    homes, registry_db, monkeypatch, zip_bytes
+):
+    """Any entry under ``skills/`` beyond the three skill dirs is malformed."""
+    _make_home(homes["claude"])
+    _mock_release(monkeypatch, zip_bytes=zip_bytes)
+
+    result = _run_setup(["--agent", "claude"])
+
+    assert result.exit_code == 1, result.output
+    assert "malformed" in result.output.lower()
+
+
+def test_missing_skill_dir_is_malformed(homes, registry_db, monkeypatch):
+    """A ``skills/`` holding only two of the three skill dirs is malformed."""
+    _make_home(homes["claude"])
+    _mock_release(
+        monkeypatch,
+        zip_bytes=_make_skills_zip(skill_dirs=("cafleet", "cafleet-design-doc")),
+    )
+
+    result = _run_setup(["--agent", "claude"])
+
+    assert result.exit_code == 1, result.output
+    assert "malformed" in result.output.lower()
+
+
+def test_bad_zip_is_malformed(homes, registry_db, monkeypatch):
+    """A non-zip / truncated download surfaces as the malformed-asset error."""
+    _make_home(homes["claude"])
+    _mock_release(monkeypatch, zip_bytes=b"this is not a zip archive")
+
+    result = _run_setup(["--agent", "claude"])
+
+    assert result.exit_code == 1, result.output
+    assert "malformed" in result.output.lower()
+
+
+# --------------------------------------------------------------------------- #
+# Release / network resolution                                               #
+# --------------------------------------------------------------------------- #
+
+
+def test_missing_asset_message(homes, registry_db, monkeypatch):
+    """An asset absent from the release surfaces the specific not-found message."""
+    _make_home(homes["claude"])
+    _mock_release(
+        monkeypatch,
+        assets=[{"name": "something-else.zip", "browser_download_url": DOWNLOAD_URL}],
+    )
+
+    result = _run_setup(["--agent", "claude"])
+
+    assert result.exit_code == 1, result.output
+    assert ASSET_NAME in result.output
+    assert "not found" in result.output.lower()
+
+
+def test_no_release_for_version(homes, registry_db, monkeypatch):
+    """A 404 from ``/releases/tags/<version>`` is the no-release-for-version error."""
+    _make_home(homes["claude"])
+    err = urllib.error.HTTPError(
+        url="https://api.github.com/repos/himkt/cafleet/releases/tags/0.12.2",
+        code=404,
+        msg="Not Found",
+        hdrs=None,
+        fp=None,
+    )
+    _mock_release(monkeypatch, api_error=err)
+
+    result = _run_setup(["--agent", "claude"])
+
+    assert result.exit_code == 1, result.output
+    assert CLI_VERSION in result.output
+    assert "no release found" in result.output.lower()
+
+
+@pytest.mark.parametrize(
+    "api_error",
+    [
+        urllib.error.URLError("dns failure"),
+        urllib.error.HTTPError(
+            url="https://api", code=403, msg="rate limited", hdrs=None, fp=None
+        ),
+        urllib.error.HTTPError(
+            url="https://api", code=500, msg="server error", hdrs=None, fp=None
+        ),
+        socket.timeout("timed out"),
+    ],
+    ids=["urlerror", "http-403", "http-500", "timeout"],
+)
+def test_network_error_folded(homes, registry_db, monkeypatch, api_error):
+    """URLError, timeout, 403 rate-limit and non-404 5xx fold into one message."""
+    _make_home(homes["claude"])
+    _mock_release(monkeypatch, api_error=api_error)
+
+    result = _run_setup(["--agent", "claude"])
+
+    assert result.exit_code == 1, result.output
+    assert "could not reach the github api" in result.output.lower()
+
+
+# --------------------------------------------------------------------------- #
+# Install-time filesystem errors                                             #
+# --------------------------------------------------------------------------- #
+
+
+def test_unwritable_target_permission_error(homes, registry_db, monkeypatch):
+    """A ``PermissionError`` during install surfaces as a ClickException."""
+    from cafleet.cli import setup as setup_module
+
+    _make_home(homes["claude"])
+    _mock_release(monkeypatch, zip_bytes=_make_skills_zip())
+
+    def deny_copytree(src, dst, *args, **kwargs):
+        raise PermissionError(13, "Permission denied", str(dst))
+
+    monkeypatch.setattr(setup_module.shutil, "copytree", deny_copytree)
+
+    result = _run_setup(["--agent", "claude"])
+
+    assert result.exit_code == 1, result.output
+    out = result.output.lower()
+    assert "permission" in out or "denied" in out
+
+
+# --------------------------------------------------------------------------- #
+# Independence of the two halves (Step 4 task 2)                              #
+# --------------------------------------------------------------------------- #
+
+
+def test_independence_skills_fail_db_succeeds(homes, registry_db, monkeypatch):
+    """Skills half fails (malformed asset); the DB half still runs to head."""
+    _make_home(homes["claude"])
+    _mock_release(monkeypatch, zip_bytes=b"not a zip")
+
+    result = _run_setup()
+
+    assert result.exit_code == 1, result.output
+    out = result.output.lower()
+    # skills-half failure reported
+    assert "malformed" in out
+    assert "skills" in out
+    # db-half success: schema created at head and its status line printed
+    assert {"alembic_version", "fleets"} <= _table_names(registry_db)
+    assert "applied" in out or "head" in out
+
+
+def test_independence_db_fail_skills_succeed(homes, registry_db, monkeypatch):
+    """DB half fails (orphan-tables DB); the skills half still installs."""
+    _make_home(homes["claude"])
+    registry_db.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(registry_db))
+    try:
+        conn.execute("CREATE TABLE legacy_squat (id INTEGER PRIMARY KEY)")
+        conn.commit()
+    finally:
+        conn.close()
+    _mock_release(monkeypatch, zip_bytes=_make_skills_zip())
+
+    result = _run_setup(["--agent", "claude"])
+
+    assert result.exit_code == 1, result.output
+    out = result.output
+    # skills-half success: installed and its report line printed
+    assert _installed_skill_dirs(homes["claude"]) == set(SKILL_DIR_NAMES)
+    assert "installed" in out.lower()
+    # db-half failure reported
+    assert "alembic stamp head" in out
+    assert "db" in out.lower()

--- a/cafleet/tests/db/test_init.py
+++ b/cafleet/tests/db/test_init.py
@@ -178,3 +178,85 @@ def test_db_init_ahead_errors(tmp_path, monkeypatch):
     finally:
         conn.close()
     assert rows == [("9999_future_revision",)]
+
+
+def test_run_db_init_creates_schema_at_head(tmp_path, monkeypatch, capsys):
+    """``run_db_init()`` called directly creates the schema at head.
+
+    Exercises the reusable helper the way ``cafleet setup``'s database half
+    invokes it -- no CLI runner, no skills mocking.
+    """
+    db_file = tmp_path / "data" / "cafleet.db"
+    monkeypatch.setattr(
+        config.settings,
+        "database_url",
+        f"sqlite+aiosqlite:///{db_file}",
+    )
+
+    assert not db_file.parent.exists()
+
+    from cafleet.cli.db import run_db_init
+
+    run_db_init()
+
+    assert db_file.parent.exists()
+    assert db_file.exists()
+
+    tables = _table_names(db_file)
+    expected = {"fleets", "agents", "tasks", "agent_placements", "alembic_version"}
+    assert expected <= tables
+
+    assert "applied" in capsys.readouterr().out.lower()
+
+
+def test_run_db_init_idempotent_reports_already_at_head(tmp_path, monkeypatch, capsys):
+    """A second direct ``run_db_init()`` is a no-op reporting ``Already at head``."""
+    db_file = tmp_path / "cafleet.db"
+    monkeypatch.setattr(
+        config.settings,
+        "database_url",
+        f"sqlite+aiosqlite:///{db_file}",
+    )
+
+    from cafleet.cli.db import run_db_init
+
+    run_db_init()
+    capsys.readouterr()
+
+    conn = sqlite3.connect(str(db_file))
+    try:
+        version_after_first = conn.execute(
+            "SELECT version_num FROM alembic_version"
+        ).fetchall()
+    finally:
+        conn.close()
+
+    run_db_init()
+
+    assert "already at head" in capsys.readouterr().out.lower()
+
+    conn = sqlite3.connect(str(db_file))
+    try:
+        version_after_second = conn.execute(
+            "SELECT version_num FROM alembic_version"
+        ).fetchall()
+    finally:
+        conn.close()
+    assert version_after_second == version_after_first
+
+
+def test_db_init_delegates_to_run_db_init(monkeypatch):
+    """``cafleet db init`` is a thin wrapper that calls ``run_db_init()``."""
+    calls = []
+
+    from cafleet.cli import db as db_module
+
+    monkeypatch.setattr(db_module, "run_db_init", lambda: calls.append(True))
+
+    from cafleet.cli import cli
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["db", "init"])
+
+    assert result.exit_code == 0, result.output
+    assert calls == [True]

--- a/design-docs/0000109-cafleet-setup-command/design-doc.md
+++ b/design-docs/0000109-cafleet-setup-command/design-doc.md
@@ -10,16 +10,16 @@ Add a `cafleet setup` CLI command that onboards a new machine in one step: it do
 
 ## Success Criteria
 
-- [ ] `cafleet setup` runs **both** halves: installs skills into every detected agent home **and** migrates the database to head.
-- [ ] The skills version is the **installed `cafleet` CLI version** (`importlib.metadata.version("cafleet")`); the skills half downloads `cafleet-skills-v<cli_version>.zip` from the Release tagged `<cli_version>` of `himkt/cafleet` over the public REST API using only the Python standard library (no new dependency, `gh` not required at runtime).
-- [ ] Auto-detect installs skills only into agent homes that exist: `claude` → `~/.claude/skills/`, `codex` → `~/.codex/skills/`, `opencode` → `~/.config/opencode/skills/`.
-- [ ] `--agent claude|codex|opencode` (repeatable, duplicate values deduped silently) scopes the **skills** targets to the named agents; the database half still runs.
-- [ ] Each of the three skill directories is **replaced** (removed then re-extracted) at every target, so re-running `cafleet setup` against the same installed CLI version yields the same tree (per-resolved-version idempotency).
-- [ ] Archive members with path-traversal / zip-slip paths (`..` or absolute) are rejected before extraction.
-- [ ] A `skills/` directory whose entries are not exactly the three `SKILL_DIRS` directories — an extra directory, a missing one, or any stray non-directory file — is treated as malformed.
-- [ ] The database half reuses the exact `cafleet db init` migration code path (including the refuse-on-unknown-revision guard); no migration logic is duplicated.
-- [ ] The two halves run independently — a failure in one does not abort the other — each prints its own status, and the command exits non-zero if **either** half fails.
-- [ ] `docs/get-started/install.md` and `README.md` present `cafleet setup` as the recommended end-user onboarding path; `gh skill install` / `mise //:skill-install` remain documented only as the contributor/local-dev path.
+- [x] `cafleet setup` runs **both** halves: installs skills into every detected agent home **and** migrates the database to head.
+- [x] The skills version is the **installed `cafleet` CLI version** (`importlib.metadata.version("cafleet")`); the skills half downloads `cafleet-skills-v<cli_version>.zip` from the Release tagged `<cli_version>` of `himkt/cafleet` over the public REST API using only the Python standard library (no new dependency, `gh` not required at runtime).
+- [x] Auto-detect installs skills only into agent homes that exist: `claude` → `~/.claude/skills/`, `codex` → `~/.codex/skills/`, `opencode` → `~/.config/opencode/skills/`.
+- [x] `--agent claude|codex|opencode` (repeatable, duplicate values deduped silently) scopes the **skills** targets to the named agents; the database half still runs.
+- [x] Each of the three skill directories is **replaced** (removed then re-extracted) at every target, so re-running `cafleet setup` against the same installed CLI version yields the same tree (per-resolved-version idempotency).
+- [x] Archive members with path-traversal / zip-slip paths (`..` or absolute) are rejected before extraction.
+- [x] A `skills/` directory whose entries are not exactly the three `SKILL_DIRS` directories — an extra directory, a missing one, or any stray non-directory file — is treated as malformed.
+- [x] The database half reuses the exact `cafleet db init` migration code path (including the refuse-on-unknown-revision guard); no migration logic is duplicated.
+- [x] The two halves run independently — a failure in one does not abort the other — each prints its own status, and the command exits non-zero if **either** half fails.
+- [x] `docs/get-started/install.md` and `README.md` present `cafleet setup` as the recommended end-user onboarding path; `gh skill install` / `mise //:skill-install` remain documented only as the contributor/local-dev path.
 
 ---
 

--- a/design-docs/0000109-cafleet-setup-command/design-doc.md
+++ b/design-docs/0000109-cafleet-setup-command/design-doc.md
@@ -1,7 +1,7 @@
 # cafleet setup command
 
 **Status**: Approved
-**Progress**: 4/13 tasks complete
+**Progress**: 5/13 tasks complete
 **Last Updated**: 2026-06-22
 
 ## Overview
@@ -184,7 +184,7 @@ This change adds a CLI command but no new config/env surface (`config.py` is unc
 
 ### Step 2: Refactor the database init code path for reuse
 
-- [ ] Extract the body of `db.init()` in `cafleet/src/cafleet/cli/db.py` into a module-level `run_db_init() -> None`, preserving the unknown-revision and orphan-tables guards and all echo messages; make `db.init()` a thin wrapper calling it. <!-- completed: -->
+- [x] Extract the body of `db.init()` in `cafleet/src/cafleet/cli/db.py` into a module-level `run_db_init() -> None`, preserving the unknown-revision and orphan-tables guards and all echo messages; make `db.init()` a thin wrapper calling it. <!-- completed: 2026-06-23T08:27 -->
 
 ### Step 3: Implement the `cafleet setup` command
 

--- a/design-docs/0000109-cafleet-setup-command/design-doc.md
+++ b/design-docs/0000109-cafleet-setup-command/design-doc.md
@@ -1,7 +1,7 @@
 # cafleet setup command
 
 **Status**: Approved
-**Progress**: 0/13 tasks complete
+**Progress**: 4/13 tasks complete
 **Last Updated**: 2026-06-22
 
 ## Overview
@@ -177,10 +177,10 @@ This change adds a CLI command but no new config/env surface (`config.py` is unc
 
 ### Step 1: Documentation first
 
-- [ ] Rewrite `docs/get-started/install.md` end-user flow around `uv tool install cafleet` → `cafleet setup`; move `gh skill install` / `mise //:skill-install` to a contributor/local-dev note; keep the integer-PK upgrade warning. <!-- completed: -->
-- [ ] Update `README.md` so onboarding points to `cafleet setup`, consistent with the install page. <!-- completed: -->
-- [ ] Add the `cafleet setup` row + detail section (the single `--agent` flag; note skills track the installed CLI version; no exit-codes table) to `docs/spec/cli-options.md`. <!-- completed: -->
-- [ ] Update affected `SKILL.md` / skill CLI-reference pages (notably `skills/cafleet/SKILL.md`) so the documented onboarding matches `cafleet setup`. <!-- completed: -->
+- [x] Rewrite `docs/get-started/install.md` end-user flow around `uv tool install cafleet` → `cafleet setup`; move `gh skill install` / `mise //:skill-install` to a contributor/local-dev note; keep the integer-PK upgrade warning. <!-- completed: 2026-06-23T08:22 -->
+- [x] Update `README.md` so onboarding points to `cafleet setup`, consistent with the install page. <!-- completed: 2026-06-23T08:22 -->
+- [x] Add the `cafleet setup` row + detail section (the single `--agent` flag; note skills track the installed CLI version; no exit-codes table) to `docs/spec/cli-options.md`. <!-- completed: 2026-06-23T08:22 -->
+- [x] Update affected `SKILL.md` / skill CLI-reference pages (notably `skills/cafleet/SKILL.md`) so the documented onboarding matches `cafleet setup`. <!-- completed: 2026-06-23T08:22 -->
 
 ### Step 2: Refactor the database init code path for reuse
 

--- a/design-docs/0000109-cafleet-setup-command/design-doc.md
+++ b/design-docs/0000109-cafleet-setup-command/design-doc.md
@@ -1,7 +1,7 @@
 # cafleet setup command
 
 **Status**: Approved
-**Progress**: 5/13 tasks complete
+**Progress**: 8/13 tasks complete
 **Last Updated**: 2026-06-22
 
 ## Overview
@@ -195,9 +195,9 @@ This change adds a CLI command but no new config/env surface (`config.py` is unc
 
 ### Step 4: Tests
 
-- [ ] Add `cafleet/tests/cli/test_setup.py` using `click.testing.CliRunner`, monkeypatching `importlib.metadata.version("cafleet")`, the `GET /releases/tags/<cli_version>` response, and the asset download (a synthetic in-memory zip; redirect-following is out of scope — monkeypatch the URL directly), with `AGENT_SKILLS_DIRS` pointed at `tmp_path` homes. Cover: auto-detect installs only into present homes; `--agent` scoping including silent dedupe of repeated values; `--agent` valid while the DB half still runs; replace/idempotency (a second run against the same version leaves a clean tree); zip-slip member rejected (nothing extracted); an extra entry under `skills/` (extra dir or stray file) → malformed; **a missing skill dir (`skills/` holds only two of the three `SKILL_DIRS`) → malformed**; missing-asset generic message; **404 no-release-for-version**; the network-error path including folded 403/5xx; `BadZipFile` → malformed; **unwritable target** (`PermissionError` during install); and **zero homes detected** (auto-detect resolves an empty set). Every *Error handling* row has a corresponding case. <!-- completed: -->
-- [ ] Add the two **independence** cases under full `cafleet setup`: (a) force the skills half to fail (malformed asset) and assert the DB half still ran (schema created at head), exit code == 1, and both per-half status lines printed; (b) force the DB half to fail (orphan-tables DB) while skills succeed, and assert skills were still installed, exit code == 1, and both status lines printed. <!-- completed: -->
-- [ ] Add a database-half test that invokes `run_db_init()` **directly** as a unit test (no skills mocking) against a temp SQLite — creates the schema at head; a re-run reports "Already at head"; confirm `cafleet db init` is otherwise unchanged. (The DB half under full `cafleet setup` is already exercised by the main test above, where the skills half is mocked.) <!-- completed: -->
+- [x] Add `cafleet/tests/cli/test_setup.py` using `click.testing.CliRunner`, monkeypatching `importlib.metadata.version("cafleet")`, the `GET /releases/tags/<cli_version>` response, and the asset download (a synthetic in-memory zip; redirect-following is out of scope — monkeypatch the URL directly), with `AGENT_SKILLS_DIRS` pointed at `tmp_path` homes. Cover: auto-detect installs only into present homes; `--agent` scoping including silent dedupe of repeated values; `--agent` valid while the DB half still runs; replace/idempotency (a second run against the same version leaves a clean tree); zip-slip member rejected (nothing extracted); an extra entry under `skills/` (extra dir or stray file) → malformed; **a missing skill dir (`skills/` holds only two of the three `SKILL_DIRS`) → malformed**; missing-asset generic message; **404 no-release-for-version**; the network-error path including folded 403/5xx; `BadZipFile` → malformed; **unwritable target** (`PermissionError` during install); and **zero homes detected** (auto-detect resolves an empty set). Every *Error handling* row has a corresponding case. <!-- completed: 2026-06-23T08:31 -->
+- [x] Add the two **independence** cases under full `cafleet setup`: (a) force the skills half to fail (malformed asset) and assert the DB half still ran (schema created at head), exit code == 1, and both per-half status lines printed; (b) force the DB half to fail (orphan-tables DB) while skills succeed, and assert skills were still installed, exit code == 1, and both status lines printed. <!-- completed: 2026-06-23T08:31 -->
+- [x] Add a database-half test that invokes `run_db_init()` **directly** as a unit test (no skills mocking) against a temp SQLite — creates the schema at head; a re-run reports "Already at head"; confirm `cafleet db init` is otherwise unchanged. (The DB half under full `cafleet setup` is already exercised by the main test above, where the skills half is mocked.) <!-- completed: 2026-06-23T08:31 -->
 
 ### Step 5: Validate
 

--- a/design-docs/0000109-cafleet-setup-command/design-doc.md
+++ b/design-docs/0000109-cafleet-setup-command/design-doc.md
@@ -1,7 +1,7 @@
 # cafleet setup command
 
 **Status**: Approved
-**Progress**: 8/13 tasks complete
+**Progress**: 12/13 tasks complete
 **Last Updated**: 2026-06-22
 
 ## Overview
@@ -188,10 +188,10 @@ This change adds a CLI command but no new config/env surface (`config.py` is unc
 
 ### Step 3: Implement the `cafleet setup` command
 
-- [ ] Create `cafleet/src/cafleet/cli/setup.py` with the `setup` command: constants (`GITHUB_REPO`, `SKILL_DIRS`, `HTTP_TIMEOUT`, `AGENT_SKILLS_DIRS`) and the sole `--agent` flag (repeatable choice, deduped; Click's choice check is the only validation). <!-- completed: -->
-- [ ] Implement the skills half: resolve target agents (auto-detect or `--agent`), read the installed version via `importlib.metadata.version("cafleet")`, resolve the Release via `GET /repos/himkt/cafleet/releases/tags/<cli_version>`, locate `cafleet-skills-v<cli_version>.zip`, download to a temp file (timeout `HTTP_TIMEOUT`), reject zip-slip members, extract + validate the `skills/` layout is exactly `SKILL_DIRS` (download/extract/validate before any rmtree), then install each skill dir with replace semantics. <!-- completed: -->
-- [ ] Implement the database half by calling `run_db_init()`, and the independent-halves orchestration (always run both, collect per-half failures, print per-half status, exit non-zero if either failed). <!-- completed: -->
-- [ ] Register `setup` in `cafleet/src/cafleet/cli/__init__.py` via `cli.add_command(setup)`. <!-- completed: -->
+- [x] Create `cafleet/src/cafleet/cli/setup.py` with the `setup` command: constants (`GITHUB_REPO`, `SKILL_DIRS`, `HTTP_TIMEOUT`, `AGENT_SKILLS_DIRS`) and the sole `--agent` flag (repeatable choice, deduped; Click's choice check is the only validation). <!-- completed: 2026-06-23T08:40 -->
+- [x] Implement the skills half: resolve target agents (auto-detect or `--agent`), read the installed version via `importlib.metadata.version("cafleet")`, resolve the Release via `GET /repos/himkt/cafleet/releases/tags/<cli_version>`, locate `cafleet-skills-v<cli_version>.zip`, download to a temp file (timeout `HTTP_TIMEOUT`), reject zip-slip members, extract + validate the `skills/` layout is exactly `SKILL_DIRS` (download/extract/validate before any rmtree), then install each skill dir with replace semantics. <!-- completed: 2026-06-23T08:40 -->
+- [x] Implement the database half by calling `run_db_init()`, and the independent-halves orchestration (always run both, collect per-half failures, print per-half status, exit non-zero if either failed). <!-- completed: 2026-06-23T08:40 -->
+- [x] Register `setup` in `cafleet/src/cafleet/cli/__init__.py` via `cli.add_command(setup)`. <!-- completed: 2026-06-23T08:40 -->
 
 ### Step 4: Tests
 

--- a/design-docs/0000109-cafleet-setup-command/design-doc.md
+++ b/design-docs/0000109-cafleet-setup-command/design-doc.md
@@ -1,7 +1,7 @@
 # cafleet setup command
 
 **Status**: Approved
-**Progress**: 12/13 tasks complete
+**Progress**: 13/13 tasks complete
 **Last Updated**: 2026-06-22
 
 ## Overview
@@ -201,7 +201,7 @@ This change adds a CLI command but no new config/env surface (`config.py` is unc
 
 ### Step 5: Validate
 
-- [ ] Run `mise //cafleet:lint`, `mise //cafleet:typecheck`, and `mise //cafleet:test`; fix any findings. <!-- completed: -->
+- [x] Run `mise //cafleet:lint`, `mise //cafleet:typecheck`, and `mise //cafleet:test`; fix any findings. <!-- completed: 2026-06-23T08:44 -->
 
 ---
 

--- a/design-docs/0000109-cafleet-setup-command/design-doc.md
+++ b/design-docs/0000109-cafleet-setup-command/design-doc.md
@@ -1,8 +1,8 @@
 # cafleet setup command
 
-**Status**: Approved
+**Status**: Complete
 **Progress**: 13/13 tasks complete
-**Last Updated**: 2026-06-22
+**Last Updated**: 2026-06-23
 
 ## Overview
 
@@ -211,3 +211,4 @@ This change adds a CLI command but no new config/env surface (`config.py` is unc
 |------|---------|
 | 2026-06-22 | Initial draft |
 | 2026-06-22 | Interview pivot: skills version derived from the installed CLI version (no latest-stable); flag surface reduced to `--agent` only (dropped `--skills-only`/`--db-only`/`--release-tag`); added zip-slip rejection and strict `skills/` layout validation; removed the asset-availability-precondition guard. |
+| 2026-06-23 | Implemented via TDD (PR #146): docs-first onboarding rewrite, `run_db_init()` extraction, `cafleet setup` command, 27 setup tests + 3 `run_db_init` tests (928 total). Opus review pass; Copilot review addressed (GitHub-API parse + zip-extract OSError folded to clean ClickExceptions, install-doc `--agent` clarification). Status → Complete. |

--- a/docs/get-started/install.md
+++ b/docs/get-started/install.md
@@ -5,25 +5,37 @@ icon: lucide/download
 # Install
 
 CAFleet has two install surfaces: the **broker CLI** (`cafleet`), which every
-fleet needs, and the **coding-agent plugins**, one per backend you intend to
-use.
+fleet needs, and the **coding-agent skills**, one set per backend you intend to
+use. The recommended end-user path installs both in two commands.
 
-## CAFleet CLI
-
-The CLI is the binary that every fleet needs. It is published as a Python
-package; pick whichever installer matches your environment:
+## Quick start (recommended)
 
 ```bash
 uv tool install cafleet     # or: pip install cafleet
-cafleet db init             # apply schema migrations (idempotent; rerun after upgrades)
+cafleet setup               # install the skills + migrate the database
 ```
+
+`cafleet setup` is the one-step onboarding command. It does two independent
+things, and runs both on every invocation:
+
+- **Installs the skills** that match your installed `cafleet` version. It
+  downloads the `cafleet-skills-v<version>.zip` asset from the matching GitHub
+  Release and extracts the three skill directories (`cafleet`,
+  `cafleet-design-doc`, `cafleet-research`) into every detected coding-agent
+  home: `claude` → `~/.claude/skills/`, `codex` → `~/.codex/skills/`,
+  `opencode` → `~/.config/opencode/skills/`. Only homes that already exist are
+  targeted. Scope the install to specific agents with
+  `--agent claude|codex|opencode` (repeatable).
+- **Migrates the database** to the head Alembic revision — the same code path
+  as `cafleet db init`.
+
+Each skill directory is fully replaced on every run, so re-running
+`cafleet setup` after upgrading the package refreshes the skills to the new
+version and applies any new migrations in the same step.
 
 The default database lives at `~/.local/share/cafleet/cafleet.db`. Override
 with the `CAFLEET_DATABASE_URL` environment variable — use an absolute path,
 since SQLAlchemy does not expand `~` in SQLite URLs.
-
-`cafleet db init` is idempotent: re-run it after upgrading the package and it
-will apply any new Alembic migrations without disturbing existing data.
 
 !!! warning "Upgrading across the integer-PK rearchitecture"
 
@@ -32,17 +44,24 @@ will apply any new Alembic migrations without disturbing existing data.
     file moved from `~/.local/share/cafleet/registry.db` to
     `~/.local/share/cafleet/cafleet.db`, so the old file is left untouched and
     ignored — remove it manually. If you set `CAFLEET_DATABASE_URL` to a custom
-    path holding an old (UUID-era) schema, `cafleet db init` refuses to run
-    against its unknown Alembic revision; delete that file and re-run
-    `cafleet db init`.
+    path holding an old (UUID-era) schema, the database half of `cafleet setup`
+    (like `cafleet db init`) refuses to run against its unknown Alembic
+    revision; delete that file and re-run `cafleet setup`.
 
-## CAFleet skills
+## Contributor / local-dev install
 
-CAFleet supports three coding agents — `claude` (Claude Code), `codex` (OpenAI
-Codex CLI), and `opencode` — and the broker CLI is shared by all three. Install
-the plugin in whichever coding agent you use.
+`cafleet setup` installs the skills from a published Release, so it is the
+**end-user (installed-CLI)** path. Contributors working from a clone install
+the skills from the working tree instead:
 
-### (a) GitHub CLI (recommended)
+```bash
+mise //:skill-install
+```
+
+This runs `gh skill install ./ --from-local` for each backend, placing the
+skills from your checkout (not a Release) into the three agent homes. You can
+also install from the published repository with the GitHub CLI or a
+coding-agent marketplace:
 
 ```bash
 gh skill install himkt/cafleet --agent claude-code
@@ -50,18 +69,14 @@ gh skill install himkt/cafleet --agent codex
 gh skill install himkt/cafleet --agent opencode
 ```
 
-### (b) Claude Code marketplace
-
 ```text
+# Claude Code marketplace
 /plugin marketplace add himkt/cafleet
 /plugin install cafleet@cafleet
-```
 
-### (c) Codex
-
-```text
+# Codex
 codex plugin marketplace add himkt/cafleet
 ```
 
-Once the CLI and at least one coding-agent plugin are installed, continue to
+Once the CLI and at least one coding-agent skill set are installed, continue to
 the [Configure](configure.md) page for the recommended per-agent settings.

--- a/docs/get-started/install.md
+++ b/docs/get-started/install.md
@@ -23,9 +23,10 @@ things, and runs both on every invocation:
   Release and extracts the three skill directories (`cafleet`,
   `cafleet-design-doc`, `cafleet-research`) into every detected coding-agent
   home: `claude` → `~/.claude/skills/`, `codex` → `~/.codex/skills/`,
-  `opencode` → `~/.config/opencode/skills/`. Only homes that already exist are
-  targeted. Scope the install to specific agents with
-  `--agent claude|codex|opencode` (repeatable).
+  `opencode` → `~/.config/opencode/skills/`. With auto-detect, only homes that
+  already exist are targeted. Scope the install to specific agents with
+  `--agent claude|codex|opencode` (repeatable) — an explicitly named agent's
+  home is created if it does not yet exist.
 - **Migrates the database** to the head Alembic revision — the same code path
   as `cafleet db init`.
 

--- a/docs/spec/cli-options.md
+++ b/docs/spec/cli-options.md
@@ -13,6 +13,7 @@ One row per subcommand. "Identity flag" is the per-subcommand option naming the 
 | Subcommand | Purpose | `--fleet-id` | Identity flag | Section |
 |---|---|---|---|---|
 | `db init` | Create or migrate the SQLite schema to head | no | none | [db init](#db-init) |
+| `setup` | Install the skills + migrate the schema to head | no | none | [setup](#cafleet-setup) |
 | `fleet create` | Create a fleet with its root Director and Administrator | no | none | [fleet create](#fleet-create) |
 | `fleet list` | List non-deleted fleets | no | none | [fleet list](#fleet-list) |
 | `fleet show` | Show one fleet (soft-deleted included) | no | none | [fleet show](#fleet-show) |
@@ -85,7 +86,7 @@ Placed **before** the subcommand:
 
 ## Fleet ID (`--fleet-id`) {#fleet-id}
 
-`--fleet-id` is a **per-subcommand option** (not a top-level option). It names the fleet the command acts on and is placed immediately **after** the subcommand name (the canonical position), ahead of the other flags — e.g. `cafleet message poll --fleet-id <id> --agent-id <id>`. It is typed `int`; a non-integer fails with Click's standard `Error: Invalid value for '--fleet-id': '<x>' is not a valid integer.` (exit 2). Every client/member/monitor leaf command that touches agents, messages, members, or the scheduler carries it; `db init`, `fleet *`, `server`, and `doctor` do **not** accept it and reject it with `No such option: --fleet-id`. Which subcommand takes it is in the [Subcommand summary](#subcommand-summary).
+`--fleet-id` is a **per-subcommand option** (not a top-level option). It names the fleet the command acts on and is placed immediately **after** the subcommand name (the canonical position), ahead of the other flags — e.g. `cafleet message poll --fleet-id <id> --agent-id <id>`. It is typed `int`; a non-integer fails with Click's standard `Error: Invalid value for '--fleet-id': '<x>' is not a valid integer.` (exit 2). Every client/member/monitor leaf command that touches agents, messages, members, or the scheduler carries it; `db init`, `setup`, `fleet *`, `server`, and `doctor` do **not** accept it and reject it with `No such option: --fleet-id`. Which subcommand takes it is in the [Subcommand summary](#subcommand-summary).
 
 It is a literal CLI flag rather than an environment variable because Claude Code's `permissions.allow` matches Bash invocations as literal command strings: a literal `--fleet-id <int>` keeps the invocation a fixed string an allow pattern can match, while shell-expansion (`export FLEET_ID=56` then `$FLEET_ID`) breaks the match and forces per-invocation permission prompts that interrupt agent work. Substitute the literal integer ids printed by `cafleet fleet create` and `cafleet agent register` — never shell variables to hold them. Matching also depends on the canonical flag order (`--fleet-id` first, immediately after the subcommand name); a different order does not match — see [`permissions.allow` coverage](#permissionsallow-coverage).
 
@@ -147,6 +148,36 @@ cafleet message poll --fleet-id <fleet-id> --agent-id <my-agent-id> --full   # f
 ```
 
 This applies to CLI emit sites only. FastAPI `/api/*` responses (see [webui-api.md](./webui-api.md)) are unchanged — the WebUI is human-facing and renders full bodies. `agent.description`, `skills[].description`, `agent_card_json` sub-fields, and `member capture` content are also untouched.
+
+## `cafleet setup` — One-Step Onboarding {#cafleet-setup}
+
+Installs the coding-agent skills **and** migrates the database in one command —
+the recommended end-user onboarding path (see
+[Install](../get-started/install.md)). It always runs both halves; they are
+independent, so a failure in one does not abort the other, and the command
+exits non-zero if either half fails.
+
+The skills installed always match the **installed `cafleet` CLI version**:
+setup reads that version, downloads the matching
+`cafleet-skills-v<version>.zip` asset from the corresponding GitHub Release of
+`himkt/cafleet`, and extracts the three skill directories (`cafleet`,
+`cafleet-design-doc`, `cafleet-research`) into each target agent home,
+replacing any existing copy. The database half reuses the `cafleet db init`
+migration code path (including its unknown-revision guard).
+
+`cafleet setup` does NOT accept `--fleet-id`. Supplying it exits 2 with
+`No such option: --fleet-id`, matching the `db init` / `fleet *` / `server` /
+`doctor` pattern.
+
+| Flag | Required | Notes |
+|---|---|---|
+| `--agent` | no | One of `claude`, `codex`, or `opencode`; repeatable (`multiple=True`), duplicate values deduped silently. Scopes the **skills** targets to exactly the named agents; the database half runs regardless. Omitted → auto-detect every agent whose home directory exists (`~/.claude`, `~/.codex`, `~/.config/opencode`). An explicitly named agent's home/skills tree is created if missing; auto-detect installs only where the home already exists. An unknown value fails Click's choice check (exit 2). |
+
+For a database-only run, use [`db init`](#db-init); setup has no
+skills-only / db-only toggle. Failures surface as runtime error messages — no
+release for the installed version, a missing or malformed skills asset, the
+GitHub API unreachable, an unwritable target, or zero detected agent homes —
+so there is no exit-codes table.
 
 ## `cafleet db` — Schema Management
 

--- a/skills/cafleet/SKILL.md
+++ b/skills/cafleet/SKILL.md
@@ -70,7 +70,7 @@ Used only when your overlay omits a token or your backend is unknown. Each defau
 
 Every `cafleet` invocation that touches agents or messages carries two literal integer ids (no env-var fallback):
 
-- `--fleet-id <int>` — per-subcommand (placed **after** the subcommand name), required on every client + member subcommand. Rejected with `No such option` on `db init` / `fleet *` / `server` / `doctor`. Missing it exits with `Error: --fleet-id <int> is required for this subcommand. …`.
+- `--fleet-id <int>` — per-subcommand (placed **after** the subcommand name), required on every client + member subcommand. Rejected with `No such option` on `db init` / `setup` / `fleet *` / `server` / `doctor`. Missing it exits with `Error: --fleet-id <int> is required for this subcommand. …`.
 - `--agent-id <int>` — per-subcommand, required on every subcommand **except** `register` (which returns the new `agent_id` to record and reuse).
 
 Use literal ids, never shell variables — `permissions.allow` matches Bash invocations as fixed strings, so `$VAR` expansion breaks the match and forces prompts. See [`cli-options.md`](../../docs/spec/cli-options.md#fleet-id) for the rationale and [`permissions.allow` coverage](../../docs/spec/cli-options.md#permissionsallow-coverage) for the pattern set.


### PR DESCRIPTION
- **docs: rewrite onboarding around cafleet setup command**
- **test: add run_db_init direct unit tests**
- **feat: extract run_db_init for reuse by cafleet setup**
- **test: add cafleet setup command tests**
- **feat: add cafleet setup onboarding command**
- **fix: replace socket.timeout alias with TimeoutError for ruff UP041**
- **docs: check off success criteria for cafleet setup**
- **test: cover asset-download network-error path**
