### PR TITLE
feat/0000137 member create explicit cwd

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1871,13 +1871,17 @@ Each method's herdr realization:
   context (`session ← workspace_id`, `window_id ← tab_id`, `pane_id`).
 
 - **`split_window(*, reference, env, command) -> str`** — layout-aware (emulates
-  tmux `select-layout main-vertical`): reads `herdr pane list` and computes the
-  right column as the panes in the Director's tab
-  (`tab_id == reference.window_id`) minus the Director's own `pane_id`. If empty →
-  `herdr pane split <reference.pane_id> --direction right --no-focus [--env K=V …]`
-  (first member); else `herdr pane split <max(column)> --direction down
-  --no-focus [--env K=V …]` followed by the column-equalization step below.
-  `--cwd` is never passed. Then `herdr pane run <new_id> "<shlex.join(command)>"`.
+  tmux `select-layout main-vertical`): fetches the invoking process's working
+  directory once per call via `os.getcwd()` (an `OSError` from the fetch maps to
+  `HerdrError("cannot resolve the working directory for pane spawn: …")`; no
+  fallback directory), then reads `herdr pane list` and computes the right column
+  as the panes in the Director's tab (`tab_id == reference.window_id`) minus the
+  Director's own `pane_id`. If empty → `herdr pane split <reference.pane_id>
+  --direction right --no-focus --cwd <cwd> [--env K=V …]` (first member); else
+  `herdr pane split <max(column)> --direction down --no-focus --cwd <cwd>
+  [--env K=V …]` followed by the column-equalization step below. `<cwd>` is the
+  fetched working directory, passed verbatim (absolute path, argv list, no
+  quoting). Then `herdr pane run <new_id> "<shlex.join(command)>"`.
   The argv `command` is rendered to a single properly-quoted string with
   `shlex.join` before the `pane run` because `pane run` submits one text line into
   the pane's shell (a genuine semantic difference from the tmux exec-argv path —

--- a/cafleet/src/cafleet/multiplexer/herdr.py
+++ b/cafleet/src/cafleet/multiplexer/herdr.py
@@ -177,7 +177,7 @@ class HerdrMultiplexer:
         # NOTE(himkt): once herdr respects the login shell when split, this won't be necessary
         # https://github.com/ogulcancelik/herdr/discussions/1517
         try:
-            cwd = os.getcwd()
+            cwd = os.getcwd()  # noqa: PTH109 - the argv wants str; the design pins os.getcwd
         except OSError as exc:
             raise HerdrError(
                 f"cannot resolve the working directory for pane spawn: {exc}"

--- a/cafleet/src/cafleet/multiplexer/herdr.py
+++ b/cafleet/src/cafleet/multiplexer/herdr.py
@@ -174,6 +174,14 @@ class HerdrMultiplexer:
         # split a deterministic column pane downward. After appending a member,
         # the column is rebalanced to equal heights (see
         # _equalize_focused_tab_column) so the result matches tmux main-vertical.
+        # NOTE(himkt): once herdr respects the login shell when split, this won't be necessary
+        # https://github.com/ogulcancelik/herdr/discussions/1517
+        try:
+            cwd = os.getcwd()
+        except OSError as exc:
+            raise HerdrError(
+                f"cannot resolve the working directory for pane spawn: {exc}"
+            ) from exc
         env_args = [arg for k, v in env.items() for arg in ("--env", f"{k}={v}")]
         result = _run_json(["herdr", "pane", "list"])
         try:
@@ -186,9 +194,9 @@ class HerdrMultiplexer:
         except KeyError as exc:
             raise HerdrError(f"herdr pane list missing {exc} field") from exc
         if not column:
-            new_pane_id = self._split_pane(reference.pane_id, "right", env_args)
+            new_pane_id = self._split_pane(reference.pane_id, "right", cwd, env_args)
         else:
-            new_pane_id = self._split_pane(max(column), "down", env_args)
+            new_pane_id = self._split_pane(max(column), "down", cwd, env_args)
             self._equalize_focused_tab_column()
         # pane run feeds one shell line, so the argv is quoted to preserve boundaries.
         _run(["herdr", "pane", "run", new_pane_id, shlex.join(command)])
@@ -265,9 +273,21 @@ class HerdrMultiplexer:
                 ]
             )
 
-    def _split_pane(self, pane_id: str, direction: str, env_args: list[str]) -> str:
+    def _split_pane(
+        self, pane_id: str, direction: str, cwd: str, env_args: list[str]
+    ) -> str:
         result = _run_json(
-            ["herdr", "pane", "split", pane_id, "--direction", direction, "--no-focus"]
+            [
+                "herdr",
+                "pane",
+                "split",
+                pane_id,
+                "--direction",
+                direction,
+                "--no-focus",
+                "--cwd",
+                cwd,
+            ]
             + env_args
         )
         try:

--- a/cafleet/tests/multiplexer/test_herdr.py
+++ b/cafleet/tests/multiplexer/test_herdr.py
@@ -124,13 +124,19 @@ def test_context_discovery__missing_field_raises(herdr_run):
 
 _REFERENCE = MultiplexerContext(session="wG", window_id="wG:t1", pane_id="wG:p1")
 
+# split_window passes the invoking process's cwd to every split via --cwd
+# (herdr does not respect the login shell when SHELL is unset — discussion
+# #1517), so each split test pins os.getcwd to this fixed path.
+_CWD = "/work/director-cwd"
 
-def test_split_window__first_member_splits_director_right(herdr_run):
+
+def test_split_window__first_member_splits_director_right(monkeypatch, herdr_run):
     """No pane in the Director's tab besides the Director itself → empty column →
     the first member starts the right column with ``pane split --direction
     right``, then runs the command in the new pane. Panes in other tabs and the
     Director's own pane are excluded from the column."""
     captured, set_returns = herdr_run
+    monkeypatch.setattr("os.getcwd", lambda: _CWD)
     set_returns(
         _envelope(
             {
@@ -158,6 +164,8 @@ def test_split_window__first_member_splits_director_right(herdr_run):
             "--direction",
             "right",
             "--no-focus",
+            "--cwd",
+            _CWD,
             "--env",
             "CAFLEET_DATABASE_URL=sqlite:////tmp/cafleet.db",
         ],
@@ -166,8 +174,9 @@ def test_split_window__first_member_splits_director_right(herdr_run):
     ]
 
 
-def test_split_window__first_member_no_env_omits_env_flags(herdr_run):
+def test_split_window__first_member_no_env_omits_env_flags(monkeypatch, herdr_run):
     captured, set_returns = herdr_run
+    monkeypatch.setattr("os.getcwd", lambda: _CWD)
     set_returns(
         _envelope({"panes": [{"pane_id": "wG:p1", "tab_id": "wG:t1"}]}),
         _envelope({"pane": {"pane_id": "wG:p2"}}),
@@ -182,6 +191,8 @@ def test_split_window__first_member_no_env_omits_env_flags(herdr_run):
         "--direction",
         "right",
         "--no-focus",
+        "--cwd",
+        _CWD,
     ]
     assert "--env" not in split_argv
 
@@ -215,13 +226,16 @@ def _balanced_layout(tab_id: str, col_x: int) -> dict:
     }
 
 
-def test_split_window__subsequent_member_splits_max_then_equalizes(herdr_run):
+def test_split_window__subsequent_member_splits_max_then_equalizes(
+    monkeypatch, herdr_run
+):
     """A non-empty column → the member splits ``max(column)`` downward, then
     ``_equalize_focused_tab_column`` reads the focused tab (``pane current`` +
     ``pane layout``) before the command runs. The column is listed [p3, p2] to
     pin that the split targets ``max`` (p3), not the last-listed pane (p2); the
     layout is already balanced (0.5), so no resize is emitted."""
     captured, set_returns = herdr_run
+    monkeypatch.setattr("os.getcwd", lambda: _CWD)
     set_returns(
         _envelope(
             {
@@ -248,7 +262,17 @@ def test_split_window__subsequent_member_splits_max_then_equalizes(herdr_run):
     assert captured == [
         ["herdr", "pane", "list"],
         # max(["wG:p3", "wG:p2"]) == "wG:p3" — the deterministic column anchor.
-        ["herdr", "pane", "split", "wG:p3", "--direction", "down", "--no-focus"],
+        [
+            "herdr",
+            "pane",
+            "split",
+            "wG:p3",
+            "--direction",
+            "down",
+            "--no-focus",
+            "--cwd",
+            _CWD,
+        ],
         ["herdr", "pane", "current"],
         ["herdr", "pane", "layout"],
         ["herdr", "pane", "run", "wG:p4", "claude second"],
@@ -261,6 +285,23 @@ def test_split_window__pane_list_missing_field_raises(herdr_run):
     set_returns(_envelope({"panes": [{"tab_id": "wG:t1"}]}))
     with pytest.raises(HerdrError, match="missing"):
         _herdr.split_window(reference=_REFERENCE, env={}, command=["claude"])
+
+
+def test_split_window__unresolvable_cwd_raises(monkeypatch, herdr_run):
+    """The cwd is fetched before any herdr subprocess; an ``OSError`` from
+    ``os.getcwd`` (the invoking process's cwd was deleted) wraps into
+    ``HerdrError`` with no fallback directory and no herdr call."""
+
+    def raise_deleted_cwd():
+        raise FileNotFoundError("No such file or directory")
+
+    captured, _set_returns = herdr_run
+    monkeypatch.setattr("os.getcwd", raise_deleted_cwd)
+    with pytest.raises(
+        HerdrError, match="cannot resolve the working directory for pane spawn"
+    ):
+        _herdr.split_window(reference=_REFERENCE, env={}, command=["claude"])
+    assert captured == []
 
 
 # --- _equalize_focused_tab_column (deterministic ratio math) ---------------

--- a/design-docs/0000137-member-create-explicit-cwd/design-doc.md
+++ b/design-docs/0000137-member-create-explicit-cwd/design-doc.md
@@ -1,7 +1,7 @@
 # Explicit Working Directory for herdr Pane Spawn in `cafleet member create`
 
 **Status**: Approved
-**Progress**: 4/9 tasks complete
+**Progress**: 6/9 tasks complete
 **Last Updated**: 2026-07-17
 
 ## Overview
@@ -149,8 +149,8 @@ Live-herdr verification (a member pane actually starting in the Director's cwd) 
 
 ### Step 2: herdr backend
 
-- [ ] In `HerdrMultiplexer.split_window`, fetch `os.getcwd()` once (annotated with the verbatim 2-line NOTE(himkt) comment), wrapping `OSError` in `HerdrError` <!-- completed: -->
-- [ ] Thread `cwd` through `_split_pane` and append `--cwd <cwd>` after `--no-focus` in the split argv <!-- completed: -->
+- [x] In `HerdrMultiplexer.split_window`, fetch `os.getcwd()` once (annotated with the verbatim 2-line NOTE(himkt) comment), wrapping `OSError` in `HerdrError` <!-- completed: 2026-07-17T12:56 -->
+- [x] Thread `cwd` through `_split_pane` and append `--cwd <cwd>` after `--no-focus` in the split argv <!-- completed: 2026-07-17T12:56 -->
 
 ### Step 3: Tests
 

--- a/design-docs/0000137-member-create-explicit-cwd/design-doc.md
+++ b/design-docs/0000137-member-create-explicit-cwd/design-doc.md
@@ -10,13 +10,13 @@
 
 ## Success Criteria
 
-- [ ] A member spawned via `cafleet member create` on the herdr backend receives the invoking process's working directory (the Director's pane cwd) as its start directory — verified by proxy via the pinned-argv `--cwd` tests in § Testing; live-herdr confirmation is a manual operator step outside this checklist.
-- [ ] Every `herdr pane split` issued by `split_window` — both the first-member right split and the subsequent down split — carries `--cwd <dir>`.
-- [ ] The tmux backend is unchanged (builtin inheritance remains the mechanism).
-- [ ] The cwd-fetching logic is annotated with the mandated 2-line `NOTE(himkt)` comment, verbatim.
-- [ ] An unresolvable cwd fails the spawn loudly (`HerdrError`); no fallback directory.
-- [ ] `mise //cafleet:test`, `mise //cafleet:lint`, and `mise //cafleet:typecheck` pass.
-- [ ] SPEC.md and `docs/spec/multiplexer-backends.md` reflect the new contract in this same cycle.
+- [x] A member spawned via `cafleet member create` on the herdr backend receives the invoking process's working directory (the Director's pane cwd) as its start directory — verified by proxy via the pinned-argv `--cwd` tests in § Testing; live-herdr confirmation is a manual operator step outside this checklist.
+- [x] Every `herdr pane split` issued by `split_window` — both the first-member right split and the subsequent down split — carries `--cwd <dir>`.
+- [x] The tmux backend is unchanged (builtin inheritance remains the mechanism).
+- [x] The cwd-fetching logic is annotated with the mandated 2-line `NOTE(himkt)` comment, verbatim.
+- [x] An unresolvable cwd fails the spawn loudly (`HerdrError`); no fallback directory.
+- [x] `mise //cafleet:test`, `mise //cafleet:lint`, and `mise //cafleet:typecheck` pass.
+- [x] SPEC.md and `docs/spec/multiplexer-backends.md` reflect the new contract in this same cycle.
 
 ---
 

