### PR TITLE
feat/0000126 consolidate readme into docs

### DIFF
--- a/docs/get-started/quickstart.md
+++ b/docs/get-started/quickstart.md
@@ -44,99 +44,101 @@ If you would rather drive CAFleet from the shell directly, the commands below
 mirror what the skill does internally. Run them inside a tmux or herdr session —
 the `fleet create` and `member create` commands require one.
 
-The walkthrough pastes literal integer ids: fleet `1`, root Director `2`,
-members `4` and `5`, task `10`. Your ids will differ — substitute the
-integers your own commands print.
+??? example "Expand the walkthrough"
 
-Create a fleet. This records your current pane as the root Director's pane:
+    The walkthrough pastes literal integer ids: fleet `1`, root Director `2`,
+    members `4` and `5`, task `10`. Your ids will differ — substitute the
+    integers your own commands print.
 
-```bash
-cafleet fleet create --name "demo"
-```
+    Create a fleet. This records your current pane as the root Director's pane:
 
-```
-1 director=2 admin=3
-```
+    ```bash
+    cafleet fleet create --name "demo"
+    ```
 
-The line carries the fleet id (`1`), the root Director's agent id (`2`), and
-the built-in Administrator's agent id (`3`). If it scrolls away, run
-`cafleet fleet list` — it re-prints the fleet id and the Director id (the
-`DIRECTOR` column).
+    ```
+    1 director=2 admin=3
+    ```
 
-Spawn two member panes. Each member's prompt is just a one-line greeting.
-Optional: add `--model <m>` (e.g. `--model sonnet`) to pin a member's LLM;
-omitted, the backend binary uses its own default model:
+    The line carries the fleet id (`1`), the root Director's agent id (`2`), and
+    the built-in Administrator's agent id (`3`). If it scrolls away, run
+    `cafleet fleet list` — it re-prints the fleet id and the Director id (the
+    `DIRECTOR` column).
 
-```bash
-cafleet member create --fleet-id 1 \
-  --agent-id 2 \
-  --name "demo-member" \
-  --description "Demo member" \
-  --text "You are demo-member. Reply hello when polled."
-```
+    Spawn two member panes. Each member's prompt is just a one-line greeting.
+    Optional: add `--model <m>` (e.g. `--model sonnet`) to pin a member's LLM;
+    omitted, the backend binary uses its own default model:
 
-```
-4 demo-member backend=claude pane=%7
-```
+    ```bash
+    cafleet member create --fleet-id 1 \
+      --agent-id 2 \
+      --name "demo-member" \
+      --description "Demo member" \
+      --text "You are demo-member. Reply hello when polled."
+    ```
 
-```bash
-cafleet member create --fleet-id 1 \
-  --agent-id 2 \
-  --name "reviewer" \
-  --description "Reviewer member" \
-  --text "You are reviewer. Reply hello when polled."
-```
+    ```
+    4 demo-member backend=claude pane=%7
+    ```
 
-```
-5 reviewer backend=claude pane=%8
-```
+    ```bash
+    cafleet member create --fleet-id 1 \
+      --agent-id 2 \
+      --name "reviewer" \
+      --description "Reviewer member" \
+      --text "You are reviewer. Reply hello when polled."
+    ```
 
-List the fleet's agents — the new members' ids (`4` and `5`) appear
-alongside the Director and the Administrator:
+    ```
+    5 reviewer backend=claude pane=%8
+    ```
 
-```bash
-cafleet member list --fleet-id 1 --all
-```
+    List the fleet's agents — the new members' ids (`4` and `5`) appear
+    alongside the Director and the Administrator:
 
