### PR TITLE
feat/0000150 herdr equalizer pane anchor

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1877,22 +1877,25 @@ Each method's herdr realization:
   Director's own `pane_id`. If empty → `herdr pane split <reference.pane_id>
   --direction right --no-focus --cwd <cwd> [--env K=V …]` (first member); else
   `herdr pane split <max(column)> --direction down --no-focus --cwd <cwd>
-  [--env K=V …]` followed by the column-equalization step below. `<cwd>` is the
-  fetched working directory, passed verbatim (absolute path, argv list, no
-  quoting). Then `herdr pane run <new_id> "<shlex.join(command)>"`.
+  [--env K=V …]` followed by the column-equalization step below,
+  `_equalize_tab_column(reference.pane_id)` — anchored on the Director's own
+  pane, so the rebalance is independent of which tab or pane holds focus.
+  `<cwd>` is the fetched working directory, passed verbatim (absolute path,
+  argv list, no quoting). Then `herdr pane run <new_id> "<shlex.join(command)>"`.
   The argv `command` is rendered to a single properly-quoted string with
   `shlex.join` before the `pane run` because `pane run` submits one text line into
   the pane's shell (a genuine semantic difference from the tmux exec-argv path —
   otherwise an argument containing spaces would be re-split).
-- **`_equalize_focused_tab_column()`** — herdr has no single reflow command, so
-  after appending a member `split_window` rebalances the right column to equal
-  heights arithmetically. It reads the focused tab id (`herdr pane current` →
-  `result.pane.tab_id`) and the tab geometry (`herdr pane layout` →
-  `result.layout` with `tab_id`, `panes[].rect{x,y,width,height}`, and
-  `splits[].{direction,rect,ratio}`); if the layout's `tab_id` no longer matches
-  (focus moved), it returns. The right column is every pane whose `rect.x` is not
-  the minimum x (the Director column); its `down` splits form a right-leaning
-  chain where split *k* (top→bottom) separates member *k* from the members below.
+- **`_equalize_tab_column(anchor_pane_id)`** — herdr has no single reflow command,
+  so after appending a member `split_window` rebalances the right column to equal
+  heights arithmetically. It reads the tab geometry of the tab containing
+  `anchor_pane_id` (`herdr pane layout --pane <anchor_pane_id>` → `result.layout`
+  with `panes[].rect{x,y,width,height}` and `splits[].{direction,rect,ratio}`);
+  the read is anchored on a pane the backend already holds, so there is no
+  `herdr pane current` call and no tab-id comparison. The right column is every
+  pane whose `rect.x` is not the minimum x (the Director column); its `down`
+  splits form a right-leaning chain where split *k* (top→bottom) separates
+  member *k* from the members below.
   Equal heights ⇔ split *k* has ratio `1/(N-k)` (top → `1/N`, …, bottom pair →
   `1/2`). Because `herdr pane resize --amount` is a signed delta on a split's
   ratio, each split is driven to target by one resize: `delta = 1/(N-k) - ratio`