--- a/design-docs/0000137-member-create-explicit-cwd/design-doc.md
+++ b/design-docs/0000137-member-create-explicit-cwd/design-doc.md
@@ -1,7 +1,7 @@
 # Explicit Working Directory for herdr Pane Spawn in `cafleet member create`
 
 **Status**: Approved
-**Progress**: 2/9 tasks complete
+**Progress**: 4/9 tasks complete
 **Last Updated**: 2026-07-17
 
 ## Overview
@@ -154,8 +154,8 @@ Live-herdr verification (a member pane actually starting in the Director's cwd) 
 
 ### Step 3: Tests
 
-- [ ] Update the three pinned-argv `split_window` tests in `tests/multiplexer/test_herdr.py` for the `--cwd` flag (fixed-path `os.getcwd` monkeypatch) <!-- completed: -->
-- [ ] Add `test_split_window__unresolvable_cwd_raises` (`os.getcwd` raises → `HerdrError`, no subprocess call) <!-- completed: -->
+- [x] Update the three pinned-argv `split_window` tests in `tests/multiplexer/test_herdr.py` for the `--cwd` flag (fixed-path `os.getcwd` monkeypatch) <!-- completed: 2026-07-17T12:52 -->
+- [x] Add `test_split_window__unresolvable_cwd_raises` (`os.getcwd` raises → `HerdrError`, no subprocess call) <!-- completed: 2026-07-17T12:52 -->
 
 ### Step 4: Verification
 

--- a/design-docs/0000137-member-create-explicit-cwd/design-doc.md
+++ b/design-docs/0000137-member-create-explicit-cwd/design-doc.md
@@ -1,6 +1,6 @@
 # Explicit Working Directory for herdr Pane Spawn in `cafleet member create`
 
-**Status**: Approved
+**Status**: Complete
 **Progress**: 9/9 tasks complete
 **Last Updated**: 2026-07-17
 
@@ -170,3 +170,4 @@ Live-herdr verification (a member pane actually starting in the Director's cwd) 
 | Date | Changes |
 |------|---------|
 | 2026-07-17 | Initial draft |
+| 2026-07-17 | Implementation complete: all 9 tasks and 7 Success Criteria satisfied, Reviewer approved round 1 with zero issues, PR #202 opened. Status → Complete. |

--- a/design-docs/0000137-member-create-explicit-cwd/design-doc.md
+++ b/design-docs/0000137-member-create-explicit-cwd/design-doc.md
@@ -1,0 +1,172 @@
+# Explicit Working Directory for herdr Pane Spawn in `cafleet member create`
+
+**Status**: Approved
+**Progress**: 2/9 tasks complete
+**Last Updated**: 2026-07-17
+
+## Overview
+
+`cafleet member create` spawns member panes whose working directory currently depends on the multiplexer's builtin cwd inheritance. That inheritance works on tmux but breaks on herdr, which spawns `/bin/sh` instead of the passwd login shell when `SHELL` is unset ([herdr discussion #1517](https://github.com/ogulcancelik/herdr/discussions/1517)). This design makes the herdr backend pass the invoking process's working directory explicitly via `herdr pane split --cwd`, removing the dependence on herdr's inheritance mechanism.
+
+## Success Criteria
+
+- [ ] A member spawned via `cafleet member create` on the herdr backend receives the invoking process's working directory (the Director's pane cwd) as its start directory — verified by proxy via the pinned-argv `--cwd` tests in § Testing; live-herdr confirmation is a manual operator step outside this checklist.
+- [ ] Every `herdr pane split` issued by `split_window` — both the first-member right split and the subsequent down split — carries `--cwd <dir>`.
+- [ ] The tmux backend is unchanged (builtin inheritance remains the mechanism).
+- [ ] The cwd-fetching logic is annotated with the mandated 2-line `NOTE(himkt)` comment, verbatim.
+- [ ] An unresolvable cwd fails the spawn loudly (`HerdrError`); no fallback directory.
+- [ ] `mise //cafleet:test`, `mise //cafleet:lint`, and `mise //cafleet:typecheck` pass.
+- [ ] SPEC.md and `docs/spec/multiplexer-backends.md` reflect the new contract in this same cycle.
+
+---
+
+## Background
+
+The spawn path: `cafleet member create` (`cafleet/src/cafleet/cli/member.py`) resolves the multiplexer, discovers the Director's pane context, and calls `Multiplexer.split_window(reference, env, command)`. Backend realizations differ:
+
+| Backend | Spawn primitive | cwd today |
+|---------|-----------------|-----------|
+| tmux | `tmux split-window` | builtin inheritance — the new pane starts in the splitting pane's cwd. Works. |
+| herdr | `herdr pane split` + `herdr pane run` | inherited via the spawned shell. Broken when `SHELL` is unset: herdr falls back to `/bin/sh` instead of the passwd login shell (discussion #1517), so the pane does not land in the expected directory. |
+
+SPEC.md §6.5 currently documents the herdr split contract as "`--cwd` is never passed." — `herdr pane split` supports a `--cwd` flag; cafleet just never uses it. The user decided (clarification round, 2026-07-17): scope the fix to herdr only, wire the cwd at split time via `--cwd` (no `cd`-prefix on the `pane run` line), source it from `os.getcwd()` of the member-create process, and fail loudly when the cwd cannot be resolved.
+
+---
+
+## Specification
+
+### Scope
+
+| Surface | Change |
+|---------|--------|
+| `cafleet/src/cafleet/multiplexer/herdr.py` | `HerdrMultiplexer.split_window` fetches the cwd and passes it to every `herdr pane split`. |
+| `Multiplexer` Protocol (`multiplexer/base.py`) | Unchanged — the signature stays `split_window(*, reference, env, command)`. The cwd is a herdr-internal concern. |
+| `cafleet/src/cafleet/multiplexer/tmux.py` | Unchanged. |
+| `cafleet/src/cafleet/cli/member.py` | Unchanged — no new parameter flows through `member create`. |
+| CLI flags / `CAFLEET_*` env vars | None added. No SKILL.md or README impact. |
+
+### cwd source and the mandated comment
+
+`HerdrMultiplexer.split_window` fetches the working directory once per call, before the `herdr pane list` read, using `os.getcwd()`. Because `split_window` executes inside the `cafleet member create` process, this is the Director's pane cwd. The fetch site carries this exact 2-line comment, verbatim:
+
+```python
+# NOTE(himkt): once herdr respects the login shell when split, this won't be necessary
+# https://github.com/ogulcancelik/herdr/discussions/1517
+```
+
+### Wiring
+
+`_split_pane` gains a `cwd` positional parameter, and both split branches pass it. The `--cwd` flag is placed after `--no-focus` and before the `--env` flags, so the env tail append is untouched and the argv shape stays deterministic for the pinned-argv tests:
+
+```python
+def split_window(
+    self,
+    *,
+    reference: MultiplexerContext,
+    env: dict[str, str],
+    command: list[str],
+) -> str:
+    # NOTE(himkt): once herdr respects the login shell when split, this won't be necessary
+    # https://github.com/ogulcancelik/herdr/discussions/1517
+    try:
+        cwd = os.getcwd()
+    except OSError as exc:
+        raise HerdrError(
+            f"cannot resolve the working directory for pane spawn: {exc}"
+        ) from exc
+    env_args = [arg for k, v in env.items() for arg in ("--env", f"{k}={v}")]
+    ...
+    if not column:
+        new_pane_id = self._split_pane(reference.pane_id, "right", cwd, env_args)
+    else:
+        new_pane_id = self._split_pane(max(column), "down", cwd, env_args)
+        self._equalize_focused_tab_column()
+    ...
+
+def _split_pane(
+    self, pane_id: str, direction: str, cwd: str, env_args: list[str]
+) -> str:
+    result = _run_json(
+        [
+            "herdr",
+            "pane",
+            "split",
+            pane_id,
+            "--direction",
+            direction,
+            "--no-focus",
+            "--cwd",
+            cwd,
+        ]
+        + env_args
+    )
+    ...
+```
+
+`os.getcwd()` returns an absolute path and the argv is a list (no shell), so no quoting or normalization is needed; the path is passed verbatim.
+
+### Error handling
+
+| Failure | Behavior |
+|---------|----------|
+| `os.getcwd()` raises `OSError` (the invoking process's cwd was deleted) | Wrapped into `HerdrError("cannot resolve the working directory for pane spawn: …")`. No fallback to `$HOME` or any other directory. |
+| herdr rejects `--cwd` (e.g. the directory vanished between fetch and split) | The non-zero exit propagates through `_run` as `HerdrError`, unchanged. |
+
+Both surface at the CLI boundary through the existing `except MultiplexerError` handler in `member create`, which rolls back the member registration (`_rollback_register`) and reports the failure — the fail-fast path already in place for split failures.
+
+### Documentation contract changes
+
+| Document | Edit |
+|----------|------|
+| `SPEC.md` §6.5, herdr `split_window` bullet | Replace "`--cwd` is never passed." with the new contract: both split forms are `herdr pane split <pane> --direction <right\|down> --no-focus --cwd <cwd> [--env K=V …]`, where `<cwd>` is `os.getcwd()` of the invoking process, fetched once per `split_window` call; an `OSError` from the fetch maps to `HerdrError` (no fallback). Update the two inline argv templates accordingly. |
+| `docs/spec/multiplexer-backends.md` | Add a short "Pane spawn working directory" subsection: tmux relies on builtin cwd inheritance; herdr receives the member-create process's cwd explicitly via `herdr pane split --cwd`, because herdr does not respect the passwd login shell when `SHELL` is unset (discussion #1517). |
+
+`docs/api/multiplexer.md` is an mkdocstrings auto-render of `multiplexer/base.py`, which is unchanged — no edit. No CLI surface changes, so `docs/spec/cli-options.md`, README.md, and all SKILL.md files are unaffected.
+
+### Testing
+
+| Test | Change |
+|------|--------|
+| `tests/multiplexer/test_herdr.py::test_split_window__first_member_splits_director_right` | Monkeypatch `os.getcwd` to a fixed path; extend the pinned split argv with `--cwd <that path>` between `--no-focus` and `--env`. |
+| `…::test_split_window__first_member_no_env_omits_env_flags` | Same monkeypatch; pinned argv ends `--no-focus --cwd <path>` with no `--env`. |
+| `…::test_split_window__subsequent_member_splits_max_then_equalizes` | Same monkeypatch; the down-split argv gains `--cwd <path>`. |
+| New: `…::test_split_window__unresolvable_cwd_raises` | Monkeypatch `os.getcwd` to raise `FileNotFoundError`; assert `HerdrError` and that no herdr subprocess ran. |
+| `tests/cli/test_member.py` (member create) | No behavioral change at this layer (the CLI passes nothing new; fakes satisfy the unchanged Protocol). Verify the suite stays green; no edits expected. |
+
+Live-herdr verification (a member pane actually starting in the Director's cwd) is manual, operator-performed — outside the automated success criteria.
+
+---
+
+## Implementation
+
+> Task format: `- [x] Done task <!-- completed: 2026-02-13T14:30 -->`
+> When completing a task, check the box and record the timestamp in the same edit.
+
+### Step 1: Documentation
+
+- [x] Update SPEC.md §6.5 herdr `split_window` bullet: new `--cwd` contract and argv templates <!-- completed: 2026-07-17T12:50 -->
+- [x] Add the "Pane spawn working directory" subsection to `docs/spec/multiplexer-backends.md` <!-- completed: 2026-07-17T12:50 -->
+
+### Step 2: herdr backend
+
+- [ ] In `HerdrMultiplexer.split_window`, fetch `os.getcwd()` once (annotated with the verbatim 2-line NOTE(himkt) comment), wrapping `OSError` in `HerdrError` <!-- completed: -->
+- [ ] Thread `cwd` through `_split_pane` and append `--cwd <cwd>` after `--no-focus` in the split argv <!-- completed: -->
+
+### Step 3: Tests
+
+- [ ] Update the three pinned-argv `split_window` tests in `tests/multiplexer/test_herdr.py` for the `--cwd` flag (fixed-path `os.getcwd` monkeypatch) <!-- completed: -->
+- [ ] Add `test_split_window__unresolvable_cwd_raises` (`os.getcwd` raises → `HerdrError`, no subprocess call) <!-- completed: -->
+
+### Step 4: Verification
+
+- [ ] `mise //cafleet:test` passes <!-- completed: -->
+- [ ] `mise //cafleet:lint` passes <!-- completed: -->
+- [ ] `mise //cafleet:typecheck` passes <!-- completed: -->
+
+---
+
+## Changelog
+
+| Date | Changes |
+|------|---------|
+| 2026-07-17 | Initial draft |

--- a/design-docs/0000137-member-create-explicit-cwd/design-doc.md
+++ b/design-docs/0000137-member-create-explicit-cwd/design-doc.md
@@ -1,7 +1,7 @@
 # Explicit Working Directory for herdr Pane Spawn in `cafleet member create`
 
 **Status**: Approved
-**Progress**: 6/9 tasks complete
+**Progress**: 9/9 tasks complete
 **Last Updated**: 2026-07-17
 
 ## Overview
@@ -159,9 +159,9 @@ Live-herdr verification (a member pane actually starting in the Director's cwd) 
 
 ### Step 4: Verification
 
-- [ ] `mise //cafleet:test` passes <!-- completed: -->
-- [ ] `mise //cafleet:lint` passes <!-- completed: -->
-- [ ] `mise //cafleet:typecheck` passes <!-- completed: -->
+- [x] `mise //cafleet:test` passes <!-- completed: 2026-07-17T13:00 -->
+- [x] `mise //cafleet:lint` passes <!-- completed: 2026-07-17T13:00 -->
+- [x] `mise //cafleet:typecheck` passes <!-- completed: 2026-07-17T13:00 -->
 
 ---
 

--- a/docs/spec/multiplexer-backends.md
+++ b/docs/spec/multiplexer-backends.md
@@ -79,6 +79,22 @@ and a concurrent reader that cafleet's synchronous `scan → wake → sleep`
 monitor loop does not have, so the socket stream is a deliberately-deferred
 optimization.
 
+## Pane spawn working directory {#pane-spawn-cwd}
+
+A member pane spawned by `cafleet member create` starts in the invoking
+process's working directory (the Director's pane cwd). Each backend realizes
+this differently:
+
+- **tmux** relies on the multiplexer's builtin cwd inheritance — a new pane
+  starts in the splitting pane's working directory.
+- **herdr** receives the member-create process's cwd explicitly: every
+  `herdr pane split` carries `--cwd <dir>`, where `<dir>` is `os.getcwd()` of
+  the invoking process. herdr's own inheritance is not relied upon because
+  herdr spawns `/bin/sh` instead of the passwd login shell when `SHELL` is
+  unset ([herdr discussion #1517](https://github.com/ogulcancelik/herdr/discussions/1517)).
+  An unresolvable cwd fails the spawn loudly with `HerdrError`; there is no
+  fallback directory.
+
 ## Push notifications {#push-notifications}
 
 CAFleet's delivery model is pull-based: recipients discover messages via


### PR DESCRIPTION
- **docs: document herdr pane split --cwd contract in SPEC and multiplexer-backends**
- **test: add pinned-argv --cwd tests for herdr split_window**
- **feat: pass explicit --cwd to herdr pane split when spawning member panes**
- **fix: suppress PTH109 on the design-pinned os.getcwd in herdr split_window**
- **docs: check off Success Criteria for design doc 0000137**