-```
-4 agents:
-  agent_id  name           status  kind           backend  session  window_id  pane_id  created_at
-  --------  -------------  ------  -------------  -------  -------  ---------  -------  --------------------
-  2         Director       active  director       claude   main     @3         %0       2026-04-15T10:00:00+00:00
-  3         Administrator  active  administrator  -        -        -          -        -
-  4         demo-member    active  member         claude   main     @3         %7       2026-04-15T10:01:00+00:00
-  5         reviewer       active  member         claude   main     @3         %8       2026-04-15T10:02:00+00:00
-```
+    ```bash
+    cafleet member list --fleet-id 1 --all
+    ```
 
-Send a message between the members — `demo-member` (`4`) messages
-`reviewer` (`5`):
+    ```
+    4 agents:
+      agent_id  name           status  kind           backend  session  window_id  pane_id  created_at
+      --------  -------------  ------  -------------  -------  -------  ---------  -------  --------------------
+      2         Director       active  director       claude   main     @3         %0       2026-04-15T10:00:00+00:00
+      3         Administrator  active  administrator  -        -        -          -        -
+      4         demo-member    active  member         claude   main     @3         %7       2026-04-15T10:01:00+00:00
+      5         reviewer       active  member         claude   main     @3         %8       2026-04-15T10:02:00+00:00
+    ```
 
-```bash
-cafleet message send --fleet-id 1 --agent-id 4 --to 5 --text "hi"
-```
+    Send a message between the members — `demo-member` (`4`) messages
+    `reviewer` (`5`):
 
-```
-Message sent.
-[10 | from:4 | 2026-06-11T09:00:00.123456+00:00]
-hi
-```
+    ```bash
+    cafleet message send --fleet-id 1 --agent-id 4 --to 5 --text "hi"
+    ```
 
-`reviewer` receives the message as a 2-line inline preview pushed into its
-tmux pane and the message lands in the broker queue. From here, the typical
-flow is `cafleet message poll` from the recipient and `cafleet message ack`
-once it has consumed the message.
+    ```
+    Message sent.
+    [10 | from:4 | 2026-06-11T09:00:00.123456+00:00]
+    hi
+    ```
 
-When you are done, tear the fleet down:
+    `reviewer` receives the message as a 2-line inline preview pushed into its
+    tmux pane and the message lands in the broker queue. From here, the typical
+    flow is `cafleet message poll` from the recipient and `cafleet message ack`
+    once it has consumed the message.
 
-```bash
-cafleet member delete --fleet-id 1 --member-id 4
-cafleet member delete --fleet-id 1 --member-id 5
-cafleet fleet delete --fleet-id 1
-```
+    When you are done, tear the fleet down:
 
-```
-Deleted fleet 1. Deregistered 2 agents.
-```
+    ```bash
+    cafleet member delete --fleet-id 1 --member-id 4
+    cafleet member delete --fleet-id 1 --member-id 5
+    cafleet fleet delete --fleet-id 1
+    ```
+
+    ```
+    Deleted fleet 1. Deregistered 2 agents.
+    ```
 
 Where to go next:
 

--- a/docs/how-to/mixed-backend-team.md
+++ b/docs/how-to/mixed-backend-team.md
@@ -53,103 +53,105 @@ deletes the fleet.
 The commands the agent runs, with literal ids — fleet `1`, root Director
 `2`, members `4`/`5`/`6`; your ids will differ.
 
-Create the fleet — the operator declares the binary running in *your* pane
-via `--coding-agent` because cafleet cannot auto-detect it
-([Coding agents](../concepts/coding-agents.md)):
+??? example "Expand the walkthrough"
 
-```bash
-cafleet fleet create --name "demo" --coding-agent claude
-```
+    Create the fleet — the operator declares the binary running in *your* pane
+    via `--coding-agent` because cafleet cannot auto-detect it
+    ([Coding agents](../concepts/coding-agents.md)):
 
-```
-1 director=2 admin=3
-```
+    ```bash
+    cafleet fleet create --name "demo" --coding-agent claude
+    ```
 
-Spawn one member per backend:
+    ```
+    1 director=2 admin=3
+    ```
 
