### PR TITLE
feat/0000142 awaiting user nudge suppression

### DIFF
--- a/design-docs/0000142-awaiting-user-nudge-suppression/design-doc.md
+++ b/design-docs/0000142-awaiting-user-nudge-suppression/design-doc.md
@@ -1,7 +1,7 @@
 # Suppress Director Nudges to Busy or Prompt-Parked Members
 
 **Status**: Approved
-**Progress**: 10/11 tasks complete
+**Progress**: 11/11 tasks complete
 **Last Updated**: 2026-07-18
 
 ## Overview
@@ -126,7 +126,7 @@ The monitoring member's behavior is untouched, satisfying the issue's first requ
 
 ### Step 4: Verification
 
-- [ ] Verify `roles/monitor.md` needs no edit (monitor behavior unchanged; its `supervision.md` section anchors — Monitor Lifecycle, Idle Semantics, the 5-step facilitation loop — still resolve after Step 2) and verify the wake-nudge payload strings in `tmux.py` / `herdr.py` and the whole `cafleet/tests/multiplexer/` suite (`test_tmux.py`, `test_herdr.py`, `test_tmux_send_inline_preview.py` — wake payloads, cross-backend byte-identity, `Esc`-first contracts) are byte-identical to before (run `mise //cafleet:test tests/multiplexer/`). <!-- completed: -->
+- [x] Verify `roles/monitor.md` needs no edit (monitor behavior unchanged; its `supervision.md` section anchors — Monitor Lifecycle, Idle Semantics, the 5-step facilitation loop — still resolve after Step 2) and verify the wake-nudge payload strings in `tmux.py` / `herdr.py` and the whole `cafleet/tests/multiplexer/` suite (`test_tmux.py`, `test_herdr.py`, `test_tmux_send_inline_preview.py` — wake payloads, cross-backend byte-identity, `Esc`-first contracts) are byte-identical to before (run `mise //cafleet:test tests/multiplexer/`). <!-- completed: 2026-07-18T13:18 -->
 
 ---
 

--- a/design-docs/0000142-awaiting-user-nudge-suppression/design-doc.md
+++ b/design-docs/0000142-awaiting-user-nudge-suppression/design-doc.md
@@ -10,11 +10,11 @@ A Director today can `cafleet member ping` or `cafleet message send` a member wh
 
 ## Success Criteria
 
