### PR TITLE
feat/0000118 spec docs impl consistency

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -359,11 +359,15 @@ unified:
   `"monitoring-member"`, or **absent** (ordinary user/Director). Constants:
   `ADMINISTRATOR_KIND = "builtin-administrator"`,
   `MONITORING_MEMBER_KIND = "monitoring-member"`.
-- **Broker projection** (§6.2 `get_agent`/`list_agents`/`list_fleet_agents`):
-  collapses to a **two-value** discriminator — the literal `ADMINISTRATOR_KIND`
-  when the card marks an administrator, else the literal `"user"`. The richer
-  `monitoring-member` kind is **not** surfaced by these projections; it is only
-  consulted internally via `is_monitoring_member` / JSON-path guards.
+- **Broker projections** (§6.2) surface the kind differently per function and
+  are **not** unified:
+  - `get_agent` returns a **four-value** `kind` — `director` (derived: the agent
+    is the fleet's root Director), `administrator` (card marks an administrator),
+    `monitor` (card marks a monitoring member), else `member`.
+  - `list_agents` surfaces **no** `kind` at all.
+  - `list_fleet_agents` collapses to a **two-value** discriminator — the literal
+    `ADMINISTRATOR_KIND` when the card marks an administrator, else the literal
+    `"user"`; the `monitoring-member` kind is not surfaced here.
 - **Internal predicates:** `is_administrator(card)` / `is_monitoring_member(card)`
   parse the JSON and compare `$.cafleet.kind`; both return false on
   absent/empty/malformed-JSON (a deliberate non-match, not an error mask).
@@ -511,10 +515,10 @@ during message delivery (§6.5) and one process-liveness probe (signal-0).
 `is_administrator(card)` and `is_monitoring_member(card)` parse
 `agent_card_json`, read `$.cafleet.kind`, and compare to their kind constant.
 Absent / null / empty / malformed-JSON / non-object `cafleet` value → non-match
-(`false`) — a deliberate, documented non-match, not an error mask. These
-collapse to the two-value broker projection (`ADMINISTRATOR_KIND` vs `"user"`)
-in `get_agent` / `list_agents` / `list_fleet_agents` per §5.4;
-`monitoring-member` is never surfaced by those projections.
+(`false`) — a deliberate, documented non-match, not an error mask. How the
+per-function broker projections surface the kind (`get_agent`'s four values,
+`list_agents`'s none, `list_fleet_agents`'s two-value `ADMINISTRATOR_KIND` vs
+`"user"` collapse) is detailed in §5.4.
 
 - `ADMINISTRATOR_KIND = "builtin-administrator"`,
   `MONITORING_MEMBER_KIND = "monitoring-member"`.
@@ -990,8 +994,9 @@ fleet-scoped command (§6.3 `--fleet-id`).
   `cafleet fleet create must be run inside a tmux session` (exit 1, no DB
   writes).
 - **list** — `--json` (local). Empty → `No fleets found.`; else a header plus
-  one formatted row per fleet (column widths 40 / 20 / 8; nullable cells fall
-  back to empty strings).
+  one formatted row per fleet (five columns: FLEET_ID / DIRECTOR / LABEL / AGENTS
+  left-padded 40 / 40 / 20 / 8, then a trailing unpadded CREATED_AT; nullable
+  cells fall back to empty strings).
 - **show** — `--fleet-id` (integer, required) + local `--json`. Not found →
   application error `fleet '<fleet_id>' not found.`. Text: `fleet_id`, `label`,
   `created_at`, plus a `deleted_at:` line when soft-deleted (soft-deleted rows
@@ -1649,8 +1654,7 @@ then `pending_count` with no padding.
 
 All four absent-cell helpers above use the single ASCII `-` glyph (§6.4 *The
 single absent glyph*). All conditional fields (`kind`, `origin`, the verbose
-`to:`/`text:` lines, the `coding_agent` key) are gated on truthiness — omitted,
-never emitted empty.
+`to:`/`text:` lines) are gated on truthiness — omitted, never emitted empty.
 
 ### 6.5 Multiplexer & tmux
 
@@ -1667,7 +1671,7 @@ method builds is given verbatim; preserve subcommand, flags, and ordering.
 - **`name`** — the registry key literal `"tmux"`.
 - **`ensure_available()`** — fail-fast. Raises if `tmux` is not on `PATH` →
   `tmux binary not found on PATH`; or if `TMUX` is unset/empty → `cafleet
-  tmux-pane commands must be run inside a tmux session`.
+  member commands must be run inside a tmux session`.
 - **`context_discovery() -> MultiplexerContext`** — resolves the **calling
   shell's** pane via `$TMUX_PANE` (not the active window). Read `TMUX_PANE`;
   missing/empty → `TMUX_PANE is not set; not running inside a tmux pane`. Invoke
@@ -1717,7 +1721,7 @@ method builds is given verbatim; preserve subcommand, flags, and ordering.
   trailing Enter submits the whole 2-line payload as one recipient turn.
 - **`send_bash_command(*, target_pane_id, command)`** — fail-fast. Strip
   surrounding whitespace; empty after strip → `send_bash_command: command may not
-  be empty`; the **original** command with a newline → `send_bash_command:
+  be empty`; the **original** command with a newline or CR → `send_bash_command:
   command may not contain newlines`. literal-then-Enter with `payload = "! " +
   normalized_command`, **no Esc-first** (honors the coding-agent `!` shortcut).
 - **`capture_pane(*, target_pane_id, lines=20) -> str`** — fail-fast. `lines <=
@@ -1826,11 +1830,11 @@ internals; it orchestrates calls into both.
 
 - **`should_ping(target, now) -> bool`** — pure due-check for one watched agent;
   no DB/multiplexer access.
-- **`monitor_tick(fleet_id, now) -> Continue | Stop`** — one scan pass.
+- **`monitor_tick(fleet_id, now) -> CONTINUE | STOP`** — one scan pass.
 - **`run_monitor_loop(fleet_id, tick_seconds)`** — foreground driver: claim slot
   → install signal handlers → `tick → sleep` until signalled → clear slot on
   exit.
-- **`Continue` / `Stop`** — tick-result markers distinguishing "keep looping"
+- **`CONTINUE` / `STOP`** — tick-result markers distinguishing "keep looping"
   from "self-terminate".
 - **`DEFAULT_TICK_SECONDS = 5`** — default scan cadence (seconds).
 - Re-exports `DIRECTOR_PING_INTERVAL_SECONDS` (180),
@@ -1839,7 +1843,7 @@ internals; it orchestrates calls into both.
   broker, re-exported so the loop imports policy from one place.
 
 The stop flag, the sleep helper, the signal handler, and the marker type are
-implementation-private; only the four functions, the markers, and the five
+implementation-private; only the three functions, the markers, and the five
 constants are public.
 
 #### `should_ping(target, now)`
@@ -1867,10 +1871,10 @@ One scan pass, steps in order:
 
 1. **Ownership-checked heartbeat.** Call the broker's heartbeat with `(fleet_id,
    this-pid, now-as-ISO)`. Returns false (zero-row update — this process was
-   displaced and another reclaimed the slot) → return `Stop`. This is the
+   displaced and another reclaimed the slot) → return `STOP`. This is the
    split-brain loser's exit.
 2. **Fleet liveness.** Fetch the fleet; absent **or** `deleted_at` set → return
-   `Stop`.
+   `STOP`.
 3. **Locate the watcher.** Ask the broker for the fleet's monitoring member (may
    be absent); shape `{agent_id, name, pane_id}`.
 4. **Fetch pane liveness once.** A **single** `list_pane_ids` call resolves
@@ -1896,7 +1900,7 @@ One scan pass, steps in order:
      agents stay flagged, so the next tick retries (no wake-storm, no silent
      skip).
    - No live watcher to wake: nothing is recorded.
-7. Return `Continue`.
+7. Return `CONTINUE`.
 
 **Critical ordering invariant:** `record_pings` and the heartbeat echo are gated
 behind `woke == true`. Preserve this gating exactly.
@@ -1914,14 +1918,14 @@ artifact (no PID file); identity throughout is the OS process id.
 3. **Install signal handlers** for SIGTERM and SIGINT; each flips the shared stop
    flag to true (the handler is minimal — just a flag flip).
 4. **Loop** while the stop flag is false: if `monitor_tick(fleet_id, now)` (each
-   pass stamps `now` fresh as tz-aware UTC) returns `Stop` → break; else call
+   pass stamps `now` fresh as tz-aware UTC) returns `STOP` → break; else call
    `interruptible_sleep(tick_seconds)`.
 5. **Cleanup (always, in a finally block):** the broker's ownership-checked clear
    `(fleet_id, pid)` — nulls the slot's process fields only if this pid still
    owns the slot, so a displaced loser's clear is a no-op.
 
 **Stop paths:** (a) a signal sets the stop flag → loop exits → finally clears;
-(b) `monitor_tick` returns `Stop` → break → finally clears; (c) a hard kill runs
+(b) `monitor_tick` returns `STOP` → break → finally clears; (c) a hard kill runs
 no cleanup — the row's heartbeat goes stale and the broker's later liveness check
 reports it dead.
 
@@ -2252,15 +2256,17 @@ array**; every other list endpoint wraps in an object (agent rows under
 - **`GET /api/agents/{agent_id}/sent`** — fleet-scoped. Same as inbox over sent
   messages; same `404` detail `Agent not found`.
 - **`GET /api/timeline`** — fleet-scoped, no per-agent check. `{"messages": […]}`
-  over all of the fleet's messages.
+  over the fleet's messages, hard-capped at the **200** most recent
+  (`status_timestamp DESC`).
 - **`POST /api/messages/send`** — fleet-scoped. Body `{from_agent_id: int,
   to_agent_id: int | "*", text: string}`. `to_agent_id` deserializes as **either
   a JSON integer or the exact JSON string `"*"`** (broadcast); anything else
   (e.g. a stringified integer `"5"`) is rejected, not coerced. If `from_agent_id`
   is not in the fleet → `400`, detail `from_agent not in fleet`. If `"*"`:
   broadcast, return `{task_id: <summary task_id>, status: <summary
-  status_state>}`. Else: recipient not in fleet → `404`, detail `Agent not
-  found`; otherwise send and return `{task_id, status}`. Both branches:
+  status_state>}`. Else: recipient not an **active** agent in the fleet →
+  `404`, detail `Agent not found`; otherwise send and return `{task_id,
+  status}`. Both branches:
   `{task_id: int, status: string}` (`status` = the broker task's `status_state`).
 
 **`FormattedMessage`** (one element of any `messages` array): `{task_id,
@@ -2377,13 +2383,13 @@ cross-module string — the "must be run inside a tmux session" text exists in t
 distinct forms with **two different provenances**:
 
 - **Tmux-pane-command path** — the multiplexer's `ensure_available` raises
-  `cafleet tmux-pane commands must be run inside a tmux session` (§6.5); the CLI
+  `cafleet member commands must be run inside a tmux session` (§6.5); the CLI
   surfaces that text as-is (it does not hardcode it).
 - **`fleet create` path** — the CLI **catches** the multiplexer's `TmuxError`,
   **discards** its message, and raises its own hardcoded command-specific string
   `cafleet fleet create must be run inside a tmux session` (§6.3, exit 1). This
   one is genuinely CLI-hardcoded; do not expect it to echo the multiplexer's
-  `tmux-pane commands` wording.
+  `member commands` wording.
 
 ### 7.3 Output / JSON / truncation
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -1009,7 +1009,9 @@ fleet-scoped command (§6.3 `--fleet-id`).
 
 All six route through `client_command`. Common: `--agent-id` (integer, required
 — the calling agent/requester) on all; `--task-id` (integer, required) on
-`ack`/`cancel`/`show`; `--full` (documented) on all. No `--quiet` flag.
+`ack`/`cancel`/`show`; `--full` (documented) on all; `--quiet` (documented
+boolean, default `false` — success output is the bare `task_id`) on `send` and
+`ack`.
 
 - **send** — also `--to` (integer, required) and the shared `--text` /
   `--text-file` body pair (exactly one required; §6.3 [text-body
@@ -1171,7 +1173,7 @@ block (`kind`, `skills`, placement sub-block) with `--full`.
 
 #### `member list`
 
-`member list` takes `--activity` (hidden boolean, default `false`) and `--all`
+`member list` takes `--activity` (boolean, default `false`) and `--all`
 (boolean, default `false`); both together → usage error (exit 2) `--all and
 --activity are mutually exclusive.`. Default: lists the
 fleet's members — active agents with a placement row, the root Director
@@ -1192,7 +1194,7 @@ members-only listing above.
 
 Options: `--member-id` (integer, required), `--lines` (integer, default **20**,
 shown in help; `--tail` is an accepted alias spelling), `--ansi` /
-`--no-ansi` (hidden boolean pair, default `false`).
+`--no-ansi` (boolean pair, default `false`).
 Ensure tmux, load the member, require a pane (`capture`). Capture the last N lines
 (a tmux error → application error `capture failed: <error>`). When `--ansi` is
 not set, strip ANSI. JSON: `{member_agent_id, pane_id, lines, content}`; text
@@ -1213,7 +1215,7 @@ quoting/escaping — reproducing the quoted intent is sufficient).
 #### `member ping`
 
 Re-pokes a member's inbox. Options: `--member-id` (integer, required — the
-**target**), `--quiet` (hidden boolean, default `false` — success output is the
+**target**), `--quiet` (boolean, default `false` — success output is the
 bare member id). Ensure tmux, load the target, require a pane (`ping`).
 Inject the inbox-poll keystroke via the multiplexer's
 `send_poll_trigger`, which is **best-effort** (§6.5) — it returns a boolean and

--- a/SPEC.md
+++ b/SPEC.md
@@ -1655,8 +1655,11 @@ then `pending_count` with no padding.
 - **ping-age humanizer** — null → ASCII `-`; else `<n>s ago`.
 
 All four absent-cell helpers above use the single ASCII `-` glyph (§6.4 *The
-single absent glyph*). All conditional fields (`kind`, `origin`, the verbose
-`to:`/`text:` lines) are gated on truthiness — omitted, never emitted empty.
+single absent glyph*). The conditional fields `kind`, `origin`, and the verbose
+`text:` line are gated on truthiness — omitted, never emitted empty. The verbose
+`to:` line is instead gated on **non-null** (`to_agent_id is not None`): a
+broadcast-summary row's NULL recipient omits it; a unicast's real id always
+shows.
 
 ### 6.5 Multiplexer & tmux
 
@@ -1753,8 +1756,8 @@ method builds is given verbatim; preserve subcommand, flags, and ordering.
 - **Best-effort boolean** (NEVER raise; `false` on any failure):
   `send_poll_trigger`, `send_wake_trigger`, `send_inline_preview`. Each guards
   "tmux missing → `false`" then wraps the keystroke so any error → `false`. The
-  boolean is consumed as the broker's `notification_sent` /
-  `notifications_sent_count` and the monitor's `woke`.
+  boolean is consumed as the broker's `notification_sent` (unicast) /
+  the broadcast `delivered` count and the monitor's `woke`.
 
 #### `MultiplexerContext` (frozen value type)
 

--- a/cafleet/src/cafleet/broker/_shared.py
+++ b/cafleet/src/cafleet/broker/_shared.py
@@ -31,24 +31,33 @@ def write_session():
         yield session
 
 
-def is_administrator(agent_card_json: str | None) -> bool:
+def _card_kind(agent_card_json: str | None) -> str | None:
+    """Extract ``$.cafleet.kind`` from a card, or None on any malformation.
+
+    Guards against invalid JSON, a non-object top level, and a null / non-object
+    ``cafleet`` value — every malformed shape resolves to a non-match (None)
+    rather than raising ``AttributeError``.
+    """
     if not agent_card_json:
-        return False
+        return None
     try:
-        kind = json.loads(agent_card_json).get("cafleet", {}).get("kind")
+        card = json.loads(agent_card_json)
     except ValueError:
-        return False
-    return kind == ADMINISTRATOR_KIND
+        return None
+    if not isinstance(card, dict):
+        return None
+    cafleet = card.get("cafleet")
+    if not isinstance(cafleet, dict):
+        return None
+    return cafleet.get("kind")
+
+
+def is_administrator(agent_card_json: str | None) -> bool:
+    return _card_kind(agent_card_json) == ADMINISTRATOR_KIND
 
 
 def is_monitoring_member(agent_card_json: str | None) -> bool:
-    if not agent_card_json:
-        return False
-    try:
-        kind = json.loads(agent_card_json).get("cafleet", {}).get("kind")
-    except ValueError:
-        return False
-    return kind == MONITORING_MEMBER_KIND
+    return _card_kind(agent_card_json) == MONITORING_MEMBER_KIND
 
 
 def derive_agent_kind(is_root_director: bool, card_kind: str | None) -> str:

--- a/cafleet/src/cafleet/broker/agents.py
+++ b/cafleet/src/cafleet/broker/agents.py
@@ -52,18 +52,19 @@ def register_agent(
         Dict with ``agent_id``, ``name``, and ``registered_at``.
 
     Raises:
-        click.UsageError: If the fleet does not exist, is soft-deleted, the
-            named Director is not active in the same fleet, or the placement
+        click.UsageError: If the fleet does not exist, the named Director is
+            not active in the same fleet, or the placement
             ``director_agent_id`` is not the fleet's root Director.
-        click.ClickException: If the named Director is the built-in
-            Administrator, the fleet already has an active monitoring member,
-            or a monitoring member is registered without a placement.
+        click.ClickException: If the fleet is soft-deleted, the named Director
+            is the built-in Administrator, the fleet already has an active
+            monitoring member, or a monitoring member is registered without a
+            placement.
     """
     sess = get_fleet(fleet_id)
     if sess is None:
         raise click.UsageError(f"Fleet '{fleet_id}' not found.")
     if sess["deleted_at"] is not None:
-        raise click.UsageError(f"fleet {fleet_id} is deleted")
+        raise click.ClickException(f"fleet {fleet_id} is deleted")
 
     registered_at = _shared.now_iso()
     agent_card: dict[str, object] = {
@@ -261,16 +262,16 @@ def deregister_agent(agent_id: int) -> bool:
         ``False`` if no matching active agent existed.
 
     Raises:
-        click.UsageError: If ``agent_id`` is the root Director of any
-            fleet — torn down via ``cafleet fleet delete`` instead.
-        click.ClickException: If ``agent_id`` is the built-in Administrator.
+        click.ClickException: If ``agent_id`` is the root Director of any
+            fleet (torn down via ``cafleet fleet delete`` instead), or the
+            built-in Administrator.
     """
     with _shared.write_session() as session:
         is_root_director = session.execute(
             select(exists().where(Fleet.director_agent_id == agent_id))
         ).scalar_one()
         if is_root_director:
-            raise click.UsageError(
+            raise click.ClickException(
                 "cannot deregister the root Director; "
                 "use 'cafleet fleet delete' instead"
             )

--- a/cafleet/src/cafleet/broker/messaging.py
+++ b/cafleet/src/cafleet/broker/messaging.py
@@ -215,7 +215,7 @@ def broadcast_message(fleet_id: int, agent_id: int, text: str) -> list[dict]:
         summary_dict = {
             "context_id": agent_id,
             "from_agent_id": agent_id,
-            "to_agent_id": 0,
+            "to_agent_id": None,
             "type": "broadcast_summary",
             "created_at": now,
             "status_state": "completed",

--- a/cafleet/src/cafleet/broker/messaging.py
+++ b/cafleet/src/cafleet/broker/messaging.py
@@ -184,8 +184,9 @@ def broadcast_message(fleet_id: int, agent_id: int, text: str) -> list[dict]:
 
     Returns:
         Single-element list containing a dict with ``task`` (the summary row
-        owned by the broadcaster) and ``notifications_sent_count`` — the
-        number of inline-preview keystrokes that landed successfully.
+        owned by the broadcaster), ``recipients`` (the real fan-out count N),
+        and ``delivered`` (the number of inline-preview keystrokes that landed
+        successfully, k ≤ N).
 
     Raises:
         ValueError: If the sender is not active in ``fleet_id``.

--- a/cafleet/src/cafleet/broker/messaging.py
+++ b/cafleet/src/cafleet/broker/messaging.py
@@ -251,7 +251,11 @@ def broadcast_message(fleet_id: int, agent_id: int, text: str) -> list[dict]:
         )
 
     return [
-        {"task": summary_dict, "notifications_sent_count": notifications_sent_count}
+        {
+            "task": summary_dict,
+            "recipients": len(recipient_ids),
+            "delivered": notifications_sent_count,
+        }
     ]
 
 

--- a/cafleet/src/cafleet/broker/queries.py
+++ b/cafleet/src/cafleet/broker/queries.py
@@ -66,7 +66,7 @@ def get_task(fleet_id: int, task_id: int) -> dict:
 
         endpoint_ids = [task_dict["from_agent_id"]]
         to_id = task_dict["to_agent_id"]
-        if to_id:
+        if to_id is not None:
             endpoint_ids.append(to_id)
         in_fleet = session.execute(
             select(

--- a/cafleet/src/cafleet/cli/_helpers.py
+++ b/cafleet/src/cafleet/cli/_helpers.py
@@ -56,7 +56,7 @@ quiet_flag = click.option(
     "quiet",
     is_flag=True,
     default=False,
-    help="Print only the resulting task_id.",
+    help="Print only the resulting id.",
 )
 
 

--- a/cafleet/src/cafleet/cli/_helpers.py
+++ b/cafleet/src/cafleet/cli/_helpers.py
@@ -44,8 +44,20 @@ def ensure_skills_current() -> None:
         )
 
 
-full_flag = click.option("--full", "full", is_flag=True, default=False, hidden=True)
-quiet_flag = click.option("--quiet", "quiet", is_flag=True, default=False, hidden=True)
+full_flag = click.option(
+    "--full",
+    "full",
+    is_flag=True,
+    default=False,
+    help="Render the full, untruncated output.",
+)
+quiet_flag = click.option(
+    "--quiet",
+    "quiet",
+    is_flag=True,
+    default=False,
+    help="Print only the resulting task_id.",
+)
 
 
 def director_member_options(func):

--- a/cafleet/src/cafleet/cli/fleet.py
+++ b/cafleet/src/cafleet/cli/fleet.py
@@ -3,7 +3,7 @@
 import click
 
 from cafleet import broker, output
-from cafleet.cli._helpers import ensure_skills_current, full_flag
+from cafleet.cli._helpers import ensure_skills_current, fleet_id_option, full_flag
 from cafleet.coding_agent import CODING_AGENTS
 from cafleet.multiplexer import MULTIPLEXERS, TmuxError
 
@@ -80,11 +80,12 @@ def fleet_list(ctx: click.Context, as_json: bool) -> None:
 
 
 @fleet.command("show")
-@click.argument("fleet_id", type=int)
+@fleet_id_option
 @click.option("--json", "as_json", is_flag=True, help="Output as JSON.")
 @click.pass_context
-def fleet_show(ctx: click.Context, fleet_id: int, as_json: bool) -> None:
+def fleet_show(ctx: click.Context, as_json: bool) -> None:
     """Show details of a single fleet."""
+    fleet_id = ctx.obj["fleet_id"]
     result = broker.get_fleet(fleet_id)
     if result is None:
         raise click.ClickException(f"fleet '{fleet_id}' not found.")
@@ -103,12 +104,14 @@ def fleet_show(ctx: click.Context, fleet_id: int, as_json: bool) -> None:
 
 
 @fleet.command("delete")
-@click.argument("fleet_id", type=int)
-def fleet_delete(fleet_id: int) -> None:
+@fleet_id_option
+@click.pass_context
+def fleet_delete(ctx: click.Context) -> None:
     """Soft-delete a fleet and deregister every active agent (idempotent)."""
     # No monitor-stop step: a running monitor loop self-terminates on its next
     # tick once the fleet is soft-deleted (monitor_tick → STOP), and
     # broker.delete_fleet removes the monitor_config + monitor_runtime rows.
+    fleet_id = ctx.obj["fleet_id"]
     result = broker.delete_fleet(fleet_id)
     n = result["deregistered_count"]
     click.echo(f"Deleted fleet {fleet_id}. Deregistered {n} agents.")

--- a/cafleet/src/cafleet/cli/member.py
+++ b/cafleet/src/cafleet/cli/member.py
@@ -491,7 +491,7 @@ def member_show(ctx, member_id, full):
     "activity",
     is_flag=True,
     default=False,
-    hidden=True,
+    help="Show per-member activity columns.",
 )
 @click.option(
     "--all",
@@ -542,7 +542,7 @@ def member_list(ctx, activity, all_agents):
 @click.option(
     "--ansi/--no-ansi",
     default=False,
-    hidden=True,
+    help="Emit raw ANSI instead of stripping it.",
 )
 @click.pass_context
 def member_capture(ctx, member_id, lines, ansi):

--- a/cafleet/src/cafleet/cli/message.py
+++ b/cafleet/src/cafleet/cli/message.py
@@ -71,7 +71,7 @@ def message_send(ctx, agent_id, to, text, text_file, full, quiet):
         output.format_task(r[0]["task"], full=True)
         if full
         else f"broadcast id={r[0]['task']['task_id']} "
-        f"recipients={r[0]['notifications_sent_count']}"
+        f"recipients={r[0]['recipients']} delivered={r[0]['delivered']}"
     ),
     truncates_task_text=True,
 )

--- a/cafleet/src/cafleet/db/alembic/versions/0007_to_agent_id_nullable.py
+++ b/cafleet/src/cafleet/db/alembic/versions/0007_to_agent_id_nullable.py
@@ -1,0 +1,42 @@
+"""to_agent_id nullable
+
+Revision ID: 0007
+Revises: 0006
+Create Date: 2026-07-04 07:30:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0007"
+down_revision: str | None = "0006"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # ``tasks`` mints ids via AUTOINCREMENT; the batch recreate must carry the
+    # ``sqlite_autoincrement`` table kwarg or it silently drops the clause.
+    with op.batch_alter_table(
+        "tasks", schema=None, table_kwargs={"sqlite_autoincrement": True}
+    ) as batch_op:
+        batch_op.alter_column(
+            "to_agent_id",
+            existing_type=sa.Integer(),
+            nullable=True,
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table(
+        "tasks", schema=None, table_kwargs={"sqlite_autoincrement": True}
+    ) as batch_op:
+        batch_op.alter_column(
+            "to_agent_id",
+            existing_type=sa.Integer(),
+            nullable=False,
+        )

--- a/cafleet/src/cafleet/db/models.py
+++ b/cafleet/src/cafleet/db/models.py
@@ -70,7 +70,7 @@ class Task(Base):
         Integer, ForeignKey("agents.agent_id", ondelete="RESTRICT"), nullable=False
     )
     from_agent_id: Mapped[int] = mapped_column(Integer, nullable=False)
-    to_agent_id: Mapped[int] = mapped_column(Integer, nullable=False)
+    to_agent_id: Mapped[int | None] = mapped_column(Integer, nullable=True)
     type: Mapped[str] = mapped_column(String, nullable=False)
     created_at: Mapped[str] = mapped_column(String, nullable=False)
     status_state: Mapped[str] = mapped_column(String, nullable=False)

--- a/cafleet/src/cafleet/output/formatters.py
+++ b/cafleet/src/cafleet/output/formatters.py
@@ -36,7 +36,7 @@ def format_task(task: dict, *, full: bool = False) -> str:
         f"  state: {task['status_state']}",
         f"  from:  {task['from_agent_id']}",
     ]
-    if task.get("to_agent_id"):
+    if task.get("to_agent_id") is not None:
         lines.append(f"  to:    {task['to_agent_id']}")
     lines.append(f"  type:  {task['type']}")
     if task.get("text"):

--- a/cafleet/src/cafleet/output/formatters.py
+++ b/cafleet/src/cafleet/output/formatters.py
@@ -216,7 +216,7 @@ def _format_idle(seconds: int | None) -> str:
 def _format_ping_age(age_seconds: int | None) -> str:
     """Render a watched agent's last-ping age for the status table."""
     if age_seconds is None:
-        return "—"
+        return "-"
     return f"{age_seconds}s ago"
 
 

--- a/cafleet/tests/broker/test_broadcast_recipients_delivered.py
+++ b/cafleet/tests/broker/test_broadcast_recipients_delivered.py
@@ -5,8 +5,11 @@ number of active non-admin peers a delivery row was fanned out to (N) — and
 ``delivered`` — how many inline-preview keystrokes actually landed (k, a subset
 of N). The legacy single ``notifications_sent_count`` key is gone.
 
-Recipients registered without a placement have no pane, so ``delivered`` is 0
-while ``recipients`` counts every peer — a scenario where N and k diverge.
+``_create_fleet`` + sender + recipient-a + recipient-b gives three peers of the
+sender (the pane-bound root Director and the two registered recipients), so
+N=3. Only the root Director has a placement, so its preview is the sole one
+that lands (k=1) while the pane-less recipients receive none — a scenario where
+N and k diverge.
 """
 
 import pytest
@@ -28,8 +31,8 @@ def test_broadcast_result_carries_separate_recipients_and_delivered():
 
     [result] = broker.broadcast_message(sid, sender["agent_id"], "hi all")
 
-    assert result["recipients"] == 2
-    assert result["delivered"] == 0
+    assert result["recipients"] == 3
+    assert result["delivered"] == 1
     assert isinstance(result["recipients"], int)
     assert isinstance(result["delivered"], int)
 

--- a/cafleet/tests/broker/test_broadcast_recipients_delivered.py
+++ b/cafleet/tests/broker/test_broadcast_recipients_delivered.py
@@ -1,0 +1,44 @@
+"""Regression tests for split broadcast counts (design 0000118, item 2.1).
+
+The broadcast result reports two distinct counts: ``recipients`` — the real
+number of active non-admin peers a delivery row was fanned out to (N) — and
+``delivered`` — how many inline-preview keystrokes actually landed (k, a subset
+of N). The legacy single ``notifications_sent_count`` key is gone.
+
+Recipients registered without a placement have no pane, so ``delivered`` is 0
+while ``recipients`` counts every peer — a scenario where N and k diverge.
+"""
+
+import pytest
+
+from cafleet import broker
+from tests.broker._helpers import _create_fleet, _register_agent
+
+
+@pytest.fixture(autouse=True)
+def _autouse_broker(broker_session):
+    return broker_session
+
+
+def test_broadcast_result_carries_separate_recipients_and_delivered():
+    sid = _create_fleet()["fleet_id"]
+    sender = _register_agent(sid, "sender")
+    _register_agent(sid, "recipient-a")
+    _register_agent(sid, "recipient-b")
+
+    [result] = broker.broadcast_message(sid, sender["agent_id"], "hi all")
+
+    assert result["recipients"] == 2
+    assert result["delivered"] == 0
+    assert isinstance(result["recipients"], int)
+    assert isinstance(result["delivered"], int)
+
+
+def test_broadcast_result_drops_legacy_notifications_sent_count_key():
+    sid = _create_fleet()["fleet_id"]
+    sender = _register_agent(sid, "sender")
+    _register_agent(sid, "recipient-a")
+
+    [result] = broker.broadcast_message(sid, sender["agent_id"], "hi all")
+
+    assert "notifications_sent_count" not in result

--- a/cafleet/tests/broker/test_fleet_bootstrap.py
+++ b/cafleet/tests/broker/test_fleet_bootstrap.py
@@ -183,14 +183,20 @@ def test_delete_fleet__unknown_fleet_raises_click_exception():
 
 
 @pytest.mark.parametrize(
-    ("scenario", "expected_substring", "must_not_contain"),
+    ("scenario", "expected_substring", "must_not_contain", "expected_exit_code"),
     [
-        ("soft_deleted_fleet", "is deleted", "not found"),
-        ("unknown_fleet", "not found", None),
+        # Soft-deleted fleet exits 1 (ClickException); unknown fleet stays exit 2
+        # (UsageError) — item 3.3 normalizes only the soft-deleted guard.
+        ("soft_deleted_fleet", "is deleted", "not found", 1),
+        ("unknown_fleet", "not found", None, 2),
     ],
 )
 def test_register_agent__rejects_dead_fleets(
-    director_context, scenario, expected_substring, must_not_contain
+    director_context,
+    scenario,
+    expected_substring,
+    must_not_contain,
+    expected_exit_code,
 ):
     if scenario == "soft_deleted_fleet":
         result = _bootstrap(ctx=director_context)
@@ -199,12 +205,13 @@ def test_register_agent__rejects_dead_fleets(
     else:
         sid = 999999
 
-    with pytest.raises(click.UsageError) as exc_info:
+    with pytest.raises(click.ClickException) as exc_info:
         broker.register_agent(
             fleet_id=sid,
             name="late-comer",
             description="too late",
         )
+    assert exc_info.value.exit_code == expected_exit_code
     msg = str(exc_info.value)
     assert (
         expected_substring in msg.lower()
@@ -240,8 +247,9 @@ def test_deregister_agent__root_director_protected_non_root_unaffected(
     sid = result["fleet_id"]
     director_id = result["director"]["agent_id"]
 
-    with pytest.raises(click.UsageError) as exc_info:
+    with pytest.raises(click.ClickException) as exc_info:
         broker.deregister_agent(director_id)
+    assert exc_info.value.exit_code == 1
     msg = str(exc_info.value)
     assert "cannot deregister the root Director" in msg
     assert "cafleet fleet delete" in msg

--- a/cafleet/tests/broker/test_guard_exit_codes.py
+++ b/cafleet/tests/broker/test_guard_exit_codes.py
@@ -1,0 +1,40 @@
+"""Regression tests: broker guards exit 1, not 2 (design 0000118, items 2.2 + 3.3).
+
+The root-Director deregistration guard (``deregister_agent``) and the
+soft-deleted-fleet guard (``register_agent``) both raise ``click.ClickException``
+(exit 1), matching the sibling CLI guard at ``member.py:328-331`` — not
+``click.UsageError`` (exit 2). ``UsageError`` is a ``ClickException`` subclass
+that overrides ``exit_code`` to 2, so the contract is asserted on ``exit_code``.
+"""
+
+import click
+import pytest
+
+from cafleet import broker
+from tests.broker._helpers import _create_fleet
+
+
+@pytest.fixture(autouse=True)
+def _autouse_broker(broker_session):
+    return broker_session
+
+
+def test_deregister_root_director_guard_exits_1():
+    fleet = _create_fleet()
+    director_id = fleet["director"]["agent_id"]
+
+    with pytest.raises(click.ClickException) as exc_info:
+        broker.deregister_agent(director_id)
+
+    assert exc_info.value.exit_code == 1
+
+
+def test_register_into_soft_deleted_fleet_guard_exits_1():
+    fleet = _create_fleet()
+    sid = fleet["fleet_id"]
+    broker.delete_fleet(sid)
+
+    with pytest.raises(click.ClickException) as exc_info:
+        broker.register_agent(fleet_id=sid, name="late", description="too late")
+
+    assert exc_info.value.exit_code == 1

--- a/cafleet/tests/broker/test_kind_predicate_safety.py
+++ b/cafleet/tests/broker/test_kind_predicate_safety.py
@@ -1,0 +1,47 @@
+"""Regression tests: kind predicates are null/non-object safe (design 0000118, item 2.4).
+
+``is_administrator`` / ``is_monitoring_member`` read ``card["cafleet"]["kind"]``.
+A malformed card whose ``cafleet`` value is null or a non-object
+(``{"cafleet": null}``, ``{"cafleet": "x"}``) must return ``False`` rather than
+raising ``AttributeError`` — the guard extends beyond the JSON-parse
+``except ValueError`` to also handle a ``cafleet`` value that is not a dict.
+"""
+
+import json
+
+import pytest
+
+from cafleet.broker import _shared
+
+_PREDICATES = [_shared.is_administrator, _shared.is_monitoring_member]
+
+_MALFORMED_CARDS = [
+    '{"cafleet": null}',
+    '{"cafleet": "x"}',
+    '{"cafleet": 42}',
+    '{"cafleet": [1, 2]}',
+]
+
+
+@pytest.mark.parametrize("predicate", _PREDICATES)
+@pytest.mark.parametrize("card", _MALFORMED_CARDS)
+def test_kind_predicate_returns_false_on_non_object_cafleet(predicate, card):
+    assert predicate(card) is False
+
+
+@pytest.mark.parametrize("predicate", _PREDICATES)
+def test_kind_predicate_returns_false_on_missing_or_empty_cafleet(predicate):
+    assert predicate('{"name": "agent"}') is False
+    assert predicate('{"cafleet": {}}') is False
+
+
+def test_is_administrator_still_true_on_well_formed_card():
+    card = json.dumps({"cafleet": {"kind": _shared.ADMINISTRATOR_KIND}})
+    assert _shared.is_administrator(card) is True
+    assert _shared.is_monitoring_member(card) is False
+
+
+def test_is_monitoring_member_still_true_on_well_formed_card():
+    card = json.dumps({"cafleet": {"kind": _shared.MONITORING_MEMBER_KIND}})
+    assert _shared.is_monitoring_member(card) is True
+    assert _shared.is_administrator(card) is False

--- a/cafleet/tests/broker/test_to_agent_id_nullable.py
+++ b/cafleet/tests/broker/test_to_agent_id_nullable.py
@@ -1,0 +1,56 @@
+"""Regression tests for nullable ``tasks.to_agent_id`` (design 0000118, items 1.1/1.2).
+
+A broadcast-summary row is owned by the broadcaster and has no single
+recipient, so its ``to_agent_id`` is NULL rather than the legacy ``0``
+sentinel. The column is nullable, the returned summary dict carries ``None``,
+and the persisted row reads back as ``None``. A real unicast still retains its
+recipient id (the "shows on a real id" half of the surfacing contract).
+"""
+
+import pytest
+
+from cafleet import broker
+from cafleet.db.models import Task
+from tests.broker._helpers import _create_fleet, _register_agent, _setup_two_agents
+
+
+@pytest.fixture(autouse=True)
+def _autouse_broker(broker_session):
+    return broker_session
+
+
+def test_task_model_to_agent_id_column_is_nullable():
+    assert Task.__table__.c.to_agent_id.nullable is True
+
+
+def test_broadcast_summary_returned_dict_has_null_to_agent_id():
+    sid = _create_fleet()["fleet_id"]
+    sender = _register_agent(sid, "sender")
+    _register_agent(sid, "recipient-a")
+    _register_agent(sid, "recipient-b")
+
+    [result] = broker.broadcast_message(sid, sender["agent_id"], "hi all")
+
+    assert result["task"]["to_agent_id"] is None
+
+
+def test_broadcast_summary_persists_null_to_agent_id():
+    sid = _create_fleet()["fleet_id"]
+    sender = _register_agent(sid, "sender")
+    _register_agent(sid, "recipient-a")
+
+    [result] = broker.broadcast_message(sid, sender["agent_id"], "hi all")
+    summary_task_id = result["task"]["task_id"]
+
+    persisted = broker.get_task(sid, summary_task_id)["task"]
+    assert persisted["to_agent_id"] is None
+
+
+def test_unicast_persists_real_to_agent_id():
+    sid, sender, recipient = _setup_two_agents()
+
+    result = broker.send_message(sid, sender, recipient, "hi")
+    task_id = result["task"]["task_id"]
+
+    persisted = broker.get_task(sid, task_id)["task"]
+    assert persisted["to_agent_id"] == recipient

--- a/cafleet/tests/broker/test_typed_columns.py
+++ b/cafleet/tests/broker/test_typed_columns.py
@@ -93,8 +93,8 @@ def test_broadcast_message__summary_envelope_shape():
     assert summary["to_agent_id"] is None
     assert summary["status_state"] == "completed"
     assert "Broadcast sent" in summary["text"]
-    assert "notifications_sent_count" in result
-    assert isinstance(result["notifications_sent_count"], int)
+    assert isinstance(result["recipients"], int)
+    assert isinstance(result["delivered"], int)
 
 
 def test_broadcast_message__delivery_task_shape_and_origin_link():

--- a/cafleet/tests/broker/test_typed_columns.py
+++ b/cafleet/tests/broker/test_typed_columns.py
@@ -90,7 +90,7 @@ def test_broadcast_message__summary_envelope_shape():
     assert summary["type"] == "broadcast_summary"
     assert summary["from_agent_id"] == sender
     assert summary["context_id"] == sender
-    assert summary["to_agent_id"] == 0
+    assert summary["to_agent_id"] is None
     assert summary["status_state"] == "completed"
     assert "Broadcast sent" in summary["text"]
     assert "notifications_sent_count" in result

--- a/cafleet/tests/cli/test_broadcast_json_to_agent_id.py
+++ b/cafleet/tests/cli/test_broadcast_json_to_agent_id.py
@@ -1,0 +1,46 @@
+"""End-to-end: ``message broadcast --json --full`` emits ``to_agent_id: null`` (design 0000118, item 1.1).
+
+The broadcast-summary row carries no single recipient, so the ``--json``
+surface emits JSON ``null`` (not ``0``) for its ``to_agent_id``. ``--full`` is
+required because the compact render projects ``to_agent_id`` out entirely; the
+full render is where the null-vs-zero distinction is observable.
+"""
+
+import json
+
+import pytest
+from click.testing import CliRunner
+
+from cafleet.cli import cli
+from tests.broker._helpers import _create_fleet, _register_agent
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+def test_broadcast_json_full_emits_null_to_agent_id(runner):
+    sid = _create_fleet()["fleet_id"]
+    sender = _register_agent(sid, "sender")
+    _register_agent(sid, "recipient-a")
+    _register_agent(sid, "recipient-b")
+
+    result = runner.invoke(
+        cli,
+        [
+            "--json",
+            "message",
+            "broadcast",
+            "--full",
+            "--fleet-id",
+            str(sid),
+            "--agent-id",
+            str(sender["agent_id"]),
+            "--text",
+            "hi all",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload[0]["task"]["to_agent_id"] is None

--- a/cafleet/tests/cli/test_broadcast_recipients_delivered.py
+++ b/cafleet/tests/cli/test_broadcast_recipients_delivered.py
@@ -1,0 +1,42 @@
+"""End-to-end: ``message broadcast`` prints ``recipients=N delivered=k`` (design 0000118, item 2.1).
+
+The compact one-line echo surfaces both counts — ``recipients`` (real peer
+count N) and ``delivered`` (previews that landed, k) — rather than the single
+legacy count mislabeled as ``recipients``.
+"""
+
+import pytest
+from click.testing import CliRunner
+
+from cafleet.cli import cli
+from tests.broker._helpers import _create_fleet, _register_agent
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+def test_broadcast_cli_prints_recipients_and_delivered(runner):
+    sid = _create_fleet()["fleet_id"]
+    sender = _register_agent(sid, "sender")
+    _register_agent(sid, "recipient-a")
+    _register_agent(sid, "recipient-b")
+
+    result = runner.invoke(
+        cli,
+        [
+            "message",
+            "broadcast",
+            "--fleet-id",
+            str(sid),
+            "--agent-id",
+            str(sender["agent_id"]),
+            "--text",
+            "hi all",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    # Two recipients registered without panes → N=2, k=0.
+    assert "recipients=2" in result.output
+    assert "delivered=0" in result.output

--- a/cafleet/tests/cli/test_broadcast_recipients_delivered.py
+++ b/cafleet/tests/cli/test_broadcast_recipients_delivered.py
@@ -37,6 +37,7 @@ def test_broadcast_cli_prints_recipients_and_delivered(runner):
         ],
     )
     assert result.exit_code == 0, result.output
-    # Two recipients registered without panes → N=2, k=0.
-    assert "recipients=2" in result.output
-    assert "delivered=0" in result.output
+    # Three peers of the sender: pane-bound root Director + recipient-a/-b.
+    # Only the Director's pane receives a preview → N=3, k=1.
+    assert "recipients=3" in result.output
+    assert "delivered=1" in result.output

--- a/cafleet/tests/cli/test_compact_echo.py
+++ b/cafleet/tests/cli/test_compact_echo.py
@@ -66,7 +66,10 @@ def _broadcast_summary_result(*, summary_id=7000, recipient_count=3):
         origin_task_id=summary_id,
         status_state="completed",
     )
-    return [{"task": summary, "notifications_sent_count": recipient_count}]
+    summary["to_agent_id"] = None
+    return [
+        {"task": summary, "recipients": recipient_count, "delivered": recipient_count}
+    ]
 
 
 def _ping_setup(monkeypatch):

--- a/cafleet/tests/cli/test_fleet.py
+++ b/cafleet/tests/cli/test_fleet.py
@@ -288,16 +288,19 @@ def test_fleet_delete__accepts_fleet_id_option(fresh_db):
 
 def test_fleet_show__rejects_positional_fleet_id(fresh_db):
     _db_file, runner = fresh_db
+    # The positional form is gone; the required --fleet-id callback preempts the
+    # extra-arg check, so a bare positional yields the exit-1 "required" error
+    # (item 3.2), matching every sibling fleet-scoped command.
     result = runner.invoke(cli, ["fleet", "show", "1"])
-    assert result.exit_code == 2, result.output
-    assert "unexpected" in (result.output or "").lower()
+    assert result.exit_code == 1, result.output
+    assert "required" in (result.output or "").lower()
 
 
 def test_fleet_delete__rejects_positional_fleet_id(fresh_db):
     _db_file, runner = fresh_db
     result = runner.invoke(cli, ["fleet", "delete", "1"])
-    assert result.exit_code == 2, result.output
-    assert "unexpected" in (result.output or "").lower()
+    assert result.exit_code == 1, result.output
+    assert "required" in (result.output or "").lower()
 
 
 def test_fleet_group_structure__subcommands_under_fleet(fresh_db):

--- a/cafleet/tests/cli/test_fleet.py
+++ b/cafleet/tests/cli/test_fleet.py
@@ -230,7 +230,7 @@ def test_fleet_show__shape_and_branches(
             conn.close()
         target = sid
 
-    result = runner.invoke(cli, ["fleet", "show", str(target)])
+    result = runner.invoke(cli, ["fleet", "show", "--fleet-id", str(target)])
     assert result.exit_code == expected_exit, result.output
     out = result.output.lower() if scenario == "missing" else result.output
     for needle in expected_in:
@@ -247,7 +247,7 @@ def test_fleet_delete__soft_deletes_and_marks_row(fresh_db):
     _seed_agent(db_file, 2, sid, status="active")
     _seed_agent(db_file, 3, sid, status="active")
 
-    result = runner.invoke(cli, ["fleet", "delete", str(sid)])
+    result = runner.invoke(cli, ["fleet", "delete", "--fleet-id", str(sid)])
     assert result.exit_code == 0, result.output
     # Row persists, deleted_at set.
     assert sid in [r[0] for r in _fleet_rows(db_file)]
@@ -258,9 +258,46 @@ def test_fleet_delete__soft_deletes_and_marks_row(fresh_db):
 def test_fleet_delete__nonexistent_fleet_handles_gracefully(fresh_db):
     _db_file, runner = fresh_db
     fake_id = 999
-    result = runner.invoke(cli, ["fleet", "delete", str(fake_id)])
+    result = runner.invoke(cli, ["fleet", "delete", "--fleet-id", str(fake_id)])
     # Either exits non-zero or returns SystemExit — never crashes uncleanly.
     assert result.exception is None or isinstance(result.exception, SystemExit)
+
+
+# --- fleet show / delete take --fleet-id, not a positional (design 0000118, item 3.1) ---
+
+
+def test_fleet_show__accepts_fleet_id_option(fresh_db):
+    db_file, runner = fresh_db
+    sid = 1
+    _seed_fleet(db_file, sid, label="opt-show")
+
+    result = runner.invoke(cli, ["fleet", "show", "--fleet-id", str(sid)])
+    assert result.exit_code == 0, result.output
+    assert "opt-show" in result.output
+
+
+def test_fleet_delete__accepts_fleet_id_option(fresh_db):
+    db_file, runner = fresh_db
+    sid = 1
+    _seed_fleet(db_file, sid)
+
+    result = runner.invoke(cli, ["fleet", "delete", "--fleet-id", str(sid)])
+    assert result.exit_code == 0, result.output
+    assert _fleet_deleted_at(db_file, sid) is not None
+
+
+def test_fleet_show__rejects_positional_fleet_id(fresh_db):
+    _db_file, runner = fresh_db
+    result = runner.invoke(cli, ["fleet", "show", "1"])
+    assert result.exit_code == 2, result.output
+    assert "unexpected" in (result.output or "").lower()
+
+
+def test_fleet_delete__rejects_positional_fleet_id(fresh_db):
+    _db_file, runner = fresh_db
+    result = runner.invoke(cli, ["fleet", "delete", "1"])
+    assert result.exit_code == 2, result.output
+    assert "unexpected" in (result.output or "").lower()
 
 
 def test_fleet_group_structure__subcommands_under_fleet(fresh_db):

--- a/cafleet/tests/cli/test_fleet_bootstrap.py
+++ b/cafleet/tests/cli/test_fleet_bootstrap.py
@@ -298,7 +298,7 @@ def test_fleet_list_hides_soft_deleted__deleted_fleet_is_hidden_from_text_list(
     keep_sid = json.loads(r1.output)["fleet_id"]
     drop_sid = json.loads(r2.output)["fleet_id"]
 
-    del_result = runner.invoke(cli, ["fleet", "delete", str(drop_sid)])
+    del_result = runner.invoke(cli, ["fleet", "delete", "--fleet-id", str(drop_sid)])
     assert del_result.exit_code == 0, del_result.output
 
     list_result = runner.invoke(cli, ["fleet", "list"])
@@ -317,7 +317,7 @@ def test_fleet_list_hides_soft_deleted__deleted_fleet_is_hidden_from_json_list(
     r2 = runner.invoke(cli, ["fleet", "create", "--json"])
     keep_sid = json.loads(r1.output)["fleet_id"]
     drop_sid = json.loads(r2.output)["fleet_id"]
-    runner.invoke(cli, ["fleet", "delete", str(drop_sid)])
+    runner.invoke(cli, ["fleet", "delete", "--fleet-id", str(drop_sid)])
 
     list_result = runner.invoke(cli, ["fleet", "list", "--json"])
     assert list_result.exit_code == 0
@@ -332,7 +332,7 @@ def test_fleet_delete_unknown_and_idempotent__unknown_fleet_id_exits_1_with_not_
 ):
     runner = CliRunner()
     fake = 999
-    result = runner.invoke(cli, ["fleet", "delete", str(fake)])
+    result = runner.invoke(cli, ["fleet", "delete", "--fleet-id", str(fake)])
     assert result.exit_code == 1, result.output
     combined = ((result.output or "") + (result.stderr or "")).lower()
     assert "not found" in combined
@@ -347,8 +347,8 @@ def test_fleet_delete_unknown_and_idempotent__second_delete_is_idempotent_and_re
     assert r.exit_code == 0
     sid = json.loads(r.output)["fleet_id"]
 
-    first = runner.invoke(cli, ["fleet", "delete", str(sid)])
-    second = runner.invoke(cli, ["fleet", "delete", str(sid)])
+    first = runner.invoke(cli, ["fleet", "delete", "--fleet-id", str(sid)])
+    second = runner.invoke(cli, ["fleet", "delete", "--fleet-id", str(sid)])
 
     assert first.exit_code == 0, first.output
     assert second.exit_code == 0, second.output

--- a/cafleet/tests/cli/test_help_budget.py
+++ b/cafleet/tests/cli/test_help_budget.py
@@ -33,16 +33,17 @@ def _help_lines(*subcommand_path: str) -> list[str]:
 # Per-subcommand line budgets. Each command's --help output must stay at or
 # below its budget; option helps are kept to a single concise sentence.
 _PER_SUBCOMMAND_BUDGETS: dict[tuple[str, ...], int] = {
-    ("message", "send"): 11,
-    ("message", "broadcast"): 10,
+    ("message", "send"): 13,
+    ("message", "broadcast"): 11,
     ("message", "poll"): 9,
-    ("message", "ack"): 10,
+    ("message", "ack"): 11,
     ("message", "cancel"): 10,
-    ("message", "show"): 9,
+    ("message", "show"): 10,
     # member create's wide option column (the --coding-agent
     # [claude|codex|opencode] metavar) wraps the --fleet-id help to two lines,
-    # so it gains 2 lines rather than 1. Added --text/--text-file increases this.
-    ("member", "create"): 19,
+    # so it gains 2 lines rather than 1. Added --text/--text-file and the
+    # now-visible --full increase this.
+    ("member", "create"): 20,
     ("member", "list"): 9,
     ("member", "show"): 9,
     ("member", "capture"): 10,

--- a/cafleet/tests/cli/test_message_text_input.py
+++ b/cafleet/tests/cli/test_message_text_input.py
@@ -66,7 +66,7 @@ def broadcast_recorder(monkeypatch):
 
     def fake_broadcast(*args, **kwargs):
         calls.append((args, kwargs))
-        return [{"task": _task_payload("stored"), "notifications_sent_count": 1}]
+        return [{"task": _task_payload("stored"), "recipients": 1, "delivered": 1}]
 
     monkeypatch.setattr(broker, "broadcast_message", fake_broadcast)
     return calls

--- a/cafleet/tests/cli/test_message_truncation.py
+++ b/cafleet/tests/cli/test_message_truncation.py
@@ -65,7 +65,7 @@ def _broadcast_summary_payload(task_id, *, sender, count):
                 "task_id": task_id,
                 "context_id": sender,
                 "from_agent_id": sender,
-                "to_agent_id": 0,
+                "to_agent_id": None,
                 "type": "broadcast_summary",
                 "created_at": "2026-05-01T00:00:00+00:00",
                 "status_state": "completed",
@@ -73,7 +73,8 @@ def _broadcast_summary_payload(task_id, *, sender, count):
                 "origin_task_id": task_id,
                 "text": SUMMARY_TEXT,
             },
-            "notifications_sent_count": count,
+            "recipients": count,
+            "delivered": count,
         }
     ]
 
@@ -234,8 +235,9 @@ def test_truncation__broadcast_summary_emitted_verbatim(
         assert len(payload) == 1
         # Summary text fits inside default 200-codepoint limit → identical for both.
         assert payload[0]["task"]["text"] == SUMMARY_TEXT
-        # notifications_sent_count preserved in JSON.
-        assert payload[0]["notifications_sent_count"] == 3
+        # Split recipient/delivery counts preserved in JSON.
+        assert payload[0]["recipients"] == 3
+        assert payload[0]["delivered"] == 3
         if full:
             assert "task_id" in payload[0]["task"]
         else:

--- a/cafleet/tests/cli/test_unhidden_flags.py
+++ b/cafleet/tests/cli/test_unhidden_flags.py
@@ -1,0 +1,64 @@
+"""Regression tests: previously-hidden flags are visible and documented (design 0000118, items 3.4 + 3.5).
+
+``--full`` / ``--quiet`` (shared ``full_flag`` / ``quiet_flag``), ``--activity``
+(``member list``), and ``--ansi/--no-ansi`` (``member capture``) drop
+``hidden=True`` and carry help text, so they appear in the relevant ``--help``
+output. The Click param carries ``hidden is False`` and a non-empty ``help``.
+"""
+
+import pytest
+from click.testing import CliRunner
+
+from cafleet.cli import cli
+
+# (command path, Click param name) for every flag unhidden by this step.
+_UNHIDDEN_FLAGS = [
+    (("message", "send"), "full"),
+    (("message", "send"), "quiet"),
+    (("message", "ack"), "quiet"),
+    (("member", "ping"), "quiet"),
+    (("member", "list"), "activity"),
+    (("member", "capture"), "ansi"),
+]
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+def _param(path, param_name):
+    command = cli
+    for name in path:
+        command = command.commands[name]
+    for param in command.params:
+        if param.name == param_name:
+            return param
+    raise AssertionError(f"no param {param_name!r} on {' '.join(path)}")
+
+
+@pytest.mark.parametrize(("path", "param_name"), _UNHIDDEN_FLAGS)
+def test_flag_is_visible_and_documented(path, param_name):
+    param = _param(path, param_name)
+    assert param.hidden is False
+    assert param.help
+
+
+def test_message_send_help_shows_full_and_quiet(runner):
+    result = runner.invoke(cli, ["message", "send", "--help"])
+    assert result.exit_code == 0, result.output
+    assert "--full" in result.output
+    assert "--quiet" in result.output
+
+
+def test_member_list_help_shows_activity(runner):
+    result = runner.invoke(cli, ["member", "list", "--help"])
+    assert result.exit_code == 0, result.output
+    assert "--activity" in result.output
+
+
+def test_member_capture_help_shows_ansi(runner):
+    result = runner.invoke(cli, ["member", "capture", "--help"])
+    assert result.exit_code == 0, result.output
+    assert "--ansi" in result.output
+    assert "--no-ansi" in result.output

--- a/cafleet/tests/db/test_alembic_smoke.py
+++ b/cafleet/tests/db/test_alembic_smoke.py
@@ -50,23 +50,25 @@ def test_alembic_upgrade_head_creates_expected_tables(alembic_upgraded_db):
         engine.dispose()
 
 
-def test_alembic_version_table_records_head_0006(alembic_upgraded_db):
+def test_alembic_version_table_records_head_0007(alembic_upgraded_db):
     engine = create_engine(f"sqlite:///{alembic_upgraded_db}")
     try:
         with engine.connect() as conn:
             result = conn.execute(text("SELECT version_num FROM alembic_version"))
             rows = result.fetchall()
-        assert rows == [("0006",)]
+        assert rows == [("0007",)]
     finally:
         engine.dispose()
 
 
-def test_six_migration_revisions_exist():
-    """The migration history is six revisions: 0001 (base) → 0002 (monitor
+def test_seven_migration_revisions_exist():
+    """The migration history is seven revisions: 0001 (base) → 0002 (monitor
     tables) → 0003 (prune non-Director monitor_config rows) → 0004 (prune the
     root-Director monitor_config rows) → 0005 (per-member intervals: prune the
     monitoring member, backfill the root Director @180 + ordinary members @720)
-    → 0006 (skill_installs: the per-home record of the installing CLI version)."""
+    → 0006 (skill_installs: the per-home record of the installing CLI version)
+    → 0007 (tasks.to_agent_id → nullable so broadcast-summary rows persist
+    NULL)."""
     with importlib.resources.as_file(
         importlib.resources.files("cafleet.db") / "alembic.ini"
     ) as ini_path:
@@ -74,16 +76,25 @@ def test_six_migration_revisions_exist():
         script = ScriptDirectory.from_config(cfg)
         revisions = list(script.walk_revisions())
 
-    assert len(revisions) == 6
+    assert len(revisions) == 7
     by_revision = {rev.revision: rev for rev in revisions}
-    assert set(by_revision) == {"0001", "0002", "0003", "0004", "0005", "0006"}
+    assert set(by_revision) == {
+        "0001",
+        "0002",
+        "0003",
+        "0004",
+        "0005",
+        "0006",
+        "0007",
+    }
     assert by_revision["0001"].down_revision is None
     assert by_revision["0002"].down_revision == "0001"
     assert by_revision["0003"].down_revision == "0002"
     assert by_revision["0004"].down_revision == "0003"
     assert by_revision["0005"].down_revision == "0004"
     assert by_revision["0006"].down_revision == "0005"
-    assert script.get_current_head() == "0006"
+    assert by_revision["0007"].down_revision == "0006"
+    assert script.get_current_head() == "0007"
 
 
 def test_minted_id_tables_declare_autoincrement(alembic_upgraded_db):
@@ -195,6 +206,19 @@ def test_tasks_table_has_origin_task_id_column(alembic_upgraded_db):
 
         # Must be nullable because unicast + historical rows store NULL
         assert cols["origin_task_id"]["nullable"] is True
+    finally:
+        engine.dispose()
+
+
+def test_tasks_to_agent_id_is_nullable_after_migration(alembic_upgraded_db):
+    """0007 alters ``tasks.to_agent_id`` to nullable so broadcast-summary rows
+    persist NULL instead of the ``0`` sentinel (design 0000118, item 1.1)."""
+    engine = create_engine(f"sqlite:///{alembic_upgraded_db}")
+    try:
+        insp = inspect(engine)
+        cols = {col["name"]: col for col in insp.get_columns("tasks")}
+
+        assert cols["to_agent_id"]["nullable"] is True
     finally:
         engine.dispose()
 

--- a/cafleet/tests/output/test_ping_age_ascii.py
+++ b/cafleet/tests/output/test_ping_age_ascii.py
@@ -1,0 +1,44 @@
+"""Regression tests: ping-age placeholder is ASCII '-' (design 0000118, item 4.1).
+
+``_format_ping_age(None)`` renders the never-pinged placeholder as ASCII ``-``
+(matching the sibling ``_format_idle``), not the EM DASH ``—`` (U+2014). The
+full ``monitor status`` text render therefore contains no U+2014.
+"""
+
+from cafleet.output.formatters import _format_ping_age, format_monitor_status
+
+_EM_DASH = "—"
+
+
+def test_format_ping_age_none_returns_ascii_hyphen():
+    result = _format_ping_age(None)
+    assert result == "-"
+    assert _EM_DASH not in result
+
+
+def test_format_ping_age_real_age_unchanged():
+    assert _format_ping_age(42) == "42s ago"
+
+
+def _never_pinged_payload():
+    return {
+        "runtime": {"running": False},
+        "agents": [
+            {
+                "agent_id": 7,
+                "name": "member-a",
+                "role": "member",
+                "interval_seconds": 720,
+                "last_ping_age_seconds": None,
+                "enabled": True,
+                "pending_count": 0,
+            }
+        ],
+    }
+
+
+def test_format_monitor_status_no_em_dash_for_never_pinged_agent():
+    rendered = format_monitor_status(_never_pinged_payload())
+    # The never-pinged agent's row is rendered (guards against a vacuous check).
+    assert "member-a" in rendered
+    assert _EM_DASH not in rendered

--- a/cafleet/tests/output/test_render_broadcast_summary.py
+++ b/cafleet/tests/output/test_render_broadcast_summary.py
@@ -45,8 +45,8 @@ def test_broadcast_summary__wrapper_count_and_text_describes_recipient_count():
     _register_agent(sid, "recipient-b")
 
     [result] = broker.broadcast_message(sid, sender["agent_id"], "hi all")
-    assert "notifications_sent_count" in result
-    assert isinstance(result["notifications_sent_count"], int)
+    assert isinstance(result["recipients"], int)
+    assert isinstance(result["delivered"], int)
     summary_text = result["task"]["text"]
     assert summary_text.startswith("Broadcast sent to ")
     assert "recipients" in summary_text

--- a/cafleet/tests/output/test_to_agent_id_render.py
+++ b/cafleet/tests/output/test_to_agent_id_render.py
@@ -1,0 +1,35 @@
+"""Regression tests for the ``to:`` line in the full task render (design 0000118, item 1.2).
+
+The verbose render surfaces ``to:`` when a recipient is present
+(``to_agent_id`` is not ``None``) and omits it for recipient-less rows such as
+broadcast summaries.
+"""
+
+from cafleet.output.formatters import format_task
+
+
+def _full_task(**overrides):
+    task = {
+        "task_id": 5,
+        "context_id": 5,
+        "from_agent_id": 1,
+        "to_agent_id": None,
+        "type": "broadcast_summary",
+        "created_at": "2026-07-04T00:00:00+00:00",
+        "status_state": "completed",
+        "status_timestamp": "2026-07-04T00:00:00+00:00",
+        "origin_task_id": 5,
+        "text": "Broadcast sent to 2 recipients",
+    }
+    task.update(overrides)
+    return task
+
+
+def test_full_render_omits_to_line_when_to_agent_id_none():
+    rendered = format_task(_full_task(to_agent_id=None), full=True)
+    assert not any(line.strip().startswith("to:") for line in rendered.splitlines())
+
+
+def test_full_render_shows_to_line_for_real_recipient():
+    rendered = format_task(_full_task(to_agent_id=42, type="unicast"), full=True)
+    assert "to:    42" in rendered

--- a/design-docs/0000118-spec-docs-impl-consistency/design-doc.md
+++ b/design-docs/0000118-spec-docs-impl-consistency/design-doc.md
@@ -1,7 +1,7 @@
 # SPEC.md / docs vs Implementation Consistency Reconciliation
 
 **Status**: Approved
-**Progress**: 29/44 tasks complete
+**Progress**: 31/44 tasks complete
 **Last Updated**: 2026-07-04
 
 ## Overview
@@ -208,8 +208,8 @@ makes them first-class. Two reconciled surfaces can plausibly appear there and M
 
 ### Step 4: Code fix — broadcast `recipients` / `delivered` keys (2.1)
 
-- [ ] Test: broker result carries separate `recipients` (N) and `delivered` (k); CLI prints `recipients=N delivered=k` <!-- completed: -->
-- [ ] `broker/messaging.py:253-255` return both keys; `cli/message.py:70-75` print both <!-- completed: -->
+- [x] Test: broker result carries separate `recipients` (N) and `delivered` (k); CLI prints `recipients=N delivered=k` <!-- completed: 2026-07-04T07:46 -->
+- [x] `broker/messaging.py:253-255` return both keys; `cli/message.py:70-75` print both <!-- completed: 2026-07-04T07:46 -->
 
 ### Step 5: Code fix — normalize broker guards to exit 1 (2.2 + 3.3)
 

--- a/design-docs/0000118-spec-docs-impl-consistency/design-doc.md
+++ b/design-docs/0000118-spec-docs-impl-consistency/design-doc.md
@@ -1,7 +1,7 @@
 # SPEC.md / docs vs Implementation Consistency Reconciliation
 
 **Status**: Approved
-**Progress**: 33/44 tasks complete
+**Progress**: 35/44 tasks complete
 **Last Updated**: 2026-07-04
 
 ## Overview
@@ -218,8 +218,8 @@ makes them first-class. Two reconciled surfaces can plausibly appear there and M
 
 ### Step 6: Code fix — kind-predicate null/non-object safety (2.4)
 
-- [ ] Test: kind predicates return `False` (no raise) on `{"cafleet": null}` and `{"cafleet":"x"}` <!-- completed: -->
-- [ ] `broker/_shared.py:34-51` → guard null / non-object `cafleet` card <!-- completed: -->
+- [x] Test: kind predicates return `False` (no raise) on `{"cafleet": null}` and `{"cafleet":"x"}` <!-- completed: 2026-07-04T07:50 -->
+- [x] `broker/_shared.py:34-51` → guard null / non-object `cafleet` card <!-- completed: 2026-07-04T07:50 -->
 
 ### Step 7: Code fix — `fleet show` / `fleet delete` take `--fleet-id` (3.1 code)
 

--- a/design-docs/0000118-spec-docs-impl-consistency/design-doc.md
+++ b/design-docs/0000118-spec-docs-impl-consistency/design-doc.md
@@ -1,7 +1,7 @@
 # SPEC.md / docs vs Implementation Consistency Reconciliation
 
 **Status**: Approved
-**Progress**: 42/44 tasks complete
+**Progress**: 44/44 tasks complete
 **Last Updated**: 2026-07-04
 
 ## Overview
@@ -239,8 +239,8 @@ makes them first-class. Two reconciled surfaces can plausibly appear there and M
 
 ### Step 10: Cross-surface verification + gates
 
-- [ ] Verify `README.md` and every `skills/*/SKILL.md` against the reconciled `fleet show`/`fleet delete` `--fleet-id` invocation and the newly-visible flags; align any drift <!-- completed: -->
-- [ ] `mise //cafleet:test`, `mise //cafleet:lint`, `mise //cafleet:typecheck`, `mise //admin:lint` all pass <!-- completed: -->
+- [x] Verify `README.md` and every `skills/*/SKILL.md` against the reconciled `fleet show`/`fleet delete` `--fleet-id` invocation and the newly-visible flags; align any drift <!-- completed: 2026-07-04T08:13 -->
+- [x] `mise //cafleet:test`, `mise //cafleet:lint`, `mise //cafleet:typecheck`, `mise //admin:lint` all pass <!-- completed: 2026-07-04T08:13 -->
 
 ---
 

--- a/design-docs/0000118-spec-docs-impl-consistency/design-doc.md
+++ b/design-docs/0000118-spec-docs-impl-consistency/design-doc.md
@@ -14,14 +14,14 @@ buggy side. The authoritative audit input is `audit-findings.md` in this directo
 
 ## Success Criteria
 
-- [ ] All 32 contradictions have a landed resolution (doc edit or code fix) — zero remaining drift.
-- [ ] Every code fix ships with a regression test that would fail against the pre-fix code.
-- [ ] `SPEC.md` and `docs/` describe only the current, true behavior (first-class targets, per
+- [x] All 32 contradictions have a landed resolution (doc edit or code fix) — zero remaining drift.
+- [x] Every code fix ships with a regression test that would fail against the pre-fix code.
+- [x] `SPEC.md` and `docs/` describe only the current, true behavior (first-class targets, per
       `documentation-maintenance.md`); `README.md` and every `skills/*/SKILL.md` are verified
       consistent with the reconciled CLI/API/schema surfaces.
-- [ ] `--json` broadcast output carries separate `recipients` / `delivered` keys; `tasks.to_agent_id`
+- [x] `--json` broadcast output carries separate `recipients` / `delivered` keys; `tasks.to_agent_id`
       is nullable and emits `null` (not `0`) for broadcast-summary rows.
-- [ ] `mise //cafleet:test`, `mise //cafleet:lint`, `mise //cafleet:typecheck` pass.
+- [x] `mise //cafleet:test`, `mise //cafleet:lint`, `mise //cafleet:typecheck` pass.
 
 ---
 

--- a/design-docs/0000118-spec-docs-impl-consistency/design-doc.md
+++ b/design-docs/0000118-spec-docs-impl-consistency/design-doc.md
@@ -1,7 +1,7 @@
 # SPEC.md / docs vs Implementation Consistency Reconciliation
 
 **Status**: Approved
-**Progress**: 39/44 tasks complete
+**Progress**: 42/44 tasks complete
 **Last Updated**: 2026-07-04
 
 ## Overview
@@ -233,9 +233,9 @@ makes them first-class. Two reconciled surfaces can plausibly appear there and M
 
 ### Step 9: Unhide the four flags (3.4 + 3.5)
 
-- [ ] Test: `--full`, `--quiet`, `--activity`, `--ansi/--no-ansi` appear in the relevant `--help` output with help text <!-- completed: -->
-- [ ] `_helpers.py:47,48` → drop `hidden=True`, add `help=` on `full_flag` + `quiet_flag`; `member.py:494,545` → drop `hidden=True`, add `help=` <!-- completed: -->
-- [ ] Doc: document `--quiet` at `cli-options.md:146,899-901` + `SPEC.md:1007`; add `--activity` / `--ansi` to `cli-options.md` + SPEC §6.3 <!-- completed: -->
+- [x] Test: `--full`, `--quiet`, `--activity`, `--ansi/--no-ansi` appear in the relevant `--help` output with help text <!-- completed: 2026-07-04T08:11 -->
+- [x] `_helpers.py:47,48` → drop `hidden=True`, add `help=` on `full_flag` + `quiet_flag`; `member.py:494,545` → drop `hidden=True`, add `help=` <!-- completed: 2026-07-04T08:11 -->
+- [x] Doc: document `--quiet` at `cli-options.md:146,899-901` + `SPEC.md:1007`; add `--activity` / `--ansi` to `cli-options.md` + SPEC §6.3 <!-- completed: 2026-07-04T08:11 -->
 
 ### Step 10: Cross-surface verification + gates
 

--- a/design-docs/0000118-spec-docs-impl-consistency/design-doc.md
+++ b/design-docs/0000118-spec-docs-impl-consistency/design-doc.md
@@ -1,7 +1,7 @@
 # SPEC.md / docs vs Implementation Consistency Reconciliation
 
 **Status**: Approved
-**Progress**: 31/44 tasks complete
+**Progress**: 33/44 tasks complete
 **Last Updated**: 2026-07-04
 
 ## Overview
@@ -213,8 +213,8 @@ makes them first-class. Two reconciled surfaces can plausibly appear there and M
 
 ### Step 5: Code fix — normalize broker guards to exit 1 (2.2 + 3.3)
 
-- [ ] Test: root-Director deregistration guard and `member create` into soft-deleted fleet both exit 1 <!-- completed: -->
-- [ ] `broker/agents.py:272-276` and `broker/agents.py:65-66` → `click.ClickException` <!-- completed: -->
+- [x] Test: root-Director deregistration guard and `member create` into soft-deleted fleet both exit 1 <!-- completed: 2026-07-04T07:48 -->
+- [x] `broker/agents.py:272-276` and `broker/agents.py:65-66` → `click.ClickException` <!-- completed: 2026-07-04T07:48 -->
 
 ### Step 6: Code fix — kind-predicate null/non-object safety (2.4)
 

--- a/design-docs/0000118-spec-docs-impl-consistency/design-doc.md
+++ b/design-docs/0000118-spec-docs-impl-consistency/design-doc.md
@@ -1,7 +1,7 @@
 # SPEC.md / docs vs Implementation Consistency Reconciliation
 
 **Status**: Approved
-**Progress**: 9/44 tasks complete
+**Progress**: 25/44 tasks complete
 **Last Updated**: 2026-07-04
 
 ## Overview
@@ -182,22 +182,22 @@ makes them first-class. Two reconciled surfaces can plausibly appear there and M
 
 ### Step 2: docs/ doc-alignment edits (docs-first)
 
-- [ ] 1.3 — index order ascending at `docs/spec/data-model.md:92-93` <!-- completed: -->
-- [ ] 2.5 — two-string not-found behavior at `docs/concepts/fleet-isolation.md:16-17` <!-- completed: -->
-- [ ] 2.6 — module layout + re-exports + `list_roster` at `docs/api/broker.md:15-22,26-30` <!-- completed: -->
-- [ ] 3.1(doc) — narrow blanket sentence at `docs/get-started/configure.md:110-111` <!-- completed: -->
-- [ ] 3.2 — missing `--fleet-id` is exit-1 `ClickException` at `docs/spec/cli-options.md:1029` <!-- completed: -->
-- [ ] 3.6(doc) — fix sample spacing at `docs/spec/cli-options.md:367-370` <!-- completed: -->
-- [ ] 4.2 — `status_state` unconditionally omitted at `docs/spec/message-envelope.md:31` <!-- completed: -->
-- [ ] 4.3 — default + `--full` agent render at `docs/concepts/token-reduction.md:25` <!-- completed: -->
-- [ ] 5.1(doc) — error string at `docs/spec/cli-options.md:420` <!-- completed: -->
-- [ ] 6.1 — heartbeat runs first at `docs/concepts/monitoring.md:180,194-196` <!-- completed: -->
-- [ ] 7.1 — timeline scoped by sender at `docs/spec/webui-api.md:232` <!-- completed: -->
-- [ ] 7.2 — `/api/fleets` shape incl `director_agent_id`, excludes soft-deleted at `docs/spec/webui-api.md:23-36` <!-- completed: -->
-- [ ] 8.1 — add `--fleet-id` to `member capture` example at `docs/reference/coding-agents/opencode.md:84` <!-- completed: -->
-- [ ] 8.2 — Codex allowlist: drop `cafleet agent`, add `member show` at `docs/get-started/configure.md:59,76-80` <!-- completed: -->
-- [ ] 8.3 — full skill-install command at `docs/get-started/install.md:89` <!-- completed: -->
-- [ ] 8.4 — `cafleet:format` runs `ruff check --fix` first at `docs/get-started/contributing.md:36` <!-- completed: -->
+- [x] 1.3 — index order ascending at `docs/spec/data-model.md:92-93` <!-- completed: 2026-07-04T07:26 -->
+- [x] 2.5 — two-string not-found behavior at `docs/concepts/fleet-isolation.md:16-17` <!-- completed: 2026-07-04T07:26 -->
+- [x] 2.6 — module layout + re-exports + `list_roster` at `docs/api/broker.md:15-22,26-30` <!-- completed: 2026-07-04T07:26 -->
+- [x] 3.1(doc) — narrow blanket sentence at `docs/get-started/configure.md:110-111` <!-- completed: 2026-07-04T07:26 -->
+- [x] 3.2 — missing `--fleet-id` is exit-1 `ClickException` at `docs/spec/cli-options.md:1029` <!-- completed: 2026-07-04T07:26 -->
+- [x] 3.6(doc) — fix sample spacing at `docs/spec/cli-options.md:367-370` <!-- completed: 2026-07-04T07:26 -->
+- [x] 4.2 — `status_state` unconditionally omitted at `docs/spec/message-envelope.md:31` <!-- completed: 2026-07-04T07:26 -->
+- [x] 4.3 — default + `--full` agent render at `docs/concepts/token-reduction.md:25` <!-- completed: 2026-07-04T07:26 -->
+- [x] 5.1(doc) — error string at `docs/spec/cli-options.md:420` <!-- completed: 2026-07-04T07:26 -->
+- [x] 6.1 — heartbeat runs first at `docs/concepts/monitoring.md:180,194-196` <!-- completed: 2026-07-04T07:26 -->
+- [x] 7.1 — timeline scoped by sender at `docs/spec/webui-api.md:232` <!-- completed: 2026-07-04T07:26 -->
+- [x] 7.2 — `/api/fleets` shape incl `director_agent_id`, excludes soft-deleted at `docs/spec/webui-api.md:23-36` <!-- completed: 2026-07-04T07:26 -->
+- [x] 8.1 — add `--fleet-id` to `member capture` example at `docs/reference/coding-agents/opencode.md:84` <!-- completed: 2026-07-04T07:26 -->
+- [x] 8.2 — Codex allowlist: drop `cafleet agent`, add `member show` at `docs/get-started/configure.md:59,76-80` <!-- completed: 2026-07-04T07:26 -->
+- [x] 8.3 — full skill-install command at `docs/get-started/install.md:89` <!-- completed: 2026-07-04T07:26 -->
+- [x] 8.4 — `cafleet:format` runs `ruff check --fix` first at `docs/get-started/contributing.md:36` <!-- completed: 2026-07-04T07:26 -->
 
 ### Step 3: Code fix — `to_agent_id` nullable + NULL sentinel (1.1 + 1.2)
 

--- a/design-docs/0000118-spec-docs-impl-consistency/design-doc.md
+++ b/design-docs/0000118-spec-docs-impl-consistency/design-doc.md
@@ -1,6 +1,6 @@
 # SPEC.md / docs vs Implementation Consistency Reconciliation
 
-**Status**: Approved
+**Status**: Complete
 **Progress**: 44/44 tasks complete
 **Last Updated**: 2026-07-04
 
@@ -250,3 +250,4 @@ makes them first-class. Two reconciled surfaces can plausibly appear there and M
 |------|---------|
 | 2026-07-04 | Initial draft — 32 contradictions reconciled per user decisions Q1–Q4 |
 | 2026-07-04 | Approved — `--quiet` disposition finalized as UNHIDE; conditional REMOVE alternative removed |
+| 2026-07-04 | Complete — all 44 tasks landed; Reviewer-approved (1 round, 4 leftover-drift fixes); 990 tests + lint + typecheck + admin:lint green; PR #163 |

--- a/design-docs/0000118-spec-docs-impl-consistency/design-doc.md
+++ b/design-docs/0000118-spec-docs-impl-consistency/design-doc.md
@@ -1,7 +1,7 @@
 # SPEC.md / docs vs Implementation Consistency Reconciliation
 
 **Status**: Approved
-**Progress**: 35/44 tasks complete
+**Progress**: 39/44 tasks complete
 **Last Updated**: 2026-07-04
 
 ## Overview
@@ -223,13 +223,13 @@ makes them first-class. Two reconciled surfaces can plausibly appear there and M
 
 ### Step 7: Code fix — `fleet show` / `fleet delete` take `--fleet-id` (3.1 code)
 
-- [ ] Test: `cafleet fleet show --fleet-id N` and `cafleet fleet delete --fleet-id N` succeed; positional form no longer accepted <!-- completed: -->
-- [ ] `cli/fleet.py:82-86` + `105-107` → `@fleet_id_option`, read from `ctx.obj` <!-- completed: -->
+- [x] Test: `cafleet fleet show --fleet-id N` and `cafleet fleet delete --fleet-id N` succeed; positional form no longer accepted <!-- completed: 2026-07-04T07:58 -->
+- [x] `cli/fleet.py:82-86` + `105-107` → `@fleet_id_option`, read from `ctx.obj` <!-- completed: 2026-07-04T07:58 -->
 
 ### Step 8: Code fix — ping-age ASCII hyphen (4.1)
 
-- [ ] Test: `_format_ping_age(None)` returns `"-"` (ASCII), no U+2014 anywhere in monitor-status render <!-- completed: -->
-- [ ] `output/formatters.py:216-220` → return `"-"` <!-- completed: -->
+- [x] Test: `_format_ping_age(None)` returns `"-"` (ASCII), no U+2014 anywhere in monitor-status render <!-- completed: 2026-07-04T07:57 -->
+- [x] `output/formatters.py:216-220` → return `"-"` <!-- completed: 2026-07-04T07:57 -->
 
 ### Step 9: Unhide the four flags (3.4 + 3.5)
 

--- a/design-docs/0000118-spec-docs-impl-consistency/design-doc.md
+++ b/design-docs/0000118-spec-docs-impl-consistency/design-doc.md
@@ -1,7 +1,7 @@
 # SPEC.md / docs vs Implementation Consistency Reconciliation
 
 **Status**: Approved
-**Progress**: 25/44 tasks complete
+**Progress**: 29/44 tasks complete
 **Last Updated**: 2026-07-04
 
 ## Overview
@@ -201,10 +201,10 @@ makes them first-class. Two reconciled surfaces can plausibly appear there and M
 
 ### Step 3: Code fix — `to_agent_id` nullable + NULL sentinel (1.1 + 1.2)
 
-- [ ] Test: broadcast-summary row persists `to_agent_id = NULL`; `--json` emits `null` <!-- completed: -->
-- [ ] Test: `to:` surfacing (`queries.py`, `formatters.py`) hides on `None`, shows on a real id <!-- completed: -->
-- [ ] `db/models.py:73` → `nullable=True`; new Alembic migration (next rev after head) <!-- completed: -->
-- [ ] `broker/messaging.py:218` → write `None`; `queries.py:68-70` + `formatters.py:39-40` → `is None`/`IS NULL` <!-- completed: -->
+- [x] Test: broadcast-summary row persists `to_agent_id = NULL`; `--json` emits `null` <!-- completed: 2026-07-04T07:34 -->
+- [x] Test: `to:` surfacing (`queries.py`, `formatters.py`) hides on `None`, shows on a real id <!-- completed: 2026-07-04T07:34 -->
+- [x] `db/models.py:73` → `nullable=True`; new Alembic migration (next rev after head) <!-- completed: 2026-07-04T07:34 -->
+- [x] `broker/messaging.py:218` → write `None`; `queries.py:68-70` + `formatters.py:39-40` → `is None`/`IS NULL` <!-- completed: 2026-07-04T07:34 -->
 
 ### Step 4: Code fix — broadcast `recipients` / `delivered` keys (2.1)
 

--- a/design-docs/0000118-spec-docs-impl-consistency/design-doc.md
+++ b/design-docs/0000118-spec-docs-impl-consistency/design-doc.md
@@ -1,7 +1,7 @@
 # SPEC.md / docs vs Implementation Consistency Reconciliation
 
 **Status**: Approved
-**Progress**: 0/44 tasks complete
+**Progress**: 9/44 tasks complete
 **Last Updated**: 2026-07-04
 
 ## Overview
@@ -170,15 +170,15 @@ makes them first-class. Two reconciled surfaces can plausibly appear there and M
 
 ### Step 1: SPEC.md doc-alignment edits (docs-first)
 
-- [ ] 2.3 — rewrite §5.4 kind-projection summary at `SPEC.md:362-366`, `514-517` <!-- completed: -->
-- [ ] 3.6 — `fleet list` is 5 columns (`40/40/20/8` padded + CREATED_AT trailing unpadded) at `SPEC.md:992-994` <!-- completed: -->
-- [ ] 4.4 — remove `coding_agent` from conditional-fields list at `SPEC.md:1652` <!-- completed: -->
-- [ ] 5.1 — "tmux-pane commands…" → "member commands…" at `SPEC.md:1668-1670`, `2379-2381` <!-- completed: -->
-- [ ] 5.2 — newline-only → newline/CR at `SPEC.md:1718-1721` <!-- completed: -->
-- [ ] 6.2 — `Continue`/`Stop` → `CONTINUE`/`STOP` at `SPEC.md:1829,1833-1834` (+1870,1873,1899,1917,1924) <!-- completed: -->
-- [ ] 6.3 — "four functions" → three at `SPEC.md:1841-1843` <!-- completed: -->
-- [ ] 7.3 — `/api/timeline` "all" → capped at 200 at `SPEC.md:2254-2255` <!-- completed: -->
-- [ ] 7.4 — send path also requires `status=="active"` at `SPEC.md:2259-2263` <!-- completed: -->
+- [x] 2.3 — rewrite §5.4 kind-projection summary at `SPEC.md:362-366`, `514-517` <!-- completed: 2026-07-04T07:18 -->
+- [x] 3.6 — `fleet list` is 5 columns (`40/40/20/8` padded + CREATED_AT trailing unpadded) at `SPEC.md:992-994` <!-- completed: 2026-07-04T07:18 -->
+- [x] 4.4 — remove `coding_agent` from conditional-fields list at `SPEC.md:1652` <!-- completed: 2026-07-04T07:18 -->
+- [x] 5.1 — "tmux-pane commands…" → "member commands…" at `SPEC.md:1668-1670`, `2379-2381` <!-- completed: 2026-07-04T07:18 -->
+- [x] 5.2 — newline-only → newline/CR at `SPEC.md:1718-1721` <!-- completed: 2026-07-04T07:18 -->
+- [x] 6.2 — `Continue`/`Stop` → `CONTINUE`/`STOP` at `SPEC.md:1829,1833-1834` (+1870,1873,1899,1917,1924) <!-- completed: 2026-07-04T07:18 -->
+- [x] 6.3 — "four functions" → three at `SPEC.md:1841-1843` <!-- completed: 2026-07-04T07:18 -->
+- [x] 7.3 — `/api/timeline` "all" → capped at 200 at `SPEC.md:2254-2255` <!-- completed: 2026-07-04T07:18 -->
+- [x] 7.4 — send path also requires `status=="active"` at `SPEC.md:2259-2263` <!-- completed: 2026-07-04T07:18 -->
 
 ### Step 2: docs/ doc-alignment edits (docs-first)
 

--- a/docs/api/broker.md
+++ b/docs/api/broker.md
@@ -16,17 +16,21 @@ persisted behavior lands here.
 |---|---|
 | `broker/fleets.py` | fleet CRUD (`create_fleet`, `list_fleets`, `get_fleet`, `delete_fleet`) |
 | `broker/agents.py` | agent registry + placement (`register_agent`, `deregister_agent`, `verify_agent_fleet`, …) |
-| `broker/members.py` | member roster + activity proxies (`list_members`, `list_members_with_activity`) |
+| `broker/members.py` | member roster + activity proxies (`list_members`, `list_members_with_activity`, `list_roster`) |
 | `broker/messaging.py` | `send_message`, `broadcast_message`, `poll_tasks`, `ack_task`, `cancel_task` + inline-preview notification |
 | `broker/queries.py` | read-only task queries (`list_inbox`, `list_sent`, `list_timeline`, `get_task`) |
+| `broker/monitor.py` | monitor runtime, enrollment, and ping records (`enroll_agent`, `find_monitoring_member`, `claim_monitor_runtime`, `heartbeat_monitor_runtime`, `clear_monitor_runtime`, `read_monitor_runtime`, `monitor_is_live`, `record_ping`, `record_pings`, `list_monitor_targets`, `list_monitor_configs`, `get_monitor_config`, `update_monitor_config`) |
+| `broker/skill_installs.py` | skill-install audit rows (`skill_installs_table_exists`, `list_skill_installs`, `record_skill_install`) |
 | `broker/_shared.py` | private cross-submodule helpers and the `read_session` / `write_session` context managers |
 
 ## Re-export contract
 
-`broker/__init__.py` re-exports the full public API with `__all__`: import
-the package and use attribute access (`from cafleet import broker` then
-`broker.send_message(...)`), never a submodule directly. The package
-attribute is the supported test patch seam; the single DB seam is
+`broker/__init__.py` re-exports the public API of every submodule **except
+`skill_installs.py`** with `__all__`: import the package and use attribute
+access (`from cafleet import broker` then `broker.send_message(...)`). The
+`skill_installs.py` helpers are the deliberate exception — they are imported
+directly from the submodule (`from cafleet.broker.skill_installs import …`).
+The package attribute is the supported test patch seam; the single DB seam is
 `cafleet.broker._shared.get_sync_sessionmaker`.
 
 ::: cafleet.broker

--- a/docs/concepts/fleet-isolation.md
+++ b/docs/concepts/fleet-isolation.md
@@ -13,8 +13,10 @@ partitions for tidiness, not security boundaries.
 
 Every operation that reads or writes agent / task data enforces fleet
 boundaries; registration additionally requires a valid, non-soft-deleted
-`fleet_id`. Cross-fleet requests always produce "not found" errors
-indistinguishable from the resource not existing.
+`fleet_id`. A cross-fleet request produces a **distinct** error:
+`send_message` raises `Destination agent not in fleet: {to_id}` when the target
+exists in another fleet, versus `Destination agent not found: {to_id}` when it
+does not exist at all.
 
 ## Lifecycle
 

--- a/docs/concepts/monitoring.md
+++ b/docs/concepts/monitoring.md
@@ -177,7 +177,7 @@ pinging and without wiping the winner's row.
 %%{init: {'theme': 'default', 'themeVariables': {'fontSize': '16px'}}}%%
 flowchart LR
     Start["monitor start<br/>(monitoring member's background task)"] --> Claim["claim runtime row"]
-    Claim --> Tick["every tick:<br/>scan watched set → wake monitor if any due → heartbeat"]
+    Claim --> Tick["every tick:<br/>heartbeat (STOP if slot lost) → scan watched set → wake monitor if any due"]
     Tick --> Tick
     Tick --> Stop["stop the task /<br/>delete the monitoring member /<br/>fleet delete"]
     Stop --> Clear["clear runtime row"]
@@ -191,9 +191,11 @@ flowchart LR
   `monitor start` in the fleet; the Director no longer runs it. The loop inherits
   the monitoring member's pane environment (`$TMUX`, `$CAFLEET_DATABASE_URL`) and
   fails fast on startup if it cannot reach a tmux session.
-- **Run**: each tick scans the watched set (Director + members), wakes the
-  monitoring member with the wake nudge when ≥ 1 watched agent is due, stamps the
-  due agents' `last_ping_at`, and rewrites the heartbeat.
+- **Run**: each tick first writes the ownership-checked heartbeat (a zero-row
+  update means the slot was reclaimed → the loop self-terminates with `STOP`),
+  then scans the watched set (Director + members), wakes the monitoring member
+  with the wake nudge when ≥ 1 watched agent is due, and stamps the due agents'
+  `last_ping_at`.
 - **Stop (first-out).** Teardown stops the monitor **before** the monitoring
   member's pane is killed: the Director messages the monitoring member to stop
   its `monitor start` background task (the task-stop delivers SIGTERM/SIGINT, so

--- a/docs/concepts/token-reduction.md
+++ b/docs/concepts/token-reduction.md
@@ -22,7 +22,7 @@ per-message, per-spawn, per-tick, and per-context-load cost down.
 | `cafleet member list --activity` | Aggregates per-member message timestamps into `last_sent` / `last_recv` / `last_ack` / `idle` columns; broadcast summary rows are excluded from `last_ack`. |
 | Persisted-shape simplification | Every `Task` field is a flat typed column; the message body lives in `Task.text` and there is no opaque per-task JSON blob. WebUI consumers use the same typed-column flat shape. |
 | Inline message preview | The broker keystrokes a 2-line preview into the recipient's pane instead of requiring a poll round-trip — see [tmux push notifications](tmux-push.md). |
-| Agent render slim | Each agent renders to the minimum-required fields by default (`id`, `name`, `description` truncated, `status`, and `coding_agent` from placement); `--full` returns the agent dict unchanged. The agent surfaces never emit `agent_card_json` in either mode. |
+| Agent render slim | The default text render is slim — `<agent_id> <name> <status>`, three space-separated fields with no labels. `--full` expands to a labeled multi-line block that adds `description` (truncated to 60), `kind`, `skills`, and the placement block (`director_agent_id`, `backend`, `session`, `window_id`, `pane_id`, `created_at`). The agent surfaces never emit `agent_card_json` in either mode. |
 
 ## Required-reading convention
 

--- a/docs/get-started/configure.md
+++ b/docs/get-started/configure.md
@@ -56,11 +56,11 @@ prefix_rule(pattern = ["cafleet", "setup"],      decision = "allow")
 prefix_rule(pattern = ["cafleet", "doctor"],     decision = "allow")
 prefix_rule(pattern = ["cafleet", "server"],     decision = "allow")
 prefix_rule(pattern = ["cafleet", "fleet"],      decision = "allow")
-prefix_rule(pattern = ["cafleet", "agent"],      decision = "allow")
 prefix_rule(pattern = ["cafleet", "message"],    decision = "allow")
 prefix_rule(pattern = ["cafleet", "monitor"],    decision = "allow")
 prefix_rule(pattern = ["cafleet", "member", "create"],  decision = "allow")
 prefix_rule(pattern = ["cafleet", "member", "delete"],  decision = "allow")
+prefix_rule(pattern = ["cafleet", "member", "show"],    decision = "allow")
 prefix_rule(pattern = ["cafleet", "member", "list"],    decision = "allow")
 prefix_rule(pattern = ["cafleet", "member", "capture"], decision = "allow")
 prefix_rule(pattern = ["cafleet", "member", "ping"],    decision = "allow")
@@ -107,9 +107,9 @@ MCP servers (MCP-contributed tools bypass the deny-list).
 
 ## Passing the fleet id
 
-Every fleet-scoped command takes a required `--fleet-id`, passed as a literal
-integer flag on each invocation (a member reads its fleet id from the
-`FLEET ID:` line of its spawn prompt). Agents driving cafleet under
+Every fleet-scoped command except `fleet create` and `fleet list` takes a
+required `--fleet-id`, passed as a literal integer flag on each invocation (a
+member reads its fleet id from the `FLEET ID:` line of its spawn prompt). Agents driving cafleet under
 `permissions.allow` pass `--fleet-id` as a literal flag — the allow patterns
 match the literal command string, so a shell-expanded variable would break the
 match and prompt.

--- a/docs/get-started/contributing.md
+++ b/docs/get-started/contributing.md
@@ -33,7 +33,7 @@ mise //cafleet:install    # editable uv tool install of the cafleet CLI
 cafleet setup db          # migrate the database schema (idempotent)
 
 mise //cafleet:lint       # ruff check + ruff format --check
-mise //cafleet:format     # ruff format
+mise //cafleet:format     # ruff check --fix + ruff format
 mise //cafleet:typecheck  # ty
 mise //cafleet:test       # pytest
 

--- a/docs/get-started/install.md
+++ b/docs/get-started/install.md
@@ -86,8 +86,10 @@ the skills from the working tree instead:
 mise //:skill-install
 ```
 
-This runs `gh skill install ./ --from-local` for each backend, placing the
-skills from your checkout (not a Release) into the three agent homes.
+This runs `gh skill install ./ --from-local --agent <backend> --force --scope
+user` for each of the three backends (`claude-code`, `codex`, `opencode`),
+placing the skills from your checkout (not a Release) into the three agent
+homes.
 
 Once the CLI and at least one coding-agent skill set are installed, continue to
 the [Configure](configure.md) page for the recommended per-agent settings.

--- a/docs/reference/coding-agents/opencode.md
+++ b/docs/reference/coding-agents/opencode.md
@@ -81,7 +81,7 @@ Only `claude` sets the pane title to the member name; locate `opencode` panes vi
 
 ## Permission-popup recovery posture
 
-In normal operation the TUI never shows a permission popup — every check resolves to `allow` or `deny` without `ask`. If a popup ever appears, it is a regression escape from the safety floor, not a runtime decision-point: the Director MUST escalate to the user and capture pane state via `cafleet member capture --member-id <opencode-member>` for diagnosis, then extend the deny-list (a source change + new release + preset refresh). The Director MUST NOT answer the popup as an ad-hoc workaround — that defeats the safety-floor invariant.
+In normal operation the TUI never shows a permission popup — every check resolves to `allow` or `deny` without `ask`. If a popup ever appears, it is a regression escape from the safety floor, not a runtime decision-point: the Director MUST escalate to the user and capture pane state via `cafleet member capture --fleet-id <fleet-id> --member-id <opencode-member>` for diagnosis, then extend the deny-list (a source change + new release + preset refresh). The Director MUST NOT answer the popup as an ad-hoc workaround — that defeats the safety-floor invariant.
 
 ## Safety floor caveats
 

--- a/docs/spec/cli-options.md
+++ b/docs/spec/cli-options.md
@@ -143,7 +143,7 @@ The table describes the resulting `text` value AFTER truncation. Text mode omits
 |---|---|---|
 | `--full` | no | Documented per-subcommand option (placed after the subcommand name, like `--agent-id` and `--task-id`). Disables truncation; emits the full message body and the full typed-column envelope. Composes orthogonally with `--json`. See [`--full` semantics](#full-semantics) for the cross-subcommand summary. |
 
-There is no `--quiet` flag on any subcommand.
+The `--quiet` flag is available on `cafleet message send`, `cafleet message ack`, and `cafleet member ping`: it suppresses the normal output and prints only the bare `task_id` (the target member id for `ping`), for shell capture.
 
 Length is measured in Python `str` codepoints, never bytes — multibyte characters are never split.
 
@@ -894,6 +894,7 @@ Re-pokes a member's inbox. Keystrokes `Esc` → `cafleet message poll --fleet-id
 | Flag | Required | Notes |
 |---|---|---|
 | `--member-id` | yes | The target member. |
+| `--quiet` | no | Suppress the normal `Pinged …` line and print only the bare member id, for shell capture. |
 
 ```bash
 cafleet member ping --fleet-id <fleet-id> --member-id <member-id>

--- a/docs/spec/cli-options.md
+++ b/docs/spec/cli-options.md
@@ -362,12 +362,7 @@ Both the root Director and the built-in Administrator are protected from `member
 
 Lists all **non-soft-deleted** fleets with their `director_agent_id`, label, created_at, and active agent count. Soft-deleted fleets (`fleets.deleted_at IS NOT NULL`) are hidden.
 
-Each row exposes the fleet's root `director_agent_id` so the Director's ID can be recovered from a list after `fleet create` output scrolls away. The `--json` output carries it as a `director_agent_id` field (integer). Text output renders it as a `DIRECTOR` column placed immediately after `FLEET_ID`:
-
-```
-FLEET_ID  DIRECTOR  LABEL       AGENTS  CREATED_AT
-1         2         my-project  3       2026-04-15T10:00:00+00:00
-```
+Each row exposes the fleet's root `director_agent_id` so the Director's ID can be recovered from a list after `fleet create` output scrolls away. The `--json` output carries it as a `director_agent_id` field (integer). Text output renders five columns: `FLEET_ID`, `DIRECTOR`, `LABEL`, and `AGENTS` are each left-padded to widths 40 / 40 / 20 / 8 (one space between columns), followed by an unpadded trailing `CREATED_AT`. The wide left-padding means the real gaps between columns are far larger than a compact sample can depict; the column order is `FLEET_ID`, `DIRECTOR` (immediately after `FLEET_ID`), `LABEL`, `AGENTS`, `CREATED_AT`. Nullable `DIRECTOR` / `LABEL` cells fall back to empty strings.
 
 ### `fleet show`
 
@@ -417,7 +412,7 @@ Prints the calling pane's tmux session/window/pane identifiers (plus `$TMUX_PANE
 
 Environment requirements:
 
-- `TMUX` env var must be set — the command rejects otherwise with `Error: cafleet tmux-pane commands must be run inside a tmux session` (the same message used by the `member *` tmux guard).
+- `TMUX` env var must be set — the command rejects otherwise with `Error: cafleet member commands must be run inside a tmux session` (the same message used by the `member *` tmux guard).
 - `TMUX_PANE` env var must be set — already required for pane discovery.
 
 Text output:
@@ -1026,7 +1021,7 @@ agent 5: interval 720s, enabled, last_ping 2026-06-13T04:51:00
 | Any `fleet` / `member` / `message` / `monitor` command with no skills install recorded (missing DB file, missing `skill_installs` table, or zero rows) | `Error: no skills install is recorded; run 'cafleet setup' first` (exit 1; see [Stale-skills guard](#stale-skills-guard)) |
 | Any `fleet` / `member` / `message` / `monitor` command with a recorded `skill_installs` version differing from the runtime CLI version | `Error: stale skills detected (<agent>=<recorded>[, ...]; CLI <runtime>); run 'cafleet setup skill' to reinstall` (exit 1; see [Stale-skills guard](#stale-skills-guard)) |
 | `setup skill` when the `skill_installs` table is missing | `Error: the database schema is missing or outdated; run 'cafleet setup' or 'cafleet setup db' first` (exit 1) |
-| Missing `--fleet-id` on a fleet-scoped subcommand | `Error: Missing option '--fleet-id'.` (exit 2) |
+| Missing `--fleet-id` on a fleet-scoped subcommand | `Error: --fleet-id <int> is required for this subcommand. Create a fleet with 'cafleet fleet create' and pass its id.` (exit 1) |
 | Missing `--agent-id` | `Error: Missing option '--agent-id'.` (exit 2) |
 | `fleet create` run outside a tmux session | `Error: cafleet fleet create must be run inside a tmux session` (exit 1; no DB writes) |
 | `fleet delete` on unknown fleet_id | `Error: fleet 'X' not found.` (exit 1) |

--- a/docs/spec/data-model.md
+++ b/docs/spec/data-model.md
@@ -89,8 +89,8 @@ Indexes:
 
 | Name | Columns | Purpose |
 |---|---|---|
-| `idx_tasks_context_status_ts` | `(context_id, status_timestamp DESC)` | Inbox listing: `WHERE context_id = ? ORDER BY status_timestamp DESC`. |
-| `idx_tasks_from_agent_status_ts` | `(from_agent_id, status_timestamp DESC)` | WebUI sender outbox: `WHERE from_agent_id = ? ORDER BY status_timestamp DESC`. |
+| `idx_tasks_context_status_ts` | `(context_id, status_timestamp)` | Inbox listing: `WHERE context_id = ? ORDER BY status_timestamp DESC`. |
+| `idx_tasks_from_agent_status_ts` | `(from_agent_id, status_timestamp)` | WebUI sender outbox: `WHERE from_agent_id = ? ORDER BY status_timestamp DESC`. |
 
 ### `agent_placements`
 

--- a/docs/spec/message-envelope.md
+++ b/docs/spec/message-envelope.md
@@ -28,7 +28,7 @@ Field decisions:
 | `text` | included, truncated to `CAFLEET_MAX_TEXT_LEN` codepoints + `…` suffix | included, untruncated |
 | `type` | omitted when `"unicast"` (the default); rendered as `kind` when `"broadcast_summary"` | rendered as `type` |
 | `created_at` | omitted | included |
-| `status_state` | omitted when `"input_required"` (the default for fresh deliveries) | included |
+| `status_state` | omitted (unconditional) | included |
 | `origin_task_id` | rendered as `origin` (full integer) when non-NULL; omitted on unicast deliveries | included |
 
 ### JSON output

--- a/docs/spec/webui-api.md
+++ b/docs/spec/webui-api.md
@@ -20,7 +20,7 @@ No server-side session cookies. The SPA stores the active fleet_id client-side v
 
 ### GET /api/fleets — List Fleets
 
-Returns all fleets with agent counts, ordered newest-first by `created_at DESC, fleet_id ASC`. No headers required.
+Returns non-soft-deleted fleets (`deleted_at IS NULL`) with agent counts, ordered newest-first by `created_at DESC, fleet_id ASC`. No headers required.
 
 **Response** (200 OK):
 
@@ -28,6 +28,7 @@ Returns all fleets with agent counts, ordered newest-first by `created_at DESC, 
 [
   {
     "fleet_id": 1,
+    "director_agent_id": 2,
     "label": "PR-42 review",
     "created_at": "2026-04-12T10:00:00+00:00",
     "agent_count": 3
@@ -229,7 +230,7 @@ Returns up to 200 most-recent non-`broadcast_summary` tasks for the selected fle
 
 **Request**: `X-Fleet-Id: <fleet_id>` header.
 
-Fleet scoping is reached through the `tasks.context_id → agents.agent_id → agents.fleet_id` join. Only tasks whose recipient belongs to the header fleet are returned; cross-fleet tasks are invisible.
+Fleet scoping is reached through the `tasks.from_agent_id → agents.agent_id → agents.fleet_id` join. Only tasks whose **sender** belongs to the header fleet are returned; cross-fleet tasks are invisible.
 
 **Response** (200 OK):
 

--- a/skills/cafleet/reference/output-flags.md
+++ b/skills/cafleet/reference/output-flags.md
@@ -1,6 +1,6 @@
 # Output flags — `--full` / `--json`
 
-`--full` and `--json` are cafleet's two **independent, composable** output-control flags over its compact default output. `--full` opts back into untruncated, every-field output — it bypasses the truncation caps. `--json` switches the encoding to structured JSON but is **still truncated** unless combined with `--full` (`--json --full` gives untruncated JSON). There is no `--quiet` flag.
+`--full` and `--json` are cafleet's two **independent, composable** output-control flags over its compact default output. `--full` opts back into untruncated, every-field output — it bypasses the truncation caps. `--json` switches the encoding to structured JSON but is **still truncated** unless combined with `--full` (`--json --full` gives untruncated JSON). A separate `--quiet` flag — on `message send`, `message ack`, and `member ping` — prints only the bare `task_id` (the target member id for `ping`) for shell capture.
 
 ## `--full` (cross-subcommand escape hatch)
 


### PR DESCRIPTION
- **docs: align SPEC.md with implementation (items 2.3, 3.6, 4.4, 5.1, 5.2, 6.2, 6.3, 7.3, 7.4)**
- **docs: align docs/ with implementation (items 1.3, 2.5, 2.6, 3.1, 3.2, 3.6, 4.2, 4.3, 5.1, 6.1, 7.1, 7.2, 8.1, 8.2, 8.3, 8.4)**
- **test: add regression tests for to_agent_id nullable + NULL sentinel (items 1.1, 1.2)**
- **feat: make tasks.to_agent_id nullable with NULL broadcast sentinel (items 1.1, 1.2)**
- **test: add broadcast recipients/delivered split tests, migrate legacy notifications_sent_count stubs (item 2.1)**
- **test: normalize broker guards to exit 1 in regression tests (items 2.2, 3.3)**
- **feat: split broadcast result into recipients and delivered counts (item 2.1)**
- **test: add kind-predicate null/non-object safety tests (item 2.4)**
- **fix: normalize broker guards to exit 1 via ClickException (items 2.2, 3.3)**
- **test: fleet show/delete take --fleet-id, reject positional (item 3.1)**
- **fix: guard kind predicates against null/non-object cafleet card (item 2.4)**
- **test: ping-age None renders ASCII hyphen, not EM DASH (item 4.1)**
- **test: unhidden flags visible and documented in --help (items 3.4, 3.5)**
- **feat: fleet show/delete take --fleet-id option, not positional (item 3.1)**
- **fix: ping-age None renders ASCII hyphen, not EM DASH (item 4.1)**
- **feat: unhide --full/--quiet/--activity/--ansi flags with help text and docs (items 3.4, 3.5)**
- **docs: fix stale --quiet denial in output-flags reference; cross-surface verification complete**
- **docs: check off all Success Criteria for design 0000118**
- **fix: address Reviewer feedback - stale notifications_sent_count/truthiness/help leftovers**