-```bash
-cafleet member create --fleet-id 1 --agent-id 2 \
-  --name "alice" --description "claude member" \
-  --coding-agent claude --text "You are alice. Wait for instructions."
-```
+    Spawn one member per backend:
 
-```
-4 alice backend=claude pane=%7
-```
+    ```bash
+    cafleet member create --fleet-id 1 --agent-id 2 \
+      --name "alice" --description "claude member" \
+      --coding-agent claude --text "You are alice. Wait for instructions."
+    ```
 
-```bash
-cafleet member create --fleet-id 1 --agent-id 2 \
-  --name "bob" --description "codex member" \
-  --coding-agent codex --text "You are bob. Wait for instructions."
-```
+    ```
+    4 alice backend=claude pane=%7
+    ```
 
-```
-5 bob backend=codex pane=%8
-```
+    ```bash
+    cafleet member create --fleet-id 1 --agent-id 2 \
+      --name "bob" --description "codex member" \
+      --coding-agent codex --text "You are bob. Wait for instructions."
+    ```
 
-```bash
-cafleet member create --fleet-id 1 --agent-id 2 \
-  --name "carol" --description "opencode member" \
-  --coding-agent opencode --text "You are carol. Wait for instructions."
-```
+    ```
+    5 bob backend=codex pane=%8
+    ```
 
-```
-6 carol backend=opencode pane=%9
-```
+    ```bash
+    cafleet member create --fleet-id 1 --agent-id 2 \
+      --name "carol" --description "opencode member" \
+      --coding-agent opencode --text "You are carol. Wait for instructions."
+    ```
 