-- [ ] `skills/cafleet/reference/supervision.md` prescribes the pre-nudge capture gate: every Director `cafleet member ping`, every non-exempt `cafleet message send`, and every `cafleet message broadcast` (all recipients) is preceded by a fresh `cafleet member capture` at `--lines 120`, classified on the existing five-state rubric using the target member's backend overlay cues, and fires only on `finished` or `stalled`.
-- [ ] A target classified `working` or `awaiting_user` has its nudge skipped for that round with the entire send deferred; the deferred send is re-evaluated with a fresh capture on a later facilitation tick, and skipped rounds do not count toward the 2-nudge escalation threshold.
-- [ ] The monitor-side suppression rule (never re-engage an `awaiting_user` pane; send nothing when the Director's pane is `awaiting_user`) is preserved verbatim in `roles/monitor.md`, `docs/concepts/monitoring.md`, and the wake-nudge payload string.
-- [ ] All three backend overlays and `_template.md` bind their *Pane-state capture cues* to both consumers: the monitor's classification rubric and the Director's pre-nudge gate.
-- [ ] No runtime change: the wake-nudge payload strings in `tmux.py` / `herdr.py` and the `cafleet/tests/multiplexer/` suite (`test_tmux.py`, `test_herdr.py`, `test_tmux_send_inline_preview.py`) are verified unchanged.
+- [x] `skills/cafleet/reference/supervision.md` prescribes the pre-nudge capture gate: every Director `cafleet member ping`, every non-exempt `cafleet message send`, and every `cafleet message broadcast` (all recipients) is preceded by a fresh `cafleet member capture` at `--lines 120`, classified on the existing five-state rubric using the target member's backend overlay cues, and fires only on `finished` or `stalled`.
+- [x] A target classified `working` or `awaiting_user` has its nudge skipped for that round with the entire send deferred; the deferred send is re-evaluated with a fresh capture on a later facilitation tick, and skipped rounds do not count toward the 2-nudge escalation threshold.
+- [x] The monitor-side suppression rule (never re-engage an `awaiting_user` pane; send nothing when the Director's pane is `awaiting_user`) is preserved verbatim in `roles/monitor.md`, `docs/concepts/monitoring.md`, and the wake-nudge payload string.
+- [x] All three backend overlays and `_template.md` bind their *Pane-state capture cues* to both consumers: the monitor's classification rubric and the Director's pre-nudge gate.
+- [x] No runtime change: the wake-nudge payload strings in `tmux.py` / `herdr.py` and the `cafleet/tests/multiplexer/` suite (`test_tmux.py`, `test_herdr.py`, `test_tmux_send_inline_preview.py`) are verified unchanged.
 
 ---
 

--- a/design-docs/0000142-awaiting-user-nudge-suppression/design-doc.md
+++ b/design-docs/0000142-awaiting-user-nudge-suppression/design-doc.md
@@ -1,0 +1,138 @@
+# Suppress Director Nudges to Busy or Prompt-Parked Members
+
+**Status**: Approved
+**Progress**: 1/11 tasks complete
+**Last Updated**: 2026-07-18
+
+## Overview
+
+A Director today can `cafleet member ping` or `cafleet message send` a member whose pane is mid-work or parked on a pending user prompt, and the primitive's leading `Esc` keystroke interrupts the work or destroys the prompt (GitHub issue #208). This design adds a **pre-nudge capture gate** to the supervision governance: before any re-engagement nudge, the Director captures the target member's pane and fires the nudge only when the capture shows a `finished` or `stalled` pane, skipping the round otherwise. The change is docs/role-definition only — no runtime behavior changes.
+
+## Success Criteria
+
+- [ ] `skills/cafleet/reference/supervision.md` prescribes the pre-nudge capture gate: every Director `cafleet member ping`, every non-exempt `cafleet message send`, and every `cafleet message broadcast` (all recipients) is preceded by a fresh `cafleet member capture` at `--lines 120`, classified on the existing five-state rubric using the target member's backend overlay cues, and fires only on `finished` or `stalled`.
+- [ ] A target classified `working` or `awaiting_user` has its nudge skipped for that round with the entire send deferred; the deferred send is re-evaluated with a fresh capture on a later facilitation tick, and skipped rounds do not count toward the 2-nudge escalation threshold.
+- [ ] The monitor-side suppression rule (never re-engage an `awaiting_user` pane; send nothing when the Director's pane is `awaiting_user`) is preserved verbatim in `roles/monitor.md`, `docs/concepts/monitoring.md`, and the wake-nudge payload string.
+- [ ] All three backend overlays and `_template.md` bind their *Pane-state capture cues* to both consumers: the monitor's classification rubric and the Director's pre-nudge gate.
+- [ ] No runtime change: the wake-nudge payload strings in `tmux.py` / `herdr.py` and the `cafleet/tests/multiplexer/` suite (`test_tmux.py`, `test_herdr.py`, `test_tmux_send_inline_preview.py`) are verified unchanged.
+
+---
+
+## Background
+
+The `awaiting_user` guard is currently policy-only and one-directional:
+
+- **Monitor → Director** (covered): the monitoring member never re-engages a pane it classified `awaiting_user`, and when the *Director's* pane is `awaiting_user` it sends nothing that wake (`roles/monitor.md` § On each wake, step 4; `docs/concepts/monitoring.md`).
+- **Director → member** (the gap): `supervision.md` § Idle Semantics says "never keystroke a member you *know* to be awaiting a user answer" — but the Director has no prescribed way to know. A member the monitor classified `awaiting_user` is silently skipped and never surfaced, while the Stall Response ladder simultaneously tells the Director to nudge quiet members. Both `cafleet member ping` (`send_poll_trigger`) and the `cafleet message send` inline preview (`send_inline_preview`) keystroke `Esc` first, unconditionally (`cafleet/src/cafleet/multiplexer/tmux.py`, `herdr.py`; `broker/messaging.py:49` fires the preview with no pane-state check). The `Esc` cancels a pending prompt on an `awaiting_user` pane and interrupts the in-flight turn on a `working` pane.
+
+No multiplexer backend exposes a native "waiting for user" state to the Director; the only observable is `cafleet member capture` content, which is already the sole classification input of the five-state rubric (`awaiting_user`, `unknown`, `finished`, `stalled`, `working`). The fix therefore extends the same capture-content judgment to the Director side, as governance in the supervision docs.
+
+---
+
+## Specification
+
+### The pre-nudge capture gate
+
+Before firing a gated primitive (table below) at a member, the Director runs a fresh read-only capture of the target and classifies it from capture content only, using the existing five-state rubric and the *Pane-state capture cues* of the **target member's** backend overlay — fleets can mix backends (`member create --coding-agent`), so the Director reads the target's backend from the `backend` column of `cafleet member list` and applies that overlay's cue table, not necessarily its own. The ambiguity tie-break carries over: a capture that cannot distinguish `awaiting_user` from `finished` classifies `awaiting_user`.
+
+```bash
+cafleet member capture --fleet-id <fleet-id> --member-id <target-member-id> --lines 120
+```
+
+| Capture classifies | Director action |
+|---|---|
+| `finished` | Fire the nudge/send. |
+| `stalled` (quiet, unchanged, no prompt, no in-flight work) | Fire the nudge/send. |
+| `awaiting_user` | **Skip this round.** Defer the entire send (nothing persisted, nothing keystroked). Do not relay the pane's prompt anywhere — the round is simply skipped. |
+| `working` | **Skip this round.** Defer the entire send. The member will surface its own result via `cafleet message send` when done. |
+| `unknown` (dead / unreadable pane) | Do not nudge. Enter the recovery path (`reference/recovery.md`) / escalation ladder instead. |
+
+The gate capture depth is normative: `--lines 120`, matching the monitoring member's on-wake capture depth in `roles/monitor.md`. A § Stall Response Stage-2 capture may double as the gate capture only when it was taken at that depth and is still fresh (same facilitation turn, no intervening keystroke into the pane); the default Stage-2 `--lines 20` capture does not satisfy the gate.
+
+The Director does not maintain stall-check baselines; for the gate, `stalled` means the capture shows a quiet pane with no pending prompt and no in-flight work, in a context where the monitoring member has reported the member stalled or the Director's own prior capture showed the same content. When in doubt between `stalled` and `working`, treat as `working` (skip the round) — a deferred nudge costs one tick; an `Esc` into an in-flight turn destroys work.
+
+The gate is judgment applied at use time: knowledge from a monitor report or an earlier capture is *stale* and never substitutes for the fresh capture immediately before the keystroke.
+
+### Gated vs exempt primitives
+
+| Primitive | Gated? | Rationale |
+|---|---|---|
+| `cafleet member ping` | **Gated** | Pure re-engagement nudge; its only purpose is waking a resting pane. |
+| `cafleet message send` — re-engagement, stall nudge, or new/queued work dispatch | **Gated** | The inline preview keystrokes `Esc` + text + `Enter` into the target pane. |
+| `cafleet message broadcast` | **Gated (all recipients)** | Fires the same `Esc`-first preview into every recipient pane, and recipients cannot be skipped individually within one send — so the broadcast fires only when **every** recipient's fresh capture classifies `finished` or `stalled`; otherwise the entire broadcast is deferred (or replaced by per-recipient gated unicasts, the Director's choice). |
+| `cafleet message send` — immediate reply to a **reply-soliciting** message (a question or blocker) received from that member in the current facilitation turn | Exempt | The member ended its turn to await this reply; its pane is at rest with no live prompt (existing rule in § Idle Semantics, preserved). A reply to a progress-only anchorless message ("still working", per `coordination.md` § Anchorless Status) is **not** exempt — the member may still be mid-turn — and routes through the gate. |
+| `cafleet member exec` | Exempt | Member-requested shell dispatch per `reference/exec-routing.md`; the member is blocked *expecting* this keystroke. |
+| Monitor wake nudge (`send_wake_trigger`) | Out of scope | Targets the monitoring member's own pane, fired by the loop, never a watched pane. Unchanged. |
+| Monitor → Director `cafleet message send` | Out of scope | Already governed by the monitor's own suppression rule (unchanged, see below). |
+
+**Member → Director sends are deliberately out of scope.** An ordinary member's own `cafleet message send` (e.g. `complete (doc)`) fires the same `Esc`-first preview into a Director pane that may be `awaiting_user`. Members hold no supervisory role and run no facilitation loop, so they cannot defer-and-retry a held send; the accepted residual protections in that direction are the preview's `Esc` safeguard and the monitor-side rule that never re-engages an `awaiting_user` Director. Gating member sends would require member-side supervision machinery this design does not introduce.
+
+### Deferred-send semantics
+
+`cafleet message send` both persists a broker message and fires the destructive inline-preview keystroke; there is no persist-without-keystroke mode and this design adds none. A skipped round therefore defers the **entire send**:
+
+1. The Director holds the deferred instruction as queued work — § Team-facilitation step 3's standing duty ("if a member is idle and inputs are available, send the instruction immediately") already obliges the Director to carry queued work across ticks; Step 2 below adds an explicit "hold deferred sends and re-evaluate each on the next tick" clause to § Stall Response so the deferral is named, not implied.
+2. On each subsequent facilitation tick (monitoring-member nudge or inbound broker message re-opening the Director's turn), the Director re-runs the gate — fresh capture, then fire or skip again.
+3. No additional wake channel is introduced: the watched member stays on its existing interval and stall-check cadences, so a deferral resolves within at most one member interval once the pane clears.
+
+### Escalation counting
+
+The Stall Response escalation threshold ("still unresponsive after 2 nudges") counts only nudges that actually fired. A skipped round is not a nudge and never advances the count. A member that remains `awaiting_user` or `working` across many rounds is not "unresponsive" — it is parked on the user or making progress, and the Director keeps skipping.
+
+### What stays unchanged (monitor side)
+
+The monitoring member's behavior is untouched, satisfying the issue's first requirement ("monitor should not nudge director if director is waiting user's response") which is already in force:
+
+- The five-state taxonomy, precedence order, capture-content-only rule, and `awaiting_user` tie-break.
+- "Never re-engage a pane classified `awaiting_user`"; when the Director's pane is `awaiting_user`, the monitor sends nothing that wake.
+- The wake-nudge payload string (`send_wake_trigger` in `tmux.py` / `herdr.py`) and its test assertions — the monitor's on-wake instructions do not change, so the strings do not change.
+
+### Affected surfaces
+
+| Surface | Change |
+|---|---|
+| `skills/cafleet/reference/supervision.md` | Primary change: the gate, deferred-send semantics, escalation counting (details in Implementation Step 2). |
+| `docs/concepts/monitoring.md` | One-paragraph addition: the facilitation layer's re-engagement is capture-gated. |
+| `skills/cafleet/reference/coding-agent/{claude,codex,opencode}-overlay.md`, `_template.md` | Extend the *Pane-state capture cues* "applies at" binding to the Director's pre-nudge gate. |
+| `skills/cafleet/roles/monitor.md` | No behavioral change; verify cross-references only. |
+| `cafleet/src/cafleet/multiplexer/tmux.py`, `herdr.py`, `cafleet/tests/multiplexer/` (`test_tmux.py`, `test_herdr.py`, `test_tmux_send_inline_preview.py`) | Verified unchanged. |
+| `SPEC.md`, `README.md`, `docs/spec/multiplexer-backends.md` | No change — no CLI, schema, HTTP, or keystroke-mechanism contract is touched. |
+
+---
+
+## Implementation
+
+> Task format: `- [x] Done task <!-- completed: 2026-02-13T14:30 -->`
+> When completing a task, check the box and record the timestamp in the same edit.
+
+### Step 1: Concepts page
+
+- [x] In `docs/concepts/monitoring.md`, extend the facilitation-layer description (§ Heartbeat vs facilitation and the "actuation is Director-only" paragraph in § The monitoring member) with the pre-nudge capture gate: Director re-engagement of a member is itself capture-gated — a fresh `cafleet member capture` classified on the same five-state rubric, firing only on `finished` or `stalled`, skipping the round on `awaiting_user` or `working`. <!-- completed: 2026-07-18T13:10 -->
+
+### Step 2: Supervision reference
+
+- [ ] In `supervision.md` § Idle Semantics, replace the know-based prohibition bullet ("never keystroke a member you know to be awaiting a user answer") with the affirmative gate rule per § Specification: capture first (at the normative `--lines 120` depth, using the target member's backend overlay cues), nudge only on `finished` / `stalled`, skip the round on `awaiting_user` / `working`; narrow the reply-exemption bullet to replies to reply-soliciting messages (questions/blockers), routing replies to progress-only messages through the gate; reword the `finished`/`stalled` re-engagement bullets to route through the gate. <!-- completed: -->
+- [ ] In `supervision.md`, include `cafleet message broadcast` in the gate rule: a broadcast fires only when every recipient's fresh capture classifies `finished` or `stalled`; otherwise defer the entire broadcast or split it into per-recipient gated unicasts. <!-- completed: -->
+- [ ] In `supervision.md` § How ordinary members are woken, bind the manual-recovery path (path 2: `cafleet member ping` / re-sent instruction) to the gate. <!-- completed: -->
+- [ ] In `supervision.md` § Team-facilitation instructions step 4, make the capture sub-step (c) the gating precondition for the send sub-step (d): (d) fires only for a member whose (c) capture classified `finished` or `stalled`. <!-- completed: -->
+- [ ] In `supervision.md` § Stall Response, add the gate as a precondition of every nudge (a Stage-2 capture doubles as the gate capture only when taken at `--lines 120` and still fresh), add the deferred-send semantics (defer the entire send; hold deferred sends and re-evaluate each with a fresh capture on the next facilitation tick), and amend § Escalation to count only fired nudges. <!-- completed: -->
+- [ ] In `supervision.md` § Quick Reference, annotate the "Message member" and "Manual inbox-poll nudge" rows with the gate precondition ("gated: fresh capture must classify finished/stalled"). <!-- completed: -->
+
+### Step 3: Backend overlays
+
+- [ ] In `claude-overlay.md`, extend the *Pane-state capture cues* note's "applies at" binding to include the Director's pre-nudge gate (`supervision.md` § Idle Semantics / § Stall Response), noting the Director applies the cues of the **target member's** backend overlay, alongside the monitor's classification rubric. <!-- completed: -->
+- [ ] Apply the same "applies at" extension to `codex-overlay.md` and `opencode-overlay.md`. <!-- completed: -->
+- [ ] In `_template.md`, require the cue-table skeleton to name both consumers (monitor classification + Director pre-nudge gate). <!-- completed: -->
+
+### Step 4: Verification
+
+- [ ] Verify `roles/monitor.md` needs no edit (monitor behavior unchanged; its `supervision.md` section anchors — Monitor Lifecycle, Idle Semantics, the 5-step facilitation loop — still resolve after Step 2) and verify the wake-nudge payload strings in `tmux.py` / `herdr.py` and the whole `cafleet/tests/multiplexer/` suite (`test_tmux.py`, `test_herdr.py`, `test_tmux_send_inline_preview.py` — wake payloads, cross-backend byte-identity, `Esc`-first contracts) are byte-identical to before (run `mise //cafleet:test tests/multiplexer/`). <!-- completed: -->
+
+---
+
+## Changelog
+
+| Date | Changes |
+|------|---------|
+| 2026-07-18 | Initial draft |
+| 2026-07-18 | Reviewer round 1: normative gate capture depth (`--lines 120`); target-member backend overlay cues; `message broadcast` gating; reply exemption narrowed to reply-soliciting messages; member→Director scope-out made explicit; deferred-send holding clause; test-verification surface widened to `cafleet/tests/multiplexer/` |

--- a/design-docs/0000142-awaiting-user-nudge-suppression/design-doc.md
+++ b/design-docs/0000142-awaiting-user-nudge-suppression/design-doc.md
@@ -1,6 +1,6 @@
 # Suppress Director Nudges to Busy or Prompt-Parked Members
 
-**Status**: Approved
+**Status**: Complete
 **Progress**: 11/11 tasks complete
 **Last Updated**: 2026-07-18
 
@@ -136,3 +136,4 @@ The monitoring member's behavior is untouched, satisfying the issue's first requ
 |------|---------|
 | 2026-07-18 | Initial draft |
 | 2026-07-18 | Reviewer round 1: normative gate capture depth (`--lines 120`); target-member backend overlay cues; `message broadcast` gating; reply exemption narrowed to reply-soliciting messages; member→Director scope-out made explicit; deferred-send holding clause; test-verification surface widened to `cafleet/tests/multiplexer/` |
+| 2026-07-18 | Implementation complete: all 11 tasks and 5 success criteria verified, Reviewer approved (round 1), PR #210 opened |

--- a/design-docs/0000142-awaiting-user-nudge-suppression/design-doc.md
+++ b/design-docs/0000142-awaiting-user-nudge-suppression/design-doc.md
@@ -1,7 +1,7 @@
 # Suppress Director Nudges to Busy or Prompt-Parked Members
 
 **Status**: Approved
-**Progress**: 7/11 tasks complete
+**Progress**: 10/11 tasks complete
 **Last Updated**: 2026-07-18
 
 ## Overview
@@ -120,9 +120,9 @@ The monitoring member's behavior is untouched, satisfying the issue's first requ
 
 ### Step 3: Backend overlays
 
-- [ ] In `claude-overlay.md`, extend the *Pane-state capture cues* note's "applies at" binding to include the Director's pre-nudge gate (`supervision.md` § Idle Semantics / § Stall Response), noting the Director applies the cues of the **target member's** backend overlay, alongside the monitor's classification rubric. <!-- completed: -->
-- [ ] Apply the same "applies at" extension to `codex-overlay.md` and `opencode-overlay.md`. <!-- completed: -->
-- [ ] In `_template.md`, require the cue-table skeleton to name both consumers (monitor classification + Director pre-nudge gate). <!-- completed: -->
+- [x] In `claude-overlay.md`, extend the *Pane-state capture cues* note's "applies at" binding to include the Director's pre-nudge gate (`supervision.md` § Idle Semantics / § Stall Response), noting the Director applies the cues of the **target member's** backend overlay, alongside the monitor's classification rubric. <!-- completed: 2026-07-18T13:16 -->
+- [x] Apply the same "applies at" extension to `codex-overlay.md` and `opencode-overlay.md`. <!-- completed: 2026-07-18T13:16 -->
+- [x] In `_template.md`, require the cue-table skeleton to name both consumers (monitor classification + Director pre-nudge gate). <!-- completed: 2026-07-18T13:16 -->
 
 ### Step 4: Verification
 

--- a/design-docs/0000142-awaiting-user-nudge-suppression/design-doc.md
+++ b/design-docs/0000142-awaiting-user-nudge-suppression/design-doc.md
@@ -1,7 +1,7 @@
 # Suppress Director Nudges to Busy or Prompt-Parked Members
 
 **Status**: Approved
-**Progress**: 1/11 tasks complete
+**Progress**: 7/11 tasks complete
 **Last Updated**: 2026-07-18
 
 ## Overview
@@ -111,12 +111,12 @@ The monitoring member's behavior is untouched, satisfying the issue's first requ
 
 ### Step 2: Supervision reference
 
-- [ ] In `supervision.md` § Idle Semantics, replace the know-based prohibition bullet ("never keystroke a member you know to be awaiting a user answer") with the affirmative gate rule per § Specification: capture first (at the normative `--lines 120` depth, using the target member's backend overlay cues), nudge only on `finished` / `stalled`, skip the round on `awaiting_user` / `working`; narrow the reply-exemption bullet to replies to reply-soliciting messages (questions/blockers), routing replies to progress-only messages through the gate; reword the `finished`/`stalled` re-engagement bullets to route through the gate. <!-- completed: -->
-- [ ] In `supervision.md`, include `cafleet message broadcast` in the gate rule: a broadcast fires only when every recipient's fresh capture classifies `finished` or `stalled`; otherwise defer the entire broadcast or split it into per-recipient gated unicasts. <!-- completed: -->
-- [ ] In `supervision.md` § How ordinary members are woken, bind the manual-recovery path (path 2: `cafleet member ping` / re-sent instruction) to the gate. <!-- completed: -->
-- [ ] In `supervision.md` § Team-facilitation instructions step 4, make the capture sub-step (c) the gating precondition for the send sub-step (d): (d) fires only for a member whose (c) capture classified `finished` or `stalled`. <!-- completed: -->
-- [ ] In `supervision.md` § Stall Response, add the gate as a precondition of every nudge (a Stage-2 capture doubles as the gate capture only when taken at `--lines 120` and still fresh), add the deferred-send semantics (defer the entire send; hold deferred sends and re-evaluate each with a fresh capture on the next facilitation tick), and amend § Escalation to count only fired nudges. <!-- completed: -->
-- [ ] In `supervision.md` § Quick Reference, annotate the "Message member" and "Manual inbox-poll nudge" rows with the gate precondition ("gated: fresh capture must classify finished/stalled"). <!-- completed: -->
+- [x] In `supervision.md` § Idle Semantics, replace the know-based prohibition bullet ("never keystroke a member you know to be awaiting a user answer") with the affirmative gate rule per § Specification: capture first (at the normative `--lines 120` depth, using the target member's backend overlay cues), nudge only on `finished` / `stalled`, skip the round on `awaiting_user` / `working`; narrow the reply-exemption bullet to replies to reply-soliciting messages (questions/blockers), routing replies to progress-only messages through the gate; reword the `finished`/`stalled` re-engagement bullets to route through the gate. <!-- completed: 2026-07-18T13:13 -->
+- [x] In `supervision.md`, include `cafleet message broadcast` in the gate rule: a broadcast fires only when every recipient's fresh capture classifies `finished` or `stalled`; otherwise defer the entire broadcast or split it into per-recipient gated unicasts. <!-- completed: 2026-07-18T13:13 -->
+- [x] In `supervision.md` § How ordinary members are woken, bind the manual-recovery path (path 2: `cafleet member ping` / re-sent instruction) to the gate. <!-- completed: 2026-07-18T13:14 -->
+- [x] In `supervision.md` § Team-facilitation instructions step 4, make the capture sub-step (c) the gating precondition for the send sub-step (d): (d) fires only for a member whose (c) capture classified `finished` or `stalled`. <!-- completed: 2026-07-18T13:14 -->
+- [x] In `supervision.md` § Stall Response, add the gate as a precondition of every nudge (a Stage-2 capture doubles as the gate capture only when taken at `--lines 120` and still fresh), add the deferred-send semantics (defer the entire send; hold deferred sends and re-evaluate each with a fresh capture on the next facilitation tick), and amend § Escalation to count only fired nudges. <!-- completed: 2026-07-18T13:15 -->
+- [x] In `supervision.md` § Quick Reference, annotate the "Message member" and "Manual inbox-poll nudge" rows with the gate precondition ("gated: fresh capture must classify finished/stalled"). <!-- completed: 2026-07-18T13:15 -->
 
 ### Step 3: Backend overlays
 

--- a/docs/concepts/monitoring.md
+++ b/docs/concepts/monitoring.md
@@ -34,6 +34,15 @@ member's pane is never parked on a permission prompt, the wake nudge does not
 lead with `Esc` — unlike the message-delivery preview and `cafleet member ping`
 (see [Push notifications](../spec/multiplexer-backends.md#esc-safeguard)).
 
+The facilitation layer's re-engagement is itself **capture-gated**: before the
+Director fires a re-engagement keystroke at a member (`cafleet member ping`, a
+non-exempt `cafleet message send`, or a `cafleet message broadcast`), it takes
+a fresh read-only `cafleet member capture` of the target and classifies it on
+the same five-state rubric the monitoring member uses, firing only on
+`finished` or `stalled` — a pane classified `awaiting_user` or `working` has
+its round skipped and the entire send deferred to a later facilitation tick.
+The full gate lives in the `/cafleet` skill's `reference/supervision.md`.
+
 ## The watched set
 
 Enrollment covers the **root Director** (default interval **180 s**) and
@@ -90,7 +99,11 @@ On each wake it runs a routine bounded to two read/act commands — read-only
 
 Observation spans the Director and every due member, but actuation is
 Director-only: the monitoring member never keystrokes ordinary members —
-all member-driving routes back through the Director.
+all member-driving routes back through the Director, whose re-engagement is in
+turn capture-gated: a fresh `cafleet member capture` classified on the same
+five-state rubric, firing only on `finished` or `stalled`, skipping the round
+on `awaiting_user` or `working` (see the `/cafleet` skill's
+`reference/supervision.md`).
 
 ## Cadence and tick precision {#cadence-and-tick-precision}
 

--- a/skills/cafleet/reference/coding-agent/_template.md
+++ b/skills/cafleet/reference/coding-agent/_template.md
@@ -21,11 +21,11 @@ Required section. Convert every note (a constraint/caveat the inline value shoul
 | Note | Applies at |
 |------|-----------|
 | <the caveat, one row each> | `{token}` — `<skill>/<file>` § <base heading> |
-| *Pane-state capture cues* (below) — this backend's `awaiting_user` vs `finished` discriminators. | classification rubric rule 1 (`awaiting_user`) — `cafleet/roles/monitor.md` § On each wake; the pane-state taxonomy in `docs/concepts/monitoring.md`. |
+| *Pane-state capture cues* (below) — this backend's `awaiting_user` vs `finished` discriminators. | classification rubric rule 1 (`awaiting_user`) — `cafleet/roles/monitor.md` § On each wake; the pane-state taxonomy in `docs/concepts/monitoring.md`; the Director's pre-nudge capture gate — `cafleet/reference/supervision.md` § Idle Semantics / § Stall Response (the Director applies the cues of the **target member's** backend overlay). |
 
 ## Pane-state capture cues
 
-Required section. Give this backend's concrete capture-content discriminators for the two pane states a single capture most easily confuses — `awaiting_user` (classification rubric rule 1, the destructive-if-missed class) vs `finished` (rule 3) — so the monitoring member can tell them apart from pane text alone, never from native `agent_status`. Register a row for this table in the *Note → applies at* table above, bound to the rubric's rule 1.
+Required section. Give this backend's concrete capture-content discriminators for the two pane states a single capture most easily confuses — `awaiting_user` (classification rubric rule 1, the destructive-if-missed class) vs `finished` (rule 3) — so both consumers can tell them apart from pane text alone, never from native `agent_status`: the monitoring member's classification rubric and the Director's pre-nudge capture gate (`cafleet/reference/supervision.md` § Idle Semantics). Register a row for this table in the *Note → applies at* table above, bound to both consumers — the rubric's rule 1 and the Director's pre-nudge gate.
 
 | State | <backend> capture cue |
 |---|---|

--- a/skills/cafleet/reference/coding-agent/claude-overlay.md
+++ b/skills/cafleet/reference/coding-agent/claude-overlay.md
@@ -22,7 +22,7 @@ Every note names the base token/instruction it qualifies.
 |------|-----------|
 | `AskUserQuestion` takes ≤ 4 options/question; the built-in "Other" is the free-text path (don't add an explicit "Other"). Question shapes → form: choice among ≤ 4 labeled options; approve-or-revise (two options); continue-or-abort (two options); open-ended draft-comparison (2–4 full candidate bodies). | `{decision_surface}` — `cafleet/SKILL.md` § Soliciting user reactions; `cafleet-design-doc/create/create.md` Step 2 question batch |
 | `TaskCreate` / `TaskUpdate` / `TaskList` / `TaskGet`: register a sub-topic with `TaskCreate`, claim with `TaskUpdate` (owner + `in_progress`), complete with `TaskUpdate` (`completed`), check progress with `TaskList`. | `{task_coord}` — `cafleet-research/report/report.md` task coordination |
-| *Pane-state capture cues* (below) — the concrete claude-pane discriminators for `awaiting_user` vs `finished`. | classification rubric rule 1 (`awaiting_user`) — `cafleet/roles/monitor.md` § On each wake (step 2); the pane-state taxonomy in `docs/concepts/monitoring.md`. |
+| *Pane-state capture cues* (below) — the concrete claude-pane discriminators for `awaiting_user` vs `finished`. | classification rubric rule 1 (`awaiting_user`) — `cafleet/roles/monitor.md` § On each wake (step 2); the pane-state taxonomy in `docs/concepts/monitoring.md`; the Director's pre-nudge capture gate — `cafleet/reference/supervision.md` § Idle Semantics / § Stall Response (the Director applies the cues of the **target member's** backend overlay). |
 
 ## Pane-state capture cues
 

--- a/skills/cafleet/reference/coding-agent/codex-overlay.md
+++ b/skills/cafleet/reference/coding-agent/codex-overlay.md
@@ -22,7 +22,7 @@ Every note names the base token/instruction it qualifies.
 |------|-----------|
 | No in-pane prompt — a fleet member sends its question to the Director, which answers as a plain operator message. Ask a concrete, answerable question, not free-form prose. | `{decision_surface}` — `cafleet/SKILL.md` § Soliciting user reactions |
 | No harness task list — track sub-topic registrations, claims, and completions as cafleet messages. | `{task_coord}` — `cafleet-research/report/report.md` task coordination |
-| *Pane-state capture cues* (below) — the concrete codex-pane discriminators for `awaiting_user` vs `finished`. | classification rubric rule 1 (`awaiting_user`) — `cafleet/roles/monitor.md` § On each wake (step 2); the pane-state taxonomy in `docs/concepts/monitoring.md`. |
+| *Pane-state capture cues* (below) — the concrete codex-pane discriminators for `awaiting_user` vs `finished`. | classification rubric rule 1 (`awaiting_user`) — `cafleet/roles/monitor.md` § On each wake (step 2); the pane-state taxonomy in `docs/concepts/monitoring.md`; the Director's pre-nudge capture gate — `cafleet/reference/supervision.md` § Idle Semantics / § Stall Response (the Director applies the cues of the **target member's** backend overlay). |
 
 ## Pane-state capture cues
 

--- a/skills/cafleet/reference/coding-agent/opencode-overlay.md
+++ b/skills/cafleet/reference/coding-agent/opencode-overlay.md
@@ -22,7 +22,7 @@ Every note names the base token/instruction it qualifies.
 |------|-----------|
 | No in-pane prompt — a fleet member sends its question to the Director, which answers as a plain operator message. The `--agent cafleet` safety floor shows no popup; if a popup ever appears it is a regression to escalate, not a decision point. | `{decision_surface}` — `cafleet/SKILL.md` § Soliciting user reactions |
 | No harness task list — track sub-topic registrations, claims, and completions as cafleet messages. | `{task_coord}` — `cafleet-research/report/report.md` task coordination |
-| *Pane-state capture cues* (below) — the concrete opencode-pane discriminators for `awaiting_user` vs `finished`. | classification rubric rule 1 (`awaiting_user`) — `cafleet/roles/monitor.md` § On each wake (step 2); the pane-state taxonomy in `docs/concepts/monitoring.md`. |
+| *Pane-state capture cues* (below) — the concrete opencode-pane discriminators for `awaiting_user` vs `finished`. | classification rubric rule 1 (`awaiting_user`) — `cafleet/roles/monitor.md` § On each wake (step 2); the pane-state taxonomy in `docs/concepts/monitoring.md`; the Director's pre-nudge capture gate — `cafleet/reference/supervision.md` § Idle Semantics / § Stall Response (the Director applies the cues of the **target member's** backend overlay). |
 
 ## Pane-state capture cues
 

--- a/skills/cafleet/reference/supervision.md
+++ b/skills/cafleet/reference/supervision.md
@@ -37,9 +37,9 @@ See [`SKILL.md`](../SKILL.md) and the [Monitoring concepts page](https://himkt.g
 Ordinary members are **watched** (each enrolled with its own 720 s interval), but the loop **never keystrokes a member pane**. When a member comes due, the loop wakes the *monitoring member*, which captures the member read-only and surfaces a stall to the Director. Member re-engagement is always Director-mediated, via two paths:
 
 1. **Primary** — the broker's inline-preview keystroke fired on every `cafleet message send` (`tmux.send_inline_preview`), landing the instant the Director or a teammate sends work.
-2. **Manual recovery** — the Director's `Esc`-safeguarded `cafleet member ping` (it reuses the `send_poll_trigger` helper, so it inherits the same `Esc` safeguard), for a member that missed its inline preview or looks stalled.
+2. **Manual recovery** — the Director's `Esc`-safeguarded `cafleet member ping` (it reuses the `send_poll_trigger` helper, so it inherits the same `Esc` safeguard), for a member that missed its inline preview or looks stalled. This path is **gated**: fire it only after a fresh capture classifies the target `finished` or `stalled` per § Idle Semantics → *The pre-nudge capture gate*.
 
-A member that has gone quiet is surfaced to the Director by the monitoring member's assessment; the Director then re-pings via `cafleet member ping` or re-sends the instruction. The monitoring member never keystrokes task instructions into a member's pane.
+A member that has gone quiet is surfaced to the Director by the monitoring member's assessment; the Director then re-pings via `cafleet member ping` or re-sends the instruction — each through the pre-nudge capture gate. The monitoring member never keystrokes task instructions into a member's pane.
 
 ## The monitoring member
 
@@ -51,13 +51,37 @@ The monitoring member's own first-person routine — its Startup (the `ready: mo
 
 **A member at rest between turns is normal, not a stall.** A member that finished its turn with no assigned work outstanding is doing exactly what it should — leave it. When a member goes quiet, what you do depends on the pane state the monitoring member reports (the five-state taxonomy in [`roles/monitor.md`](../roles/monitor.md)):
 
-- **`finished` with outstanding assigned work → drive it forward (issue #174 bullet 3).** A member that completed its turn while the task you assigned is unfinished is NOT left alone: dispatch the next step or re-engage it via `cafleet message send` / `cafleet member ping`. You alone judge whether assigned work remains — the monitoring member reports `finished`, you decide.
-- **`finished` with nothing outstanding → leave it.** Expected rest; idle notifications about it are informational, not a call to act. Idle members receive messages normally — the broker's inline preview wakes them when you have new work.
-- **`stalled` mid-execution → re-engage (issue #174 bullet 2).** The monitoring member surfaces a member whose capture is unchanged across two consecutive stall-check observations; re-engage via `cafleet member ping` / `cafleet message send`.
-- **`awaiting_user` → never keystroke it (issue #174 bullet 1).** Never `cafleet member ping` or `cafleet message send` a member you know to be awaiting a user answer while its prompt is up — both primitives keystroke `Esc` first, which would cancel the pending prompt. Relay the answer through the user ({decision_surface}) and let the member consume it.
-- A member that sent you a question and sits at an **idle** prompt awaiting your reply is not `awaiting_user` (its pane shows no live prompt) — reply via `cafleet message send`; the reply's `Esc`-first keystroke cancels nothing.
+- **`finished` with outstanding assigned work → drive it forward (issue #174 bullet 3).** A member that completed its turn while the task you assigned is unfinished is NOT left alone: dispatch the next step or re-engage it — through the pre-nudge capture gate below — via `cafleet message send` / `cafleet member ping`. You alone judge whether assigned work remains — the monitoring member reports `finished`, you decide.
+- **`finished` with nothing outstanding → leave it.** Expected rest; idle notifications about it are informational, not a call to act. Idle members receive messages normally — the broker's inline preview wakes them when you have new work (each such send still routes through the gate).
+- **`stalled` mid-execution → re-engage (issue #174 bullet 2).** The monitoring member surfaces a member whose capture is unchanged across two consecutive stall-check observations; re-engage — through the gate — via `cafleet member ping` / `cafleet message send`.
+- **`awaiting_user` or `working` → skip the round (issue #174 bullet 1).** The gate below defers the entire send; a pending user prompt is never destroyed and an in-flight turn is never interrupted.
+- An immediate reply to a **reply-soliciting** message (a question or blocker) received from that member in the current facilitation turn is exempt from the gate: the member ended its turn to await this reply, so its pane is at rest with no live prompt — reply via `cafleet message send`; the reply's `Esc`-first keystroke cancels nothing. A reply to a progress-only status message ("still working", "ack") is NOT exempt — the member may still be mid-turn — and routes through the gate.
 
 Idleness alone is never a stop signal, never a stall, and never grounds for a passive-hold message. See the Authorization-Scope Guard below.
+
+### The pre-nudge capture gate
+
+Every re-engagement keystroke at a member — `cafleet member ping`, a non-exempt `cafleet message send`, and `cafleet message broadcast` (all recipients) — is **capture-gated**: immediately before firing, take a fresh read-only capture of the target and classify it from capture content only, on the five-state rubric, using the *Pane-state capture cues* of the **target member's** backend overlay ([`coding-agent/<name>-overlay.md`](coding-agent/)). Fleets can mix backends, so read the target's backend from the `backend` column of `cafleet member list` and apply that overlay's cue table — not necessarily your own. The gate capture depth is normative:
+
+```bash
+cafleet member capture --fleet-id <fleet-id> --member-id <target-member-id> --lines 120
+```
+
+| Capture classifies | Director action |
+|---|---|
+| `finished` | Fire the nudge/send. |
+| `stalled` (quiet, unchanged, no prompt, no in-flight work) | Fire the nudge/send. |
+| `awaiting_user` | **Skip this round.** Defer the entire send (nothing persisted, nothing keystroked). Do not relay the pane's prompt anywhere — the round is simply skipped. |
+| `working` | **Skip this round.** Defer the entire send. The member surfaces its own result via `cafleet message send` when done. |
+| `unknown` (dead / unreadable pane) | Do not nudge. Enter the recovery path ([`reference/recovery.md`](recovery.md)) / § Stall Response → Escalation instead. |
+
+The ambiguity tie-break carries over from the monitor rubric: a capture that cannot distinguish `awaiting_user` from `finished` classifies `awaiting_user`. When in doubt between `stalled` and `working`, treat as `working` (skip the round) — a deferred nudge costs one tick; an `Esc` into an in-flight turn destroys work. You maintain no stall-check baselines; for the gate, `stalled` means the capture shows a quiet pane with no pending prompt and no in-flight work, in a context where the monitoring member has reported the member stalled or your own prior capture showed the same content.
+
+The gate is judgment applied at use time: knowledge from a monitor report or an earlier capture is *stale* and never substitutes for the fresh capture immediately before the keystroke.
+
+A `cafleet message broadcast` fires the same `Esc`-first preview into every recipient pane, and recipients cannot be skipped individually within one send — so the broadcast fires only when **every** recipient's fresh capture classifies `finished` or `stalled`; otherwise defer the entire broadcast, or replace it with per-recipient gated unicasts.
+
+**Exempt from the gate:** the immediate reply to a reply-soliciting message (bullet above), and `cafleet member exec` — member-requested shell dispatch per [`reference/exec-routing.md`](exec-routing.md), where the member is blocked *expecting* the keystroke.
 
 ## Authorization-Scope Guard (CRITICAL)
 
@@ -114,7 +138,7 @@ On every supervision tick — whether fired by the monitoring member's on-demand
 1. **Poll inbox.** `cafleet message poll --fleet-id <fleet-id> --member-id <director-member-id>` returns only the un-acked (`input_required`) deliveries; ACKing each one (step 2) consumes it — the poll semantics are canonical at § Stall Response → Stage 1.
 2. **ACK every message** that requires no further action: `cafleet message ack --fleet-id <fleet-id> --member-id <director-member-id> --message-id <message-id>`. Unacknowledged messages accumulate in the Director's inbox and obscure new arrivals.
 3. **Dispatch queued work.** If a member is idle and inputs are available (review comments to route, the next implementation step in a design doc, reviewer feedback waiting at the Drafter, a teammate reply waiting to be acted on), send the instruction immediately via `cafleet message send`. **Do not wait for a fresh "go" from the user** — the user's original authorization persists across ticks; see § Authorization-Scope Guard.
-4. **Run the health-check sequence** for any member that has not reported recent progress — cheapest, least-intrusive check first: (a) `cafleet member list` (enumerate members + pane status); (b) `cafleet message poll` (progress reports / help requests); (c) for a member silent since the last check, `cafleet member capture` to inspect it (a decision-prompt frame → see Stall Response for the decision-relay escape hatch); (d) `cafleet message send` a specific instruction to any stalled/idle member; (e) once all members report completion, tell the user "All deliverables are ready for review."
+4. **Run the health-check sequence** for any member that has not reported recent progress — cheapest, least-intrusive check first: (a) `cafleet member list` (enumerate members + pane status); (b) `cafleet message poll` (progress reports / help requests); (c) for a member silent since the last check, a fresh `cafleet member capture --lines 120` classified per § Idle Semantics → *The pre-nudge capture gate* (a decision-prompt frame → see Stall Response for the decision-relay escape hatch); (d) `cafleet message send` a specific instruction — (c) is the gating precondition: (d) fires only for a member whose (c) capture classified `finished` or `stalled`; on `awaiting_user` or `working`, skip the round and defer the send; (e) once all members report completion, tell the user "All deliverables are ready for review."
 5. **Escalate** to the user via {decision_surface} whenever a queued action requires a *new* user decision (option choice, risky/remote-visible operation, ambiguous teammate question); for the stall path (two nudges with no progress) see § Stall Response → Escalation. Do **not** emit passive-hold messages like `Skipping. Holding for go.` — the tick is a health check, not a permission renewal.
 
 ## Monitor Lifecycle
@@ -131,7 +155,7 @@ On every supervision tick — whether fired by the monitoring member's on-demand
 
 ## Stall Response
 
-When you receive any signal that a member may be stalled (the monitoring member's nudge, idle notification, user nudge), evaluate using this 2-stage protocol. A quiet ordinary member is never woken by the monitor loop — the monitoring member's capture-and-classify assessment surfaces a `stalled`/`finished` member to the Director, who re-engages it via `cafleet member ping` or `cafleet message send`; ordinary-member re-engagement is always Director-mediated.
+When you receive any signal that a member may be stalled (the monitoring member's nudge, idle notification, user nudge), evaluate using this 2-stage protocol. A quiet ordinary member is never woken by the monitor loop — the monitoring member's capture-and-classify assessment surfaces a `stalled`/`finished` member to the Director, who re-engages it via `cafleet member ping` or `cafleet message send`; ordinary-member re-engagement is always Director-mediated. **Every nudge is gate-preconditioned**: fire it only after a fresh capture classifies the target `finished` or `stalled` per § Idle Semantics → *The pre-nudge capture gate* — a monitor report is stale knowledge, never a substitute for the fresh capture.
 
 > **Bash request blocking case**: When `cafleet message poll` returns a member message asking for a shell command, dispatch via `cafleet member exec "<cmd>"` per [`reference/exec-routing.md`](exec-routing.md). Member blocks until the keystroke lands; process requests one at a time, don't skip ahead to other inbox items.
 
@@ -154,11 +178,15 @@ The `cafleet member capture` default is `--lines 20`; bump `--lines` to show mor
 
 If `cafleet message poll` shows no recent messages from the member, fall back to capturing the terminal buffer. This is non-intrusive (read-only inspection that works even when the member is mid-task) and replaces raw `tmux capture-pane`.
 
+A Stage-2 capture doubles as the gate capture only when it was taken at `--lines 120` and is still fresh (same facilitation turn, no intervening keystroke into the pane); the default `--lines 20` capture does not satisfy the gate.
+
+**Deferred sends.** `cafleet message send` both persists a broker message and fires the inline-preview keystroke; there is no persist-without-keystroke mode. A round the gate skips (`awaiting_user` / `working`) therefore defers the **entire send**: hold each deferred send as queued work and re-evaluate it with a fresh capture on the next facilitation tick, then fire or skip again. No additional wake channel exists for deferrals — the member stays on its existing interval and stall-check cadences, so a deferral resolves within at most one member interval once the pane clears.
+
 > **The decision surface is a backend delta.** The concrete user-reaction surface by which the Director asks the user is backend-specific — see your overlay ([`coding-agent/<name>-overlay.md`](coding-agent/)). The canonical, backend-neutral user-reaction rule is [`SKILL.md`](../SKILL.md) § *Soliciting user reactions*.
 
 ### Escalation
 
-If a member is still unresponsive after 2 nudges via `cafleet message send` AND `cafleet member capture` shows no forward progress in the terminal buffer, escalate to the user via {decision_surface} (per [`SKILL.md`](../SKILL.md) § *Soliciting user reactions*) with concrete options (e.g. re-nudge once more / re-spawn the member / drop its task).
+If a member is still unresponsive after 2 **fired** nudges via `cafleet message send` AND `cafleet member capture` shows no forward progress in the terminal buffer, escalate to the user via {decision_surface} (per [`SKILL.md`](../SKILL.md) § *Soliciting user reactions*) with concrete options (e.g. re-nudge once more / re-spawn the member / drop its task). Only nudges that actually fired count toward the threshold: a round the gate skipped is not a nudge and never advances the count. A member that remains `awaiting_user` or `working` across many rounds is not "unresponsive" — it is parked on the user or making progress; keep skipping.
 
 The unblock primitives and their ordering — non-intrusive `cafleet message poll` → read-only `cafleet member capture` → authoritative `cafleet message send` → `cafleet member ping` (missed auto-fire / required post-`exec` follow-up) → `cafleet member exec "<cmd>"` (shell dispatch) → `cafleet member delete` (last resort, kills the pane immediately, never raw `tmux kill-pane`) → escalate to the user via {decision_surface} — are documented in [`reference/director.md`](director.md), [`reference/recovery.md`](recovery.md), [`reference/exec-routing.md`](exec-routing.md), and the § Quick Reference table below.
 
@@ -188,10 +216,10 @@ Cleanup follows [`reference/recovery.md`](recovery.md) § Shutdown Protocol (fir
 | Verify Director pane env | `cafleet doctor` | Pre-spawn precondition; gating. Aborts the spawn protocol when no supported multiplexer (tmux or herdr) resolves. Replaces raw `tmux display-message` and `TMUX` env-var expansion. |
 | Start the supervision tick | Spawn the monitoring member first: `cafleet member create --fleet-id <s> --name monitor --description <…> --role monitor --model {monitor_model} --text-file <…>`; it runs `cafleet monitor start` in its own pane — see [`roles/monitor.md`](../roles/monitor.md) | Its `ready: monitor live` handshake gates the first ordinary `member create`. |
 | Spawn member | `cafleet member create --fleet-id <s> --name <n> --description <d> --text-file <abs path to ${BASE}/.prompts/<role>-<UTC-compact>.md>` | Pre-spawn file IS the audit artifact (see [`reference/director.md`](director.md) § *Member Create — Scratch and audit files*). Verify with `cafleet member list`. Inline `--text "<prompt>"` is still permitted for trivial one-line spawns. |
-| Message member | `cafleet message send --fleet-id <s> --from-member-id <director> --to-member-id <member> --text "..."` | Broker keystrokes an inline preview into the member's pane |
+| Message member | `cafleet message send --fleet-id <s> --from-member-id <director> --to-member-id <member> --text "..."` | Broker keystrokes an inline preview into the member's pane. Gated: fresh capture must classify finished/stalled (§ Idle Semantics → *The pre-nudge capture gate*; reply-soliciting replies exempt) |
 | ACK reply | `cafleet message ack --fleet-id <s> --member-id <director> --message-id <message>` | Unacknowledged messages accumulate; ACK every reply you act on |
 | Inspect stalled member | `cafleet member capture --fleet-id <s> --member-id <member>` | Replaces raw `tmux capture-pane` |
-| Manual inbox-poll nudge | `cafleet member ping --fleet-id <s> --member-id <member>` | Pre-approved; for missed auto-fires and post-`exec` chains |
+| Manual inbox-poll nudge | `cafleet member ping --fleet-id <s> --member-id <member>` | Pre-approved; for missed auto-fires and post-`exec` chains. Gated: fresh capture must classify finished/stalled (§ Idle Semantics → *The pre-nudge capture gate*) |
 | Shell-dispatch on member's behalf | `cafleet member exec --fleet-id <s> --member-id <member> "<cmd>"` | Per [`reference/exec-routing.md`](exec-routing.md); follow with `member ping` |
 | Answer a member's relayed question | {decision_surface} → `cafleet message send` | Ask the user via {decision_surface} first, then relay the answer back to the member as a message; never decide silently |
 | Relay user input | {decision_surface} → `cafleet message send` | Pass-through; never substitute judgment |


### PR DESCRIPTION
- **docs: add pre-nudge capture gate to monitoring concepts page**
- **docs: add pre-nudge capture gate to supervision governance**
- **docs: bind pane-state capture cues to the Director pre-nudge gate in backend overlays**
- **docs: complete design doc 0000142 verification step**
- **docs: check off verified success criteria for design doc 0000142**