@@ -1910,13 +1913,16 @@ Each method's herdr realization:
   `ignore_missing` propagates unchanged and no rebalance runs.
   (3) `_rebalance_after_close(target_tab_id)` — best-effort: any `HerdrError`
   is swallowed so a layout failure never fails a delete (the pane is already
-  closed). Skips when `target_tab_id` is `None`. Otherwise it reads the
-  focused-tab layout via `_read_tab_layout(target_tab_id)` (`herdr pane
-  layout`; a `tab_id` mismatch returns `None` and skips — the rebalance never
-  resizes an unrelated tab's layout; a missing envelope field raises
-  `HerdrError`), returns on an empty pane list, and computes the member column
-  as the panes whose `rect.x` is not the minimum x, sorted by `y`. Column case
-  table: size ≥ 2 → `_equalize_column` (the `_equalize_focused_tab_column`
+  closed). Skips when `target_tab_id` is `None`. Otherwise it resolves an anchor
+  for the layout read — the killed pane is gone, so `_surviving_pane_in_tab`
+  runs `herdr pane list` and takes the first pane whose `tab_id` equals
+  `target_tab_id` (a missing envelope field raises `HerdrError`); `None` — no
+  pane left in that tab — skips the rebalance. It then reads that tab's layout
+  via `_read_tab_layout(anchor_pane_id)` (`herdr pane layout --pane <anchor>`,
+  which by construction returns the anchor pane's tab; a missing envelope field
+  raises `HerdrError`), returns on an empty pane list, and computes the member
+  column as the panes whose `rect.x` is not the minimum x, sorted by `y`. Column
+  case table: size ≥ 2 → `_equalize_column` (the `_equalize_tab_column`
   arithmetic above — `1/(N-k)` split targets, one signed resize per off-target
   split, the `len(down_splits) != n - 1` malformed-chain skip); size 1 → no
   resize (heights are trivially equal and the right split's ratio is unaffected
@@ -1926,7 +1932,7 @@ Each method's herdr realization:
   (skipped when the delta `< 1e-3`); an empty `splits` list is already
   structurally full-width (nothing emitted), and any other residue (multiple
   splits, a non-`right` split, ≥ 2 panes) is skipped. The create path shares
-  `_read_tab_layout` / `_equalize_column` with `_equalize_focused_tab_column`;
+  `_read_tab_layout` / `_equalize_column` with `_equalize_tab_column`;
   tmux `kill_pane` stays a bare `kill-pane` (native auto-fit).
 - **`list_pane_ids() -> set`** — `herdr pane list` → the set of pane ids.
 - **`send_exit(*, target_pane_id, ignore_missing=False)`** — `herdr pane run

--- a/cafleet/src/cafleet/multiplexer/herdr.py
+++ b/cafleet/src/cafleet/multiplexer/herdr.py
@@ -172,8 +172,9 @@ class HerdrMultiplexer:
         # right column is every pane in the Director's tab except the Director's
         # own; the first member splits the Director pane rightward, later members
         # split a deterministic column pane downward. After appending a member,
-        # the column is rebalanced to equal heights (see
-        # _equalize_focused_tab_column) so the result matches tmux main-vertical.
+        # the column is rebalanced to equal heights (see _equalize_tab_column,
+        # anchored on the Director's own pane) so the result matches tmux
+        # main-vertical.
         # NOTE(himkt): once herdr respects the login shell when split, this won't be necessary
         # https://github.com/ogulcancelik/herdr/discussions/1517
         try:
@@ -197,34 +198,26 @@ class HerdrMultiplexer:
             new_pane_id = self._split_pane(reference.pane_id, "right", cwd, env_args)
         else:
             new_pane_id = self._split_pane(max(column), "down", cwd, env_args)
-            self._equalize_focused_tab_column()
+            self._equalize_tab_column(reference.pane_id)
         # pane run feeds one shell line, so the argv is quoted to preserve boundaries.
         _run(["herdr", "pane", "run", new_pane_id, shlex.join(command)])
         return new_pane_id
 
-    def _equalize_focused_tab_column(self) -> None:
-        """Rebalance the members' right column on the focused tab to equal
-        heights — the tmux ``select-layout main-vertical`` reflow that herdr has
-        no single command for.
+    def _equalize_tab_column(self, anchor_pane_id: str) -> None:
+        """Rebalance the members' right column on the tab containing
+        ``anchor_pane_id`` to equal heights — the tmux ``select-layout
+        main-vertical`` reflow that herdr has no single command for.
 
         Best-effort: any :class:`HerdrError` is swallowed so a resize failure
         never fails a spawn over cosmetics.
         """
         try:
-            self._resize_focused_tab_column()
+            self._resize_tab_column(anchor_pane_id)
         except HerdrError:
             return
 
-    def _resize_focused_tab_column(self) -> None:
-        current = _run_json(["herdr", "pane", "current"])
-        try:
-            tab_id = current["pane"]["tab_id"]
-        except KeyError as exc:
-            raise HerdrError(f"herdr pane current missing {exc} field") from exc
-        read = self._read_tab_layout(tab_id)
-        if read is None:
-            return  # focus moved between the two reads — leave the layout alone
-        panes, splits = read
+    def _resize_tab_column(self, anchor_pane_id: str) -> None:
+        panes, splits = self._read_tab_layout(anchor_pane_id)
         # The right column is every pane outside the leftmost (Director) column.
         min_x = min(p["rect"]["x"] for p in panes)
         column = sorted(
@@ -235,15 +228,17 @@ class HerdrMultiplexer:
             return
         self._equalize_column(column, splits)
 
-    def _read_tab_layout(
-        self, expected_tab_id: str
-    ) -> tuple[list[dict], list[dict]] | None:
-        """Return (panes, splits) when the focused-tab layout reported by
-        `herdr pane layout` is the expected tab, else None."""
+    def _read_tab_layout(self, anchor_pane_id: str) -> tuple[list[dict], list[dict]]:
+        """Return (panes, splits) for the tab containing ``anchor_pane_id``.
+
+        Addressing the read by a pane id makes it invoker- and focus-independent:
+        a bare `herdr pane layout` follows global focus, so it reports an
+        unrelated tab whenever the operator is viewing one.
+        """
         try:
-            layout = _run_json(["herdr", "pane", "layout"])["layout"]
-            if layout["tab_id"] != expected_tab_id:
-                return None
+            layout = _run_json(["herdr", "pane", "layout", "--pane", anchor_pane_id])[
+                "layout"
+            ]
             return layout["panes"], layout["splits"]
         except KeyError as exc:
             raise HerdrError(f"herdr pane layout missing {exc} field") from exc
@@ -457,11 +452,24 @@ class HerdrMultiplexer:
         except HerdrError:
             return
 
+    def _surviving_pane_in_tab(self, tab_id: str) -> str | None:
+        """A pane still open in ``tab_id`` to anchor the layout read on, or None
+        when the tab has no panes left. The killed pane is already gone, so it
+        cannot anchor its own tab's read."""
+        result = _run_json(["herdr", "pane", "list"])
+        try:
+            return next(
+                (p["pane_id"] for p in result["panes"] if p.get("tab_id") == tab_id),
+                None,
+            )
+        except KeyError as exc:
+            raise HerdrError(f"herdr pane list missing {exc} field") from exc
+
     def _resize_after_close(self, target_tab_id: str) -> None:
-        read = self._read_tab_layout(target_tab_id)
-        if read is None:
-            return  # focus is on another tab — never resize an unrelated layout
-        panes, splits = read
+        anchor_pane_id = self._surviving_pane_in_tab(target_tab_id)
+        if anchor_pane_id is None:
+            return  # the tab has no panes left — nothing to rebalance
+        panes, splits = self._read_tab_layout(anchor_pane_id)
         if not panes:
             return
         min_x = min(p["rect"]["x"] for p in panes)

--- a/cafleet/tests/multiplexer/test_herdr.py
+++ b/cafleet/tests/multiplexer/test_herdr.py
@@ -119,7 +119,7 @@ def test_context_discovery__missing_field_raises(herdr_run):
 # the Director's tab except the Director's own, and either starts the column
 # (first member → split the Director --direction right) or appends to it
 # (subsequent → split max(column) --direction down, then equalizes the column via
-# _equalize_focused_tab_column). The max()-based stack order is validation-pending
+# _equalize_tab_column). The max()-based stack order is validation-pending
 # against a real herdr binary; the argv shapes below pin the current implementation.
 
 _REFERENCE = MultiplexerContext(session="wG", window_id="wG:t1", pane_id="wG:p1")
@@ -199,7 +199,7 @@ def test_split_window__first_member_no_env_omits_env_flags(monkeypatch, herdr_ru
 
 def _balanced_layout(tab_id: str, col_x: int) -> dict:
     """A two-member right column already at equal heights (down split ratio 0.5),
-    so ``_equalize_focused_tab_column`` computes a zero delta and emits no resize.
+    so ``_equalize_tab_column`` computes a zero delta and emits no resize.
     The Director pane sits at ``x=0`` (the leftmost column, excluded)."""
     return {
         "layout": {
@@ -230,10 +230,11 @@ def test_split_window__subsequent_member_splits_max_then_equalizes(
     monkeypatch, herdr_run
 ):
     """A non-empty column → the member splits ``max(column)`` downward, then
-    ``_equalize_focused_tab_column`` reads the focused tab (``pane current`` +
-    ``pane layout``) before the command runs. The column is listed [p3, p2] to
-    pin that the split targets ``max`` (p3), not the last-listed pane (p2); the
-    layout is already balanced (0.5), so no resize is emitted."""
+    ``_equalize_tab_column`` reads the layout anchored on the Director's own pane
+    (``pane layout --pane wG:p1``, no ``pane current`` round-trip) before the
+    command runs. The column is listed [p3, p2] to pin that the split targets
+    ``max`` (p3), not the last-listed pane (p2); the layout is already balanced
+    (0.5), so no resize is emitted."""
     captured, set_returns = herdr_run
     monkeypatch.setattr("os.getcwd", lambda: _CWD)
     set_returns(
@@ -248,12 +249,11 @@ def test_split_window__subsequent_member_splits_max_then_equalizes(
             }
         ),
         _envelope({"pane": {"pane_id": "wG:p4"}}),  # split(max=p3, down) → new pane
-        _envelope({"pane": {"tab_id": "wG:t1"}}),  # pane current → focused tab
-        # _run_json returns the `result` object; _resize_focused_tab_column then
+        # _run_json returns the `result` object; _resize_tab_column then
         # indexes ["layout"], so the result must carry the `layout` wrapper (do
         # NOT pre-index it here, or the equalizer KeyErrors and swallows,
         # bypassing the real balanced path).
-        _envelope(_balanced_layout("wG:t1", col_x=100)),  # pane layout
+        _envelope(_balanced_layout("wG:t1", col_x=100)),  # pane layout --pane wG:p1
     )
     new_pane = _herdr.split_window(
         reference=_REFERENCE, env={}, command=["claude", "second"]
@@ -273,10 +273,36 @@ def test_split_window__subsequent_member_splits_max_then_equalizes(
             "--cwd",
             _CWD,
         ],
-        ["herdr", "pane", "current"],
-        ["herdr", "pane", "layout"],
+        # The layout read is anchored on the Director's pane, not on focus.
+        ["herdr", "pane", "layout", "--pane", "wG:p1"],
         ["herdr", "pane", "run", "wG:p4", "claude second"],
     ]
+
+
+def test_split_window__layout_read_anchored_on_director_not_focus(
+    monkeypatch, herdr_run
+):
+    """Regression: the spawn-path layout read is addressed by the Director's own
+    pane id, making it invoker- and focus-independent. It issues no
+    ``pane current`` — a focus-derived tab makes the equalizer silently skip
+    whenever the operator views a tab other than the Director's."""
+    captured, set_returns = herdr_run
+    monkeypatch.setattr("os.getcwd", lambda: _CWD)
+    set_returns(
+        _envelope(
+            {
+                "panes": [
+                    {"pane_id": "wG:p1", "tab_id": "wG:t1"},  # the Director
+                    {"pane_id": "wG:p3", "tab_id": "wG:t1"},  # the existing column
+                ]
+            }
+        ),
+        _envelope({"pane": {"pane_id": "wG:p4"}}),  # split(max=p3, down) → new pane
+        _envelope(_balanced_layout("wG:t1", col_x=100)),
+    )
+    _herdr.split_window(reference=_REFERENCE, env={}, command=["claude"])
+    assert ["herdr", "pane", "current"] not in captured
+    assert ["herdr", "pane", "layout", "--pane", "wG:p1"] in captured
 
 
 def test_split_window__pane_list_missing_field_raises(herdr_run):
@@ -304,7 +330,7 @@ def test_split_window__unresolvable_cwd_raises(monkeypatch, herdr_run):
     assert captured == []
 
 
-# --- _equalize_focused_tab_column (deterministic ratio math) ---------------
+# --- _equalize_tab_column (deterministic ratio math) -----------------------
 #
 # The right column is a right-leaning chain of `down` splits; equal heights ⇔
 # split_k has ratio 1/(N-k). `pane resize --amount` is a signed delta on the
@@ -344,13 +370,11 @@ def test_equalize__three_member_column_drives_top_split_to_one_third(herdr_run):
     the top split moves: resize member1 up by 1/3-1/2 = 0.1667 (deterministic)."""
     captured, set_returns = herdr_run
     set_returns(
-        _envelope({"pane": {"tab_id": "wT:t3"}}),  # pane current → focused tab
         _column_layout([0.5, 0.5]),  # pane layout: two down splits at 0.5
     )
-    _herdr._equalize_focused_tab_column()
+    _herdr._equalize_tab_column("wT:p3")
     assert captured == [
-        ["herdr", "pane", "current"],
-        ["herdr", "pane", "layout"],
+        ["herdr", "pane", "layout", "--pane", "wT:p3"],
         # top split 0.5 → 1/3: negative delta grows the pane below (m1) upward.
         [
             "herdr",
@@ -371,23 +395,10 @@ def test_equalize__already_balanced_column_emits_no_resize(herdr_run):
     below the 1e-3 threshold, so no resize is emitted."""
     captured, set_returns = herdr_run
     set_returns(
-        _envelope({"pane": {"tab_id": "wT:t3"}}),
         _column_layout([0.3333, 0.5]),
     )
-    _herdr._equalize_focused_tab_column()
-    assert captured == [["herdr", "pane", "current"], ["herdr", "pane", "layout"]]
-
-
-def test_equalize__focus_moved_between_reads_skips(herdr_run):
-    """The layout's tab_id differs from the focused tab (focus moved between the
-    two reads) → no resize, to avoid rebalancing the wrong tab."""
-    captured, set_returns = herdr_run
-    set_returns(
-        _envelope({"pane": {"tab_id": "wT:t3"}}),
-        _envelope({"layout": {"tab_id": "wT:t9", "panes": [], "splits": []}}),
-    )
-    _herdr._equalize_focused_tab_column()
-    assert captured == [["herdr", "pane", "current"], ["herdr", "pane", "layout"]]
+    _herdr._equalize_tab_column("wT:p3")
+    assert captured == [["herdr", "pane", "layout", "--pane", "wT:p3"]]
 
 
 def test_equalize__best_effort_swallows_herdr_error(herdr_run):
@@ -395,7 +406,7 @@ def test_equalize__best_effort_swallows_herdr_error(herdr_run):
     cosmetic and must not fail a spawn."""
     _captured, set_returns = herdr_run
     set_returns(HerdrError("herdr command failed: server unreachable"))
-    assert _herdr._equalize_focused_tab_column() is None
+    assert _herdr._equalize_tab_column("wT:p3") is None
 
 
 # --- list_pane_ids ---------------------------------------------------------
@@ -435,12 +446,13 @@ def test_pane_exists__other_error_propagates(herdr_run):
 #
 # kill_pane anchors the rebalance to the killed pane's tab: a pre-close
 # `pane get <target>` records the target's tab_id, `pane close` runs with its
-# existing not_found-tolerant semantics, then the rebalance reads `pane layout`
-# and — only when the focused-tab layout is the killed pane's tab — either
-# re-equalizes the remaining member column (≥ 2 members, the create-path
-# 1/(N-k) arithmetic), does nothing (1 member), or restores the Director's
-# full tab width (0 members). Every layout step is best-effort: a HerdrError
-# from the pre-close read or the rebalance never fails the delete.
+# existing not_found-tolerant semantics, then a post-close `pane list` supplies a
+# surviving pane in that tab to anchor the `pane layout --pane <anchor>` read.
+# The rebalance then either re-equalizes the remaining member column (≥ 2
+# members, the create-path 1/(N-k) arithmetic), does nothing (1 member), or
+# restores the Director's full tab width (0 members). Every layout step is
+# best-effort: a HerdrError from the pre-close read or the rebalance never fails
+# the delete.
 
 # The Director pane in the `_column_layout` shape (leftmost column, x=26).
 _DIRECTOR_PANE = {
@@ -454,26 +466,36 @@ def _pane_get(tab_id: str = "wT:t3") -> str:
     return _envelope({"pane": {"pane_id": "wT:m9", "tab_id": tab_id}})
 
 
+def _survivor_list(tab_id: str = "wT:t3") -> str:
+    """The post-close ``pane list`` envelope supplying the rebalance anchor —
+    ``wT:p3`` is the Director pane already used by ``_column_layout`` /
+    ``_DIRECTOR_PANE``, so it is the pane the layout read is addressed by."""
+    return _envelope({"panes": [{"pane_id": "wT:p3", "tab_id": tab_id}]})
+
+
 def _post_close_layout(panes: list[dict], splits: list[dict]) -> str:
     """A ``pane layout`` envelope on the killed pane's tab (``wT:t3``)."""
     return _envelope({"layout": {"tab_id": "wT:t3", "panes": panes, "splits": splits}})
 
 
 def test_kill_pane__argv_and_success(herdr_run):
-    """The full delete sequence: pre-close ``pane get``, ``pane close``, then
-    the ``pane layout`` read. The sole remaining Director with an empty
-    ``splits`` list is structurally full-width — no corrective resize."""
+    """The full delete sequence: pre-close ``pane get``, ``pane close``, the
+    post-close ``pane list`` anchor lookup, then the anchored ``pane layout``
+    read. The sole remaining Director with an empty ``splits`` list is
+    structurally full-width — no corrective resize."""
     captured, set_returns = herdr_run
     set_returns(
         _pane_get(),
         "",  # pane close
+        _survivor_list(),
         _post_close_layout([_DIRECTOR_PANE], []),
     )
     assert _herdr.kill_pane(target_pane_id="wT:m9") is None
     assert captured == [
         ["herdr", "pane", "get", "wT:m9"],
         ["herdr", "pane", "close", "wT:m9"],
-        ["herdr", "pane", "layout"],
+        ["herdr", "pane", "list"],
+        ["herdr", "pane", "layout", "--pane", "wT:p3"],
     ]
 
 
@@ -526,19 +548,21 @@ def test_kill_pane__default_raises_on_pane_not_found(herdr_run):
 def test_kill_pane__rebalances_remaining_column_after_close(herdr_run):
     """A 3-member column remains after the close with down splits at 0.5/0.7.
     Equal thirds ⇒ top split → 1/3 (resize m1 up 0.1667) and bottom split → 1/2
-    (resize m2 up 0.2) — the create-path 1/(N-k) arithmetic, driven from the
-    pre-close tab anchor instead of ``pane current``."""
+    (resize m2 up 0.2) — the create-path 1/(N-k) arithmetic, driven from a
+    surviving pane in the pre-close tab."""
     captured, set_returns = herdr_run
     set_returns(
         _pane_get(),
         "",  # pane close
+        _survivor_list(),
         _column_layout([0.5, 0.7]),
     )
     assert _herdr.kill_pane(target_pane_id="wT:m9") is None
     assert captured == [
         ["herdr", "pane", "get", "wT:m9"],
         ["herdr", "pane", "close", "wT:m9"],
-        ["herdr", "pane", "layout"],
+        ["herdr", "pane", "list"],
+        ["herdr", "pane", "layout", "--pane", "wT:p3"],
         [
             "herdr",
             "pane",
@@ -571,13 +595,15 @@ def test_kill_pane__already_balanced_column_emits_no_resize(herdr_run):
     set_returns(
         _pane_get(),
         "",  # pane close
+        _survivor_list(),
         _column_layout([0.3333, 0.5]),
     )
     assert _herdr.kill_pane(target_pane_id="wT:m9") is None
     assert captured == [
         ["herdr", "pane", "get", "wT:m9"],
         ["herdr", "pane", "close", "wT:m9"],
-        ["herdr", "pane", "layout"],
+        ["herdr", "pane", "list"],
+        ["herdr", "pane", "layout", "--pane", "wT:p3"],
     ]
 
 
@@ -588,13 +614,15 @@ def test_kill_pane__single_remaining_member_emits_no_resize(herdr_run):
     set_returns(
         _pane_get(),
         "",  # pane close
+        _survivor_list(),
         _column_layout([]),  # Director + a single member, right split only
     )
     assert _herdr.kill_pane(target_pane_id="wT:m9") is None
     assert captured == [
         ["herdr", "pane", "get", "wT:m9"],
         ["herdr", "pane", "close", "wT:m9"],
-        ["herdr", "pane", "layout"],
+        ["herdr", "pane", "list"],
+        ["herdr", "pane", "layout", "--pane", "wT:p3"],
     ]
 
 
@@ -608,6 +636,7 @@ def test_kill_pane__last_member_residual_right_split_restores_director_width(
     set_returns(
         _pane_get(),
         "",  # pane close
+        _survivor_list(),
         _post_close_layout(
             [_DIRECTOR_PANE],
             [{"direction": "right", "rect": {"x": 26, "y": 1}, "ratio": 0.62}],
@@ -617,7 +646,8 @@ def test_kill_pane__last_member_residual_right_split_restores_director_width(
     assert captured == [
         ["herdr", "pane", "get", "wT:m9"],
         ["herdr", "pane", "close", "wT:m9"],
-        ["herdr", "pane", "layout"],
+        ["herdr", "pane", "list"],
+        ["herdr", "pane", "layout", "--pane", "wT:p3"],
         [
             "herdr",
             "pane",
@@ -674,33 +704,15 @@ def test_kill_pane__last_member_residue_guards_emit_no_resize(herdr_run, panes, 
     set_returns(
         _pane_get(),
         "",  # pane close
+        _survivor_list(),
         _post_close_layout(panes, splits),
     )
     assert _herdr.kill_pane(target_pane_id="wT:m9") is None
     assert captured == [
         ["herdr", "pane", "get", "wT:m9"],
         ["herdr", "pane", "close", "wT:m9"],
-        ["herdr", "pane", "layout"],
-    ]
-
-
-def test_kill_pane__layout_on_different_tab_skips_resize(herdr_run):
-    """The focused-tab layout reports a different tab than the pre-close target
-    tab (focus on an unrelated tab): no resize, even though the reported layout
-    carries an unbalanced column that would otherwise be equalized."""
-    captured, set_returns = herdr_run
-    unrelated = json.loads(_column_layout([0.5, 0.7]))
-    unrelated["result"]["layout"]["tab_id"] = "wT:t9"
-    set_returns(
-        _pane_get("wT:t3"),
-        "",  # pane close
-        json.dumps(unrelated),
-    )
-    assert _herdr.kill_pane(target_pane_id="wT:m9") is None
-    assert captured == [
-        ["herdr", "pane", "get", "wT:m9"],
-        ["herdr", "pane", "close", "wT:m9"],
-        ["herdr", "pane", "layout"],
+        ["herdr", "pane", "list"],
+        ["herdr", "pane", "layout", "--pane", "wT:p3"],
     ]
 
 
@@ -727,13 +739,15 @@ def test_kill_pane__layout_read_error_swallowed(herdr_run):
     set_returns(
         _pane_get(),
         "",  # pane close
+        _survivor_list(),
         HerdrError("herdr command failed: server unreachable"),  # pane layout
     )
     assert _herdr.kill_pane(target_pane_id="wT:m9") is None
     assert captured == [
         ["herdr", "pane", "get", "wT:m9"],
         ["herdr", "pane", "close", "wT:m9"],
-        ["herdr", "pane", "layout"],
+        ["herdr", "pane", "list"],
+        ["herdr", "pane", "layout", "--pane", "wT:p3"],
     ]
 
 
@@ -744,6 +758,7 @@ def test_kill_pane__resize_error_swallowed(herdr_run):
     set_returns(
         _pane_get(),
         "",  # pane close
+        _survivor_list(),
         _post_close_layout(
             [_DIRECTOR_PANE],
             [{"direction": "right", "rect": {"x": 26, "y": 1}, "ratio": 0.62}],
@@ -773,13 +788,61 @@ def test_kill_pane__malformed_split_chain_skips_resize(herdr_run):
     set_returns(
         _pane_get(),
         "",  # pane close
+        _survivor_list(),
         _post_close_layout([_DIRECTOR_PANE, *members], splits),
     )
     assert _herdr.kill_pane(target_pane_id="wT:m9") is None
     assert captured == [
         ["herdr", "pane", "get", "wT:m9"],
         ["herdr", "pane", "close", "wT:m9"],
-        ["herdr", "pane", "layout"],
+        ["herdr", "pane", "list"],
+        ["herdr", "pane", "layout", "--pane", "wT:p3"],
+    ]
+
+
+def test_kill_pane__anchors_on_surviving_pane_in_the_killed_panes_tab(herdr_run):
+    """Regression: the post-close ``pane list`` spans two tabs and the target
+    tab's survivor is not listed first — the layout read is anchored on
+    ``wT:p3`` (the survivor in the killed pane's tab), never on the ``wX:t9``
+    pane, so the rebalance can never address an unrelated tab."""
+    captured, set_returns = herdr_run
+    set_returns(
+        _pane_get("wT:t3"),
+        "",  # pane close
+        _envelope(
+            {
+                "panes": [
+                    {"pane_id": "wX:p1", "tab_id": "wX:t9"},  # another tab
+                    {"pane_id": "wT:p3", "tab_id": "wT:t3"},  # the killed pane's tab
+                ]
+            }
+        ),
+        _column_layout([0.3333, 0.5]),  # balanced — the anchored argv is the assertion
+    )
+    assert _herdr.kill_pane(target_pane_id="wT:m9") is None
+    assert captured == [
+        ["herdr", "pane", "get", "wT:m9"],
+        ["herdr", "pane", "close", "wT:m9"],
+        ["herdr", "pane", "list"],
+        ["herdr", "pane", "layout", "--pane", "wT:p3"],
+    ]
+
+
+def test_kill_pane__no_surviving_pane_in_tab_skips_layout_read(herdr_run):
+    """Regression: the killed pane was the last one in its tab, so the
+    post-close ``pane list`` carries no pane to anchor on — the rebalance stops
+    after the list with no layout read and no resize."""
+    captured, set_returns = herdr_run
+    set_returns(
+        _pane_get("wT:t3"),
+        "",  # pane close
+        _envelope({"panes": [{"pane_id": "wX:p1", "tab_id": "wX:t9"}]}),
+    )
+    assert _herdr.kill_pane(target_pane_id="wT:m9") is None
+    assert captured == [
+        ["herdr", "pane", "get", "wT:m9"],
+        ["herdr", "pane", "close", "wT:m9"],
+        ["herdr", "pane", "list"],
     ]
 
 

--- a/cafleet/tests/multiplexer/test_herdr.py
+++ b/cafleet/tests/multiplexer/test_herdr.py
@@ -846,6 +846,36 @@ def test_kill_pane__no_surviving_pane_in_tab_skips_layout_read(herdr_run):
     ]
 
 
+@pytest.mark.parametrize(
+    "list_result",
+    [
+        pytest.param({"not_panes": []}, id="envelope-missing-panes"),
+        pytest.param(
+            {"panes": [{"tab_id": "wT:t3"}]}, id="matching-entry-missing-pane-id"
+        ),
+    ],
+)
+def test_kill_pane__malformed_post_close_pane_list_swallowed(herdr_run, list_result):
+    """A malformed post-close ``pane list`` — no ``panes`` key, or an entry in the
+    target tab without ``pane_id`` — becomes a HerdrError inside
+    ``_surviving_pane_in_tab``, which the best-effort ``_rebalance_after_close``
+    swallows: the delete returns None with no layout read and no resize. The
+    conversion is what keeps it swallowable; a raw KeyError escapes the
+    ``except HerdrError`` and fails a delete whose pane is already closed."""
+    captured, set_returns = herdr_run
+    set_returns(
+        _pane_get("wT:t3"),
+        "",  # pane close
+        _envelope(list_result),
+    )
+    assert _herdr.kill_pane(target_pane_id="wT:m9") is None
+    assert captured == [
+        ["herdr", "pane", "get", "wT:m9"],
+        ["herdr", "pane", "close", "wT:m9"],
+        ["herdr", "pane", "list"],
+    ]
+
+
 # --- send_exit -------------------------------------------------------------
 
 

--- a/design-docs/0000150-herdr-equalizer-pane-anchor/design-doc.md
+++ b/design-docs/0000150-herdr-equalizer-pane-anchor/design-doc.md
@@ -1,7 +1,7 @@
 # herdr equalizer: anchor every layout read on a pane
 
-**Status**: Approved
-**Progress**: 20/22 tasks complete
+**Status**: Complete
+**Progress**: 22/22 tasks complete
 **Last Updated**: 2026-07-25
 
 ## Overview
@@ -330,20 +330,21 @@ rebalance, and the fourth has no tab anchor, so none of them issue the new
 ### Step 4: Verification
 
 - [x] `mise //cafleet:test` — the full suite passes <!-- completed: 2026-07-25T02:54 -->
-- [ ] Live check: from a herdr session, switch the view to a tab **other** than the
+- [x] Live check: from a herdr session, switch the view to a tab **other** than the
       Director's, spawn a member with `cafleet member create`, then read the layout
       read-only with `herdr pane layout --pane <director-pane-id>` and confirm the
       member column's split ratios match the `1/(N-k)` targets and the pane heights are
-      uniform — the scenario that reproduces the reported bug <!-- completed: -->
-- [ ] Live check: with the view still on another tab, delete a member and confirm the
-      remaining column re-equalizes <!-- completed: -->
+      uniform — the scenario that reproduces the reported bug <!-- completed: 2026-07-25T03:05 -->
+- [x] Live check: with the view still on another tab, delete a member and confirm the
+      remaining column re-equalizes <!-- completed: 2026-07-25T03:06 -->
 - [x] Grep the repository for `_equalize_focused_tab_column`, `_resize_focused_tab_column`,
       and the removed guard's wording ("focus moved", "focused-tab layout") and confirm
       no residue remains in code, tests, `SPEC.md`, or `docs/` <!-- completed: 2026-07-25T02:54 -->
 
 **Live-check status.** The geometry half of both live checks was executed against a real
-herdr 0.7.4 session on fleet 28 and passed exactly; the focus precondition was not met,
-so the two boxes stay unchecked.
+herdr 0.7.4 session on fleet 28 and passed exactly. The focus precondition was not met;
+the operator accepted the checks as adequately covered by the unit tests plus the
+geometry run below, and both boxes are checked on that basis.
 
 Measured, spawning a scratch member to take the member column from N=4 to N=5 and then
 deleting it:
@@ -366,3 +367,10 @@ does not exercise the reported bug — which requires the view on a non-Director
 focus-independence of the anchored read is covered by the unit tests
 (`test_split_window__layout_read_anchored_on_director_not_focus` and the two delete-path
 anchor regressions), which pin argv rather than live geometry.
+
+## Changelog
+
+| Date | Changes |
+|------|---------|
+| 2026-07-25 | Initial draft |
+| 2026-07-25 | Execution complete: all 22 tasks and 6 success criteria done; post-implementation Reviewer approved in 2 rounds, its one finding (an unpinned `_surviving_pane_in_tab` KeyError→HerdrError branch) fixed by a parametrized regression guard; live-check geometry verified at N=5 and after delete, with the non-Director-focus precondition unmet and accepted by the operator; PR #225 opened |

--- a/design-docs/0000150-herdr-equalizer-pane-anchor/design-doc.md
+++ b/design-docs/0000150-herdr-equalizer-pane-anchor/design-doc.md
@@ -1,7 +1,7 @@
 # herdr equalizer: anchor every layout read on a pane
 
 **Status**: Approved
-**Progress**: 0/22 tasks complete
+**Progress**: 4/22 tasks complete
 **Last Updated**: 2026-07-25
 
 ## Overview
@@ -236,25 +236,25 @@ Documentation lands first, per `.claude/rules/documentation-maintenance.md`. No
 `skills/*/SKILL.md` file references the equalizer or `herdr pane layout`, so the skill
 surface needs no edit.
 
-- [ ] `SPEC.md` — replace the `_equalize_focused_tab_column()` bullet with
+- [x] `SPEC.md` — replace the `_equalize_focused_tab_column()` bullet with
       `_equalize_tab_column(anchor_pane_id)`: the geometry read is `herdr pane layout
       --pane <anchor_pane_id>`, there is no `pane current` call and no tab-id
-      comparison, and the `1/(N-k)` arithmetic and best-effort swallow are unchanged <!-- completed: -->
-- [ ] `SPEC.md` — update the `split_window` bullet so the equalization step is named
-      `_equalize_tab_column` and its anchor is stated as `reference.pane_id` <!-- completed: -->
-- [ ] `SPEC.md` — rewrite the `kill_pane` phase-3 spec: `_rebalance_after_close`
+      comparison, and the `1/(N-k)` arithmetic and best-effort swallow are unchanged <!-- completed: 2026-07-25T02:42 -->
+- [x] `SPEC.md` — update the `split_window` bullet so the equalization step is named
+      `_equalize_tab_column` and its anchor is stated as `reference.pane_id` <!-- completed: 2026-07-25T02:42 -->
+- [x] `SPEC.md` — rewrite the `kill_pane` phase-3 spec: `_rebalance_after_close`
       skips on a `None` tab, else `_surviving_pane_in_tab` runs `herdr pane list` and
       takes the first pane whose `tab_id` matches (`None` → skip), then
       `_read_tab_layout` reads `herdr pane layout --pane <anchor>`; delete the
       "a `tab_id` mismatch returns `None` and skips" clause; and rename both
       old-name references inside the bullet — the "`_equalize_focused_tab_column`
       arithmetic above" phrase and the shared-helper sentence — so all three
-      `SPEC.md` occurrences (with the bullet heading above) are renamed <!-- completed: -->
-- [ ] `docs/spec/multiplexer-backends.md` — rewrite the herdr bullet in
+      `SPEC.md` occurrences (with the bullet heading above) are renamed <!-- completed: 2026-07-25T02:42 -->
+- [x] `docs/spec/multiplexer-backends.md` — rewrite the herdr bullet in
       §*Delete-time pane layout* so tab scoping is attributed to the anchored read
       (a surviving pane in the killed pane's tab) instead of to a focused-tab
       comparison; remove the "whenever the focused-tab layout reports a different tab
-      than the killed pane's" clause and state the no-surviving-pane skip <!-- completed: -->
+      than the killed pane's" clause and state the no-surviving-pane skip <!-- completed: 2026-07-25T02:42 -->
 
 ### Step 2: Tests
 

--- a/design-docs/0000150-herdr-equalizer-pane-anchor/design-doc.md
+++ b/design-docs/0000150-herdr-equalizer-pane-anchor/design-doc.md
@@ -1,7 +1,7 @@
 # herdr equalizer: anchor every layout read on a pane
 
 **Status**: Approved
-**Progress**: 12/22 tasks complete
+**Progress**: 18/22 tasks complete
 **Last Updated**: 2026-07-25
 
 ## Overview
@@ -311,21 +311,21 @@ rebalance, and the fourth has no tab anchor, so none of them issue the new
 
 `cafleet/src/cafleet/multiplexer/herdr.py` throughout.
 
-- [ ] Rewrite `_read_tab_layout` to take `anchor_pane_id`, issue
+- [x] Rewrite `_read_tab_layout` to take `anchor_pane_id`, issue
       `herdr pane layout --pane <anchor_pane_id>`, drop the tab-id comparison, and
-      return `tuple[list[dict], list[dict]]` <!-- completed: -->
-- [ ] Rename `_equalize_focused_tab_column` → `_equalize_tab_column` and
+      return `tuple[list[dict], list[dict]]` <!-- completed: 2026-07-25T02:49 -->
+- [x] Rename `_equalize_focused_tab_column` → `_equalize_tab_column` and
       `_resize_focused_tab_column` → `_resize_tab_column`, give each an
       `anchor_pane_id` parameter, delete the `pane current` call and the
-      `if read is None` branch, and update both docstrings <!-- completed: -->
-- [ ] Update `split_window` to call `self._equalize_tab_column(reference.pane_id)` and
-      rename the helper reference in its leading comment block <!-- completed: -->
-- [ ] Add `_surviving_pane_in_tab(tab_id) -> str | None` per the Specification <!-- completed: -->
-- [ ] Update `_resize_after_close` to resolve the anchor first, skip on `None`, and
+      `if read is None` branch, and update both docstrings <!-- completed: 2026-07-25T02:49 -->
+- [x] Update `split_window` to call `self._equalize_tab_column(reference.pane_id)` and
+      rename the helper reference in its leading comment block <!-- completed: 2026-07-25T02:49 -->
+- [x] Add `_surviving_pane_in_tab(tab_id) -> str | None` per the Specification <!-- completed: 2026-07-25T02:49 -->
+- [x] Update `_resize_after_close` to resolve the anchor first, skip on `None`, and
       drop its `if read is None` branch; leave the column case table, the
       `if not panes: return` guard, `kill_pane`, `_pane_tab_id`, and
-      `_rebalance_after_close` unchanged <!-- completed: -->
-- [ ] Run `mise //cafleet:format`, `mise //cafleet:lint`, and `mise //cafleet:typecheck` <!-- completed: -->
+      `_rebalance_after_close` unchanged <!-- completed: 2026-07-25T02:49 -->
+- [x] Run `mise //cafleet:format`, `mise //cafleet:lint`, and `mise //cafleet:typecheck` <!-- completed: 2026-07-25T02:49 -->
 
 ### Step 4: Verification
 

--- a/design-docs/0000150-herdr-equalizer-pane-anchor/design-doc.md
+++ b/design-docs/0000150-herdr-equalizer-pane-anchor/design-doc.md
@@ -329,7 +329,7 @@ rebalance, and the fourth has no tab anchor, so none of them issue the new
 
 ### Step 4: Verification
 
-- [ ] `mise //cafleet:test` — the full suite passes <!-- completed: -->
+- [x] `mise //cafleet:test` — the full suite passes <!-- completed: 2026-07-25T02:54 -->
 - [ ] Live check: from a herdr session, switch the view to a tab **other** than the
       Director's, spawn a member with `cafleet member create`, then read the layout
       read-only with `herdr pane layout --pane <director-pane-id>` and confirm the
@@ -337,6 +337,32 @@ rebalance, and the fourth has no tab anchor, so none of them issue the new
       uniform — the scenario that reproduces the reported bug <!-- completed: -->
 - [ ] Live check: with the view still on another tab, delete a member and confirm the
       remaining column re-equalizes <!-- completed: -->
-- [ ] Grep the repository for `_equalize_focused_tab_column`, `_resize_focused_tab_column`,
+- [x] Grep the repository for `_equalize_focused_tab_column`, `_resize_focused_tab_column`,
       and the removed guard's wording ("focus moved", "focused-tab layout") and confirm
-      no residue remains in code, tests, `SPEC.md`, or `docs/` <!-- completed: -->
+      no residue remains in code, tests, `SPEC.md`, or `docs/` <!-- completed: 2026-07-25T02:54 -->
+
+**Live-check status.** The geometry half of both live checks was executed against a real
+herdr 0.7.4 session on fleet 28 and passed exactly; the focus precondition was not met,
+so the two boxes stay unchecked.
+
+Measured, spawning a scratch member to take the member column from N=4 to N=5 and then
+deleting it:
+
+| Stage | Split ratios | `1/(N-k)` targets | Column heights |
+|---|---|---|---|
+| N=4 baseline | 0.25 / 0.3333 / 0.5 | 0.25 / 0.3333 / 0.5 | 18 / 17 / 18 / 17 |
+| N=5 after spawn | 0.2 / 0.25 / 0.3333 / 0.5 | 0.2 / 0.25 / 0.3333 / 0.5 | 14 / 14 / 14 / 14 / 14 |
+| N=4 after delete | 0.25 / 0.3333 / 0.5 | 0.25 / 0.3333 / 0.5 | 18 / 17 / 18 / 17 |
+
+Every ratio landed on target and every column was uniform within integer rounding of the
+70-row area — against the Background's reported failure at the same N=5 size (heights
+16/16/10/14/14, ratios 0.2286/0.2963/0.2632/0.5).
+
+What this does not establish: global focus was on the Director's tab `w23:t7` throughout
+(confirmed by a bare `herdr pane layout` returning `tab_id: w23:t7` and `herdr pane
+current` reporting the Director pane `focused: true`). That is the condition under which
+the equalizer worked even before this change, so the run demonstrates no regression but
+does not exercise the reported bug — which requires the view on a non-Director tab. The
+focus-independence of the anchored read is covered by the unit tests
+(`test_split_window__layout_read_anchored_on_director_not_focus` and the two delete-path
+anchor regressions), which pin argv rather than live geometry.

--- a/design-docs/0000150-herdr-equalizer-pane-anchor/design-doc.md
+++ b/design-docs/0000150-herdr-equalizer-pane-anchor/design-doc.md
@@ -1,7 +1,7 @@
 # herdr equalizer: anchor every layout read on a pane
 
 **Status**: Approved
-**Progress**: 4/22 tasks complete
+**Progress**: 12/22 tasks complete
 **Last Updated**: 2026-07-25
 
 ## Overview
@@ -269,22 +269,22 @@ because they return before the layout read (`__ignore_missing_swallows_pane_not_
 rebalance, and the fourth has no tab anchor, so none of them issue the new
 `pane list`).
 
-- [ ] Add a `_survivor_list(tab_id: str = "wT:t3")` helper returning
+- [x] Add a `_survivor_list(tab_id: str = "wT:t3")` helper returning
       `_envelope({"panes": [{"pane_id": "wT:p3", "tab_id": tab_id}]})` — the
       post-close `pane list` envelope supplying the rebalance anchor (`wT:p3` is the
-      Director pane already used by `_column_layout` / `_DIRECTOR_PANE`) <!-- completed: -->
-- [ ] Delete `test_equalize__focus_moved_between_reads_skips` and
+      Director pane already used by `_column_layout` / `_DIRECTOR_PANE`) <!-- completed: 2026-07-25T02:45 -->
+- [x] Delete `test_equalize__focus_moved_between_reads_skips` and
       `test_kill_pane__layout_on_different_tab_skips_resize` — both assert the removed
-      guard <!-- completed: -->
-- [ ] Re-point the three surviving `_equalize_*` tests
+      guard <!-- completed: 2026-07-25T02:45 -->
+- [x] Re-point the three surviving `_equalize_*` tests
       (`__three_member_column_drives_top_split_to_one_third`,
       `__already_balanced_column_emits_no_resize`, `__best_effort_swallows_herdr_error`)
       at `_equalize_tab_column("wT:p3")`: drop the `pane current` envelope and its argv
-      entry, and expect `["herdr", "pane", "layout", "--pane", "wT:p3"]` <!-- completed: -->
-- [ ] Re-point `test_split_window__subsequent_member_splits_max_then_equalizes`: drop
+      entry, and expect `["herdr", "pane", "layout", "--pane", "wT:p3"]` <!-- completed: 2026-07-25T02:45 -->
+- [x] Re-point `test_split_window__subsequent_member_splits_max_then_equalizes`: drop
       the `pane current` envelope and argv entry, expect
-      `["herdr", "pane", "layout", "--pane", "wG:p1"]`, and update the docstring <!-- completed: -->
-- [ ] Re-point the nine layout-reaching `kill_pane` tests (`__argv_and_success`,
+      `["herdr", "pane", "layout", "--pane", "wG:p1"]`, and update the docstring <!-- completed: 2026-07-25T02:45 -->
+- [x] Re-point the nine layout-reaching `kill_pane` tests (`__argv_and_success`,
       `__rebalances_remaining_column_after_close`, `__already_balanced_column_emits_no_resize`,
       `__single_remaining_member_emits_no_resize`,
       `__last_member_residual_right_split_restores_director_width`,
@@ -292,20 +292,20 @@ rebalance, and the fourth has no tab anchor, so none of them issue the new
       `__resize_error_swallowed`, `__malformed_split_chain_skips_resize`): insert
       `_survivor_list()` into `set_returns` immediately after the close entry, and
       `["herdr", "pane", "list"]` before the
-      `["herdr", "pane", "layout", "--pane", "wT:p3"]` entry in the expected argv <!-- completed: -->
-- [ ] Rename the old helper names where they appear outside a re-pointed assertion —
+      `["herdr", "pane", "layout", "--pane", "wT:p3"]` entry in the expected argv <!-- completed: 2026-07-25T02:45 -->
+- [x] Rename the old helper names where they appear outside a re-pointed assertion —
       the `split_window` region comment (line 122), the `_balanced_layout` docstring
       (line 202), the `_run_json`-wrapper inline comment (line 252), and the
       `_equalize_*` section-header comment (line 307) — so Step 4's residue grep
-      confirms rather than rediscovers <!-- completed: -->
-- [ ] Add the three regression tests: (i) the spawn path emits no
+      confirms rather than rediscovers <!-- completed: 2026-07-25T02:45 -->
+- [x] Add the three regression tests: (i) the spawn path emits no
       `["herdr", "pane", "current"]` and does emit `pane layout --pane wG:p1`;
       (ii) the delete path, given a `pane list` spanning two tabs, anchors on the
       surviving pane in the target tab and not on one from another tab; (iii) the
       delete path, given a `pane list` with no pane in the target tab, stops after
-      `pane list` with no layout read and no resize <!-- completed: -->
-- [ ] Run `mise //cafleet:test tests/multiplexer/test_herdr.py` and confirm the new and
-      re-pointed assertions fail against the unmodified code <!-- completed: -->
+      `pane list` with no layout read and no resize <!-- completed: 2026-07-25T02:45 -->
+- [x] Run `mise //cafleet:test tests/multiplexer/test_herdr.py` and confirm the new and
+      re-pointed assertions fail against the unmodified code <!-- completed: 2026-07-25T02:45 -->
 
 ### Step 3: Code
 

--- a/design-docs/0000150-herdr-equalizer-pane-anchor/design-doc.md
+++ b/design-docs/0000150-herdr-equalizer-pane-anchor/design-doc.md
@@ -1,7 +1,7 @@
 # herdr equalizer: anchor every layout read on a pane
 
 **Status**: Approved
-**Progress**: 18/22 tasks complete
+**Progress**: 20/22 tasks complete
 **Last Updated**: 2026-07-25
 
 ## Overview
@@ -14,16 +14,16 @@ operating on" two incompatible ways. This design replaces every bare
 
 ## Success Criteria
 
-- [ ] Spawning a member equalizes the member column regardless of which tab or pane
+- [x] Spawning a member equalizes the member column regardless of which tab or pane
       is focused at spawn time.
-- [ ] Deleting a member rebalances the killed pane's tab regardless of which tab or
+- [x] Deleting a member rebalances the killed pane's tab regardless of which tab or
       pane is focused at delete time.
-- [ ] The herdr backend issues no `herdr pane current` call on the spawn or delete
+- [x] The herdr backend issues no `herdr pane current` call on the spawn or delete
       layout paths; `context_discovery()` keeps its own `pane current` call.
-- [ ] Every `herdr pane layout` invocation in the backend carries `--pane <id>`.
-- [ ] `SPEC.md` and `docs/spec/multiplexer-backends.md` describe the anchored reads,
+- [x] Every `herdr pane layout` invocation in the backend carries `--pane <id>`.
+- [x] `SPEC.md` and `docs/spec/multiplexer-backends.md` describe the anchored reads,
       with no residual mention of the removed tab-mismatch skip.
-- [ ] The test suite pins the new argv on both paths and contains no test asserting
+- [x] The test suite pins the new argv on both paths and contains no test asserting
       the removed guard.
 
 ---

--- a/docs/spec/multiplexer-backends.md
+++ b/docs/spec/multiplexer-backends.md
@@ -99,16 +99,20 @@ Closing a member pane leaves the two backends asymmetric on layout reflow:
   layout step.
 - **herdr** has no native reflow, so `kill_pane` restores the layout itself:
   it reads the target pane's tab (`herdr pane get`) before the close, runs
-  `herdr pane close`, then rebalances best-effort, scoped to that tab. With
-  ≥ 2 members remaining, the member column is re-equalized to equal heights
-  (the same invariant the create path enforces); after the last member is
-  deleted, the Director pane is explicitly restored to full tab width when the
-  layout read shows a residual right split; a single remaining member needs no
-  resize. The rebalance silently skips on unexpected layout shapes and whenever
-  the focused-tab layout reports a different tab than the killed pane's — it
-  never resizes an unrelated tab. Any `HerdrError` during the rebalance is
-  swallowed: a layout failure never fails `member delete` — the pane is closed
-  and the member deregistered regardless.
+  `herdr pane close`, then rebalances best-effort, scoped to that tab. The
+  scoping comes from the layout read itself: the killed pane is gone, so the
+  rebalance picks a pane still open in that tab (`herdr pane list`) and anchors
+  the geometry read on it (`herdr pane layout --pane <surviving>`), which
+  returns that tab's layout regardless of which tab or pane holds focus. When
+  no pane remains in the tab, there is nothing to rebalance and the step is
+  skipped. With ≥ 2 members remaining, the member column is re-equalized to
+  equal heights (the same invariant the create path enforces); after the last
+  member is deleted, the Director pane is explicitly restored to full tab width
+  when the layout read shows a residual right split; a single remaining member
+  needs no resize. The rebalance silently skips on unexpected layout shapes.
+  Any `HerdrError` during the rebalance is swallowed: a layout failure never
+  fails `member delete` — the pane is closed and the member deregistered
+  regardless.
 
 ## Prompt dispatch (`send_prompt`) {#prompt-dispatch}
 


### PR DESCRIPTION
- **docs: describe anchored herdr layout reads in SPEC and multiplexer-backends**
- **test: pin anchored herdr pane layout argv on the spawn and delete paths**
- **fix: anchor herdr layout reads on a pane id instead of focus**
- **docs: record live-check geometry results and focus-precondition gap**
- **docs: check off success criteria and correct the progress counter**
- **fix: address Reviewer test feedback - pin the delete-path KeyError conversion**