-List the panes — only the `claude` pane titles itself with the member name
-([Known asymmetries](../concepts/coding-agents.md#known-asymmetries-intentional-non-goals)),
-so use the `pane_id` column to locate `bob` and `carol`:
+    ```
+    6 carol backend=opencode pane=%9
+    ```
 
-```bash
-cafleet member list --fleet-id 1 --all
-```
+    List the panes — only the `claude` pane titles itself with the member name
+    ([Known asymmetries](../concepts/coding-agents.md#known-asymmetries-intentional-non-goals)),
+    so use the `pane_id` column to locate `bob` and `carol`:
 
-```
-5 agents:
-  agent_id  name           status  kind           backend   session  window_id  pane_id  created_at
-  --------  -------------  ------  -------------  --------  -------  ---------  -------  --------------------
-  2         Director       active  director       claude    main     @3         %0       2026-04-15T10:00:00+00:00
-  3         Administrator  active  administrator  -         -        -          -        -
-  4         alice          active  member         claude    main     @3         %7       2026-04-15T10:01:00+00:00
-  5         bob            active  member         codex     main     @3         %8       2026-04-15T10:02:00+00:00
-  6         carol          active  member         opencode  main     @3         %9       2026-04-15T10:03:00+00:00
-```
+    ```bash
+    cafleet member list --fleet-id 1 --all
+    ```
 
-Message each member — repeat with `--to 5` and `--to 6`; the envelope and
-the 2-line inline preview are identical for every backend
-([tmux push](../concepts/tmux-push.md)):
+    ```
+    5 agents:
+      agent_id  name           status  kind           backend   session  window_id  pane_id  created_at
+      --------  -------------  ------  -------------  --------  -------  ---------  -------  --------------------
+      2         Director       active  director       claude    main     @3         %0       2026-04-15T10:00:00+00:00
+      3         Administrator  active  administrator  -         -        -          -        -
+      4         alice          active  member         claude    main     @3         %7       2026-04-15T10:01:00+00:00
+      5         bob            active  member         codex     main     @3         %8       2026-04-15T10:02:00+00:00
+      6         carol          active  member         opencode  main     @3         %9       2026-04-15T10:03:00+00:00
+    ```
 
-```bash
-cafleet message send --fleet-id 1 --agent-id 2 --to 4 --text "alice: report status"
-```
+    Message each member — repeat with `--to 5` and `--to 6`; the envelope and
+    the 2-line inline preview are identical for every backend
+    ([tmux push](../concepts/tmux-push.md)):
 
-```
-Message sent.
-[10 | from:2 | 2026-06-11T09:05:00.123456+00:00]
-alice: report status
-```
+    ```bash
+    cafleet message send --fleet-id 1 --agent-id 2 --to 4 --text "alice: report status"
+    ```
 
-Tear down — repeat `member delete` for members `5` and `6`, then delete the
-fleet:
+    ```
+    Message sent.
+    [10 | from:2 | 2026-06-11T09:05:00.123456+00:00]
+    alice: report status
+    ```
 
-```bash
-cafleet member delete --fleet-id 1 --member-id 4
-```
+    Tear down — repeat `member delete` for members `5` and `6`, then delete the
+    fleet:
 
-```
-Member deleted.
-  agent_id:  4
-  pane_id:   %7 (closed)
-```
+    ```bash
+    cafleet member delete --fleet-id 1 --member-id 4
+    ```
 
-```bash
-cafleet fleet delete --fleet-id 1
-```
+    ```
+    Member deleted.
+      agent_id:  4
+      pane_id:   %7 (closed)
+    ```
 
-```
-Deleted fleet 1. Deregistered 2 agents.
-```
+    ```bash
+    cafleet fleet delete --fleet-id 1
+    ```
+
+    ```
+    Deleted fleet 1. Deregistered 2 agents.
+    ```
 
 Every `member create` / `member delete` flag and exit code is documented in
 [CLI options](../spec/cli-options.md#member-create).

--- a/docs/how-to/monitor-and-recover.md
+++ b/docs/how-to/monitor-and-recover.md
@@ -53,91 +53,93 @@ the member's pane ([tmux push](../concepts/tmux-push.md)).
 The commands the agent runs, all from the Director's pane, with literal
 ids — fleet `1`, members `4`/`5`/`6`; your ids will differ.
 
-Watch the team — `last_sent` is the agent's most recent outgoing message,
-`last_recv` its most recent delivery, `last_ack` the most recent delivery
-it acknowledged, and `idle` the wall-time since the latest of `last_sent` /
-`last_recv`; a member that receives work but never sends or acks is stalled
-— `alice` (`4`) below has been quiet for 14 minutes (aggregation rules in
-[CLI options](../spec/cli-options.md#member-list-activity-output)):
+??? example "Expand the walkthrough"
 
-```bash
-cafleet member list --fleet-id 1 --activity
-```
+    Watch the team — `last_sent` is the agent's most recent outgoing message,
+    `last_recv` its most recent delivery, `last_ack` the most recent delivery
+    it acknowledged, and `idle` the wall-time since the latest of `last_sent` /
+    `last_recv`; a member that receives work but never sends or acks is stalled
+    — `alice` (`4`) below has been quiet for 14 minutes (aggregation rules in
+    [CLI options](../spec/cli-options.md#member-list-activity-output)):
 
-```
-3 members:
-  agent_id        name      status  last_sent  last_recv  last_ack   idle
-  --------------  --------  ------  ---------  ---------  ---------  -----
-  4               alice     active  -          12:20:00   12:20:00   14m
-  5               bob       active  12:30:11   12:33:02   12:33:02   2m
-  6               carol     active  12:34:56   12:34:50   12:34:50   6s
-```
+    ```bash
+    cafleet member list --fleet-id 1 --activity
+    ```
 
-Inspect the quiet member — prints the last 20 lines of the pane buffer with
-ANSI escapes stripped (`--lines N` for a longer tail); a stalled member
-typically shows a pending prompt:
+    ```
+    3 members:
+      agent_id        name      status  last_sent  last_recv  last_ack   idle
+      --------------  --------  ------  ---------  ---------  ---------  -----
+      4               alice     active  -          12:20:00   12:20:00   14m
+      5               bob       active  12:30:11   12:33:02   12:33:02   2m
+      6               carol     active  12:34:56   12:34:50   12:34:50   6s
+    ```
 
-```bash
-cafleet member capture --fleet-id 1 --member-id 4
-```
+    Inspect the quiet member — prints the last 20 lines of the pane buffer with
+    ANSI escapes stripped (`--lines N` for a longer tail); a stalled member
+    typically shows a pending prompt:
 
-```
- Do you want to proceed?
- ❯ 1. Yes
-   2. No
-```
+    ```bash
+    cafleet member capture --fleet-id 1 --member-id 4
+    ```
 
-Ladder rung 1, `member ping` — injects an `Esc`-safeguarded
-`cafleet message poll` keystroke (the leading `Esc` dismisses any pending
-permission prompt) so the member drains anything it missed; panes need
-re-poking at all because inline previews are best-effort keystrokes
-([tmux push](../concepts/tmux-push.md)):
+    ```
+     Do you want to proceed?
+     ❯ 1. Yes
+       2. No
+    ```
 
-```bash
-cafleet member ping --fleet-id 1 --member-id 4
-```
+    Ladder rung 1, `member ping` — injects an `Esc`-safeguarded
+    `cafleet message poll` keystroke (the leading `Esc` dismisses any pending
+    permission prompt) so the member drains anything it missed; panes need
+    re-poking at all because inline previews are best-effort keystrokes
+    ([tmux push](../concepts/tmux-push.md)):
 
-```
-Pinged member alice (%7) — poll keystroke dispatched.
-```
+    ```bash
+    cafleet member ping --fleet-id 1 --member-id 4
+    ```
 
-Ladder rung 2, `member exec` — keystrokes `! git status` into the pane so
-the coding agent runs it natively, the dispatch half of the
-bash-via-Director protocol ([Bash routing](../concepts/bash-routing.md)):
+    ```
+    Pinged member alice (%7) — poll keystroke dispatched.
+    ```
 
-```bash
-cafleet member exec --fleet-id 1 --member-id 4 "git status"
-```
+    Ladder rung 2, `member exec` — keystrokes `! git status` into the pane so
+    the coding agent runs it natively, the dispatch half of the
+    bash-via-Director protocol ([Bash routing](../concepts/bash-routing.md)):
 
-```
-Sent bash command 'git status' to member alice (%7).
-```
+    ```bash
+    cafleet member exec --fleet-id 1 --member-id 4 "git status"
+    ```
 
-Ladder rung 3, `member delete` (last resort) — sends the backend exit
-keystroke and waits up to 15 s for the pane to close:
+    ```
+    Sent bash command 'git status' to member alice (%7).
+    ```
 
-```bash
-cafleet member delete --fleet-id 1 --member-id 4
-```
+    Ladder rung 3, `member delete` (last resort) — sends the backend exit
+    keystroke and waits up to 15 s for the pane to close:
 
-```
-Member deleted.
-  agent_id:  4
-  pane_id:   %7 (closed)
-```
+    ```bash
+    cafleet member delete --fleet-id 1 --member-id 4
+    ```
 
-A pane that refuses to close makes the command exit 2 with the pane tail
-and a built-in recovery hint; `cafleet member delete --member-id 4 --force`
-skips the wait, kills the pane, and exits 0 even if the pane was already
-gone:
+    ```
+    Member deleted.
+      agent_id:  4
+      pane_id:   %7 (closed)
+    ```
 
-```
-Error: pane %7 did not close within 15.0s after /exit.
---- pane %7 tail (last 80 lines) ---
-<captured terminal buffer>
----
-Recovery: inspect with `cafleet member capture`, then re-run `cafleet member delete`. Or re-run with `--force` to skip the wait and kill the pane.
-```
+    A pane that refuses to close makes the command exit 2 with the pane tail
+    and a built-in recovery hint; `cafleet member delete --member-id 4 --force`
+    skips the wait, kills the pane, and exits 0 even if the pane was already
+    gone:
+
+    ```
+    Error: pane %7 did not close within 15.0s after /exit.
+    --- pane %7 tail (last 80 lines) ---
+    <captured terminal buffer>
+    ---
+    Recovery: inspect with `cafleet member capture`, then re-run `cafleet member delete`. Or re-run with `--force` to skip the wait and kill the pane.
+    ```
 
 Every flag, validation rule, and exit code for the `member`
 subcommands is documented in [CLI options](../spec/cli-options.md#cafleet-member).

--- a/docs/reference/coding-agents/claude.md
+++ b/docs/reference/coding-agents/claude.md
@@ -44,29 +44,31 @@ Claude Code honors the leading-`!` shell shortcut that `cafleet member exec` use
 
 Gated on local install of the `claude` binary. Run from inside a tmux or herdr session. The recipe pastes literal ids: fleet `1`, Director `2`, member `4` — your ids will differ.
 
-```bash
-cafleet fleet create --name claude-smoke --coding-agent claude
-# Expect: a '<fleet_id> director=<director_id> admin=<admin_id>' line.
-# Note the fleet and Director ids — the steps below use 1 and 2.
+??? example "Expand the recipe"
 
-cafleet member create --fleet-id 1 --agent-id 2 \
-  --name Claude-Smoke --description "claude smoke member" \
-  --text "You are Claude-Smoke. Reply hello when polled."
-# Expect: the backend defaults to claude (no --coding-agent needed).
+    ```bash
+    cafleet fleet create --name claude-smoke --coding-agent claude
+    # Expect: a '<fleet_id> director=<director_id> admin=<admin_id>' line.
+    # Note the fleet and Director ids — the steps below use 1 and 2.
 
-cafleet member list --fleet-id 1 --all
-# Expect: the new agent's row, backend column shows 'claude'; the pane title shows the member name.
+    cafleet member create --fleet-id 1 --agent-id 2 \
+      --name Claude-Smoke --description "claude smoke member" \
+      --text "You are Claude-Smoke. Reply hello when polled."
+    # Expect: the backend defaults to claude (no --coding-agent needed).
 
-cafleet message send --fleet-id 1 --agent-id 2 \
-  --to 4 --text "ping"
-# Expect: the claude pane receives the 2-line inline preview and the member ack-loops correctly.
+    cafleet member list --fleet-id 1 --all
+    # Expect: the new agent's row, backend column shows 'claude'; the pane title shows the member name.
 
-cafleet member exec --fleet-id 1 \
-  --member-id 4 "git status --short"
-# Expect: '! git status --short' lands in the claude pane and the command runs.
+    cafleet message send --fleet-id 1 --agent-id 2 \
+      --to 4 --text "ping"
+    # Expect: the claude pane receives the 2-line inline preview and the member ack-loops correctly.
 
-cafleet member delete --fleet-id 1 --member-id 4
-cafleet fleet delete --fleet-id 1
-```
+    cafleet member exec --fleet-id 1 \
+      --member-id 4 "git status --short"
+    # Expect: '! git status --short' lands in the claude pane and the command runs.
+
+    cafleet member delete --fleet-id 1 --member-id 4
+    cafleet fleet delete --fleet-id 1
+    ```
 
 This recipe is not part of the automated test suite — it is the manual verification path before shipping changes that touch the claude backend.

--- a/docs/reference/coding-agents/codex.md
+++ b/docs/reference/coding-agents/codex.md
@@ -75,32 +75,34 @@ Only `claude` sets the pane title to the member name; locate `codex` panes via `
 
 Gated on local install of both `claude` and `codex` binaries. Run from inside a tmux or herdr session. The recipe pastes literal ids: fleet `1`, Director `2`, members `4` (claude) / `5` (codex) — your ids will differ.
 
-```bash
-cafleet fleet create --name codex-smoke --coding-agent claude
-# Expect: a '<fleet_id> director=<director_id> admin=<admin_id>' line.
-# Note the fleet and Director ids — the steps below use 1 and 2.
+??? example "Expand the recipe"
 
-cafleet member create --fleet-id 1 --agent-id 2 \
-  --name Claude-Smoke --description "claude smoke member" --coding-agent claude \
-  --text "You are Claude-Smoke. Reply hello when polled."
-cafleet member create --fleet-id 1 --agent-id 2 \
-  --name Codex-Smoke --description "codex smoke member" --coding-agent codex \
-  --text "You are Codex-Smoke. Reply hello when polled."
+    ```bash
+    cafleet fleet create --name codex-smoke --coding-agent claude
+    # Expect: a '<fleet_id> director=<director_id> admin=<admin_id>' line.
+    # Note the fleet and Director ids — the steps below use 1 and 2.
 
-cafleet member list --fleet-id 1 --all
-# Expect: two member rows, backend column shows 'claude' and 'codex' respectively.
+    cafleet member create --fleet-id 1 --agent-id 2 \
+      --name Claude-Smoke --description "claude smoke member" --coding-agent claude \
+      --text "You are Claude-Smoke. Reply hello when polled."
+    cafleet member create --fleet-id 1 --agent-id 2 \
+      --name Codex-Smoke --description "codex smoke member" --coding-agent codex \
+      --text "You are Codex-Smoke. Reply hello when polled."
 
-cafleet message send --fleet-id 1 --agent-id 2 \
-  --to 5 --text "ping"
-# Expect: the codex pane receives the 2-line inline preview and the member ack-loops correctly.
+    cafleet member list --fleet-id 1 --all
+    # Expect: two member rows, backend column shows 'claude' and 'codex' respectively.
 
-cafleet member exec --fleet-id 1 \
-  --member-id 5 "git status --short"
-# Expect: '! git status --short' lands in the codex pane and the command runs.
+    cafleet message send --fleet-id 1 --agent-id 2 \
+      --to 5 --text "ping"
+    # Expect: the codex pane receives the 2-line inline preview and the member ack-loops correctly.
 
-cafleet member delete --fleet-id 1 --member-id 5
-cafleet member delete --fleet-id 1 --member-id 4
-cafleet fleet delete --fleet-id 1
-```
+    cafleet member exec --fleet-id 1 \
+      --member-id 5 "git status --short"
+    # Expect: '! git status --short' lands in the codex pane and the command runs.
+
+    cafleet member delete --fleet-id 1 --member-id 5
+    cafleet member delete --fleet-id 1 --member-id 4
+    cafleet fleet delete --fleet-id 1
+    ```
 
 This recipe is not part of the automated test suite — it is the manual verification path before shipping changes that touch the codex backend.

--- a/docs/reference/coding-agents/opencode.md
+++ b/docs/reference/coding-agents/opencode.md
@@ -100,41 +100,43 @@ The opencode backend writes exactly one file — `~/.opencode/agents/cafleet.md`
 
 Gated on local install of `opencode`. Run from inside a tmux or herdr session. The recipe pastes literal ids: fleet `1`, Director `2`, member `4` — your ids will differ.
 
-```bash
-rm -f ~/.opencode/agents/cafleet.md
+??? example "Expand the recipe"
 
-cafleet fleet create --name opencode-smoke --coding-agent claude
-# Expect: a '<fleet_id> director=<director_id> admin=<admin_id>' line.
-# Note the fleet and Director ids — the steps below use 1 and 2.
+    ```bash
+    rm -f ~/.opencode/agents/cafleet.md
 
-cafleet member create --fleet-id 1 --agent-id 2 \
-  --name Opencode-Smoke --description "opencode smoke member" --coding-agent opencode \
-  --text "You are Opencode-Smoke. Reply hello when polled."
-# Expect: ~/.opencode/agents/cafleet.md is materialized with the
-# cafleet preset (cat it and verify the JSON frontmatter).
+    cafleet fleet create --name opencode-smoke --coding-agent claude
+    # Expect: a '<fleet_id> director=<director_id> admin=<admin_id>' line.
+    # Note the fleet and Director ids — the steps below use 1 and 2.
 
-cafleet member list --fleet-id 1 --all
-# Expect: backend column shows 'opencode' for the smoke member.
+    cafleet member create --fleet-id 1 --agent-id 2 \
+      --name Opencode-Smoke --description "opencode smoke member" --coding-agent opencode \
+      --text "You are Opencode-Smoke. Reply hello when polled."
+    # Expect: ~/.opencode/agents/cafleet.md is materialized with the
+    # cafleet preset (cat it and verify the JSON frontmatter).
 
-cafleet message send --fleet-id 1 --agent-id 2 \
-  --to 4 --text "ping"
-# Expect: the opencode pane receives the inline preview and the member ack-loops.
+    cafleet member list --fleet-id 1 --all
+    # Expect: backend column shows 'opencode' for the smoke member.
 
-cafleet member exec --fleet-id 1 \
-  --member-id 4 "git status --short"
-# Expect: '! git status --short' lands in the opencode pane and the
-# command runs.
+    cafleet message send --fleet-id 1 --agent-id 2 \
+      --to 4 --text "ping"
+    # Expect: the opencode pane receives the inline preview and the member ack-loops.
 
-cafleet member exec --fleet-id 1 \
-  --member-id 4 "curl https://example.com"
-# Expect: the deny-list blocks the curl command. If it does NOT, the
-# safety floor is broken — STOP and inspect ~/.opencode/agents/cafleet.md;
-# the preset's deny ruleset is not being applied.
+    cafleet member exec --fleet-id 1 \
+      --member-id 4 "git status --short"
+    # Expect: '! git status --short' lands in the opencode pane and the
+    # command runs.
 
-cafleet member delete --fleet-id 1 --member-id 4
-cafleet fleet delete --fleet-id 1
-```
+    cafleet member exec --fleet-id 1 \
+      --member-id 4 "curl https://example.com"
+    # Expect: the deny-list blocks the curl command. If it does NOT, the
+    # safety floor is broken — STOP and inspect ~/.opencode/agents/cafleet.md;
+    # the preset's deny ruleset is not being applied.
 
-A second `cafleet member create --coding-agent opencode` invocation with the preset file already in place should leave the file unchanged (verify by capturing `stat --format=%Y ~/.opencode/agents/cafleet.md` before and after).
+    cafleet member delete --fleet-id 1 --member-id 4
+    cafleet fleet delete --fleet-id 1
+    ```
+
+    A second `cafleet member create --coding-agent opencode` invocation with the preset file already in place should leave the file unchanged (verify by capturing `stat --format=%Y ~/.opencode/agents/cafleet.md` before and after).
 
 This recipe is not part of the automated test suite — it is the manual verification path before shipping changes that touch the opencode backend.


### PR DESCRIPTION
- **feat: move README-only content into docs (capability list, prerequisites, tmux-or-herdr, tech stack)**
- **feat: document codex workspace pre-trust in configure.md with codex.md pointer**
- **feat: thin README to entry-point structure and fix stale README mention**
- **feat: align update-readme skill and documentation-maintenance rule with thin README**
- **docs: verify and check off Success Criteria for design 0000126**
- **docs: mark design doc as complete**
- **docs: generalize workspace trust instruction to all coding agents**
- **docs: move building-docs-locally from configure to contributing**
- **docs: collapse the raw CLI walkthrough behind a details toggle on quickstart**
- **docs: collapse smoke-test recipes and CLI appendices behind details toggles**
