### PR TITLE
feat/0000156 drop director monitor enrollment

### DIFF
--- a/.claude/rules/documentation-tables.md
+++ b/.claude/rules/documentation-tables.md
@@ -59,8 +59,8 @@ a restatement of the owned attributes.
 Two rules keep the non-owning mentions honest:
 
 - **Echo rule.** A non-owning page may describe an owned enumeration in
-  qualitative magnitude terms ("the Director is checked far more often than an
-  ordinary member"); it states no exact values.
+  qualitative magnitude terms ("the stall-check fires several times more often
+  than a member's own ping interval"); it states no exact values.
 - **Term tie-break.** When copies have drifted on what to call something, the
   term in the Core terms table of the concepts overview governs. The owning
   table and every linking mention adopt it.

--- a/SPEC.md
+++ b/SPEC.md
@@ -314,7 +314,7 @@ The unified shapes:
 | Field | Type | Notes |
 |---|---|---|
 | `member_id` | integer | FK→members, ON DELETE CASCADE |
-| `interval_seconds` | integer | DDL default 60; enrollment writes 180 (Director) / 720 (member) |
+| `interval_seconds` | integer | DDL default 60; enrollment writes 720 |
 | `last_ping_at` | optional string | |
 | `enabled` | boolean | stored INTEGER 0/1; exposed as boolean at the broker boundary |
 | `last_stall_check_at` | optional string | last successfully dispatched stall-check wake |
@@ -513,11 +513,9 @@ non-object `cafleet` card value collapses to the ordinary kind — a deliberate,
 documented non-match, not an error mask.
 
 - `MONITORING_MEMBER_KIND = "monitoring-member"`.
-- Enrollment intervals: the root Director is enrolled at **180 seconds**
-  (`DIRECTOR_PING_INTERVAL_SECONDS`) by `create_fleet`; ordinary pane-bound
-  members at **720 seconds** (`MEMBER_PING_INTERVAL_SECONDS`) by
-  `register_member`. The monitoring member is **never**
-  enrolled.
+- Enrollment interval: ordinary pane-bound members are enrolled at **720
+  seconds** (`MEMBER_PING_INTERVAL_SECONDS`) by `register_member`. The root
+  Director and the monitoring member are **never** enrolled.
 - Liveness staleness: `MONITOR_STALE_FACTOR = 3`,
   `MONITOR_STALE_FLOOR_SECONDS = 15` → `stale_after = max(3·tick_seconds, 15)`.
 - Root Director identity strings written by `create_fleet`: name `Director`,
@@ -534,9 +532,8 @@ documented non-match, not an error mask.
   Director's placement (the root Director is pane-bound and keeps its own
   placement row) carrying the multiplexer identity (`mux_session`
   / `mux_window_id` / `mux_pane_id`), the `backend` (the resolved `mux.name`),
-  and `coding_agent`;
-  enroll the Director at 180s; back-fill the fleet's `director_member_id`.
-  Returns `{fleet_id, name, created_at, director:{…}}`.
+  and `coding_agent`; back-fill the fleet's `director_member_id`. Returns
+  `{fleet_id, name, created_at, director:{…}}`.
 - **`list_fleets()`** — one record `{fleet_id, director_member_id, name,
   created_at, member_count}` per non-soft-deleted fleet (`deleted_at IS NULL`);
   `member_count` counts only **active** members (0 for empty fleets). Ordering:
@@ -721,14 +718,13 @@ documented non-match, not an error mask.
   else set `last_ping_at = when` for all listed configs.
 - **`list_monitor_targets(fleet_id)`** — one row per **active, enrolled** member
   (the watched set; the monitoring member is excluded by the monitor_config
-  join). Each row: `{member_id, name, is_director, pane_id, coding_agent,
-  interval_seconds, last_ping_at, enabled, last_stall_check_at, pending_count,
-  oldest_pending_ts}`, where
-  `pending_count` counts messages with `owner_member_id = member_id`,
-  `status_state = "input_required"`, `type != "broadcast_summary"`, and
-  `oldest_pending_ts` is `MIN(status_timestamp)` over the same predicate set
-  (a second correlated scalar subquery; `None` when the member has no pending
-  delivery).
+  join). Each row: `{member_id, name, pane_id, coding_agent, interval_seconds,
+  last_ping_at, enabled, last_stall_check_at, pending_count,
+  oldest_pending_ts}`, where `pending_count` counts messages with
+  `owner_member_id = member_id`, `status_state = "input_required"`,
+  `type != "broadcast_summary"`, and `oldest_pending_ts` is
+  `MIN(status_timestamp)` over the same predicate set (a second correlated
+  scalar subquery; `None` when the member has no pending delivery).
 
 #### Monitor — no broker stall state
 
@@ -776,14 +772,12 @@ The `monitor_runtime` table holds **exactly one row per fleet** (PK = fleet_id)
   process fields null when the monitor is not live (no row, or a stale/cleared
   heartbeat).
 - **`monitor_members_payload(fleet_id, now)`** — the per-member rows consumed
-  by the WebUI `GET /api/monitor`: one dict per
-  `list_monitor_targets` row — `{member_id, name, role, interval_seconds,
-  last_ping_at, last_ping_age_seconds, enabled, pending_count,
-  oldest_pending_ts, oldest_pending_age_seconds}` — with `role` =
-  `"director"`/`"member"` from `is_director`, and `last_ping_age_seconds` /
-  `oldest_pending_age_seconds` computed against the single supplied `now`
-  (whole seconds, integer-truncated; `None` when the source timestamp is
-  `None`).
+  by the WebUI `GET /api/monitor`: one dict per `list_monitor_targets` row —
+  `{member_id, name, interval_seconds, last_ping_at, last_ping_age_seconds,
+  enabled, pending_count, oldest_pending_ts, oldest_pending_age_seconds}` —
+  with `last_ping_age_seconds` / `oldest_pending_age_seconds` computed against
+  the single supplied `now` (whole seconds, integer-truncated; `None` when the
+  source timestamp is `None`).
 - **`delete_fleet_monitor_rows(session, fleet_id)`** /
   **`delete_member_monitor_row(session, member_id)`** (in caller's transaction) —
   in-transaction cascade deletes: the fleet variant deletes the fleet's
@@ -1720,11 +1714,10 @@ Director's `MultiplexerContext` and passes it directly.
   **Esc-first=YES**, any error → `false`. Used only by `member ping`.
 - **`send_wake_trigger(*, target_pane_id, due_members, director) -> bool`** —
   best-effort; the **sole** keystroke the monitor loop fires. Each due entry has
-  `member_id`, `name`, `is_director`, validated `coding_agent`, and ordered
-  deduped `wake_reasons`; the Director descriptor has `member_id` and
-  `coding_agent`. Names and agent values pass the single-line sanitizer.
-  Render each entry as `<role> <id> (<name>; coding_agent=<agent>)
-  [<reasons>]`.
+  `member_id`, `name`, validated `coding_agent`, and ordered deduped
+  `wake_reasons`; the Director descriptor has `member_id` and `coding_agent`.
+  Names and agent values pass the single-line sanitizer. Render each entry as
+  `member <id> (<name>; coding_agent=<agent>) [<reasons>]`.
 
   The tmux/herdr payload is byte-identical and is a **pure trigger** — the due
   list, the Director descriptor, and one pointer sentence naming the
@@ -2009,22 +2002,20 @@ internals; it orchestrates calls into both. It resolves its backend via
 - **`CONTINUE` / `STOP`** — tick-result markers distinguishing "keep looping"
   from "self-terminate".
 - **`DEFAULT_TICK_SECONDS = 5`** — default scan cadence (seconds).
-- Re-exports `DIRECTOR_PING_INTERVAL_SECONDS` (180),
-  `MEMBER_PING_INTERVAL_SECONDS` (720), `MONITOR_STALE_FACTOR` (3),
+- Re-exports `MEMBER_PING_INTERVAL_SECONDS` (720), `MONITOR_STALE_FACTOR` (3),
   `MONITOR_STALE_FLOOR_SECONDS` (15) — policy tunables whose single home is the
   broker, re-exported so the loop imports policy from one place.
 
 The stop flag, the sleep helper, the signal handler, and the marker type are
-implementation-private; only the three functions, the markers, and the five
+implementation-private; only the three functions, the markers, and the four
 constants are public.
 
 #### `should_ping(target, now)`
 
-Pure function of one watched-member scan row (`member_id`, `name`, `is_director`,
-`pane_id` optional, `interval_seconds`, `last_ping_at` optional ISO string,
-`enabled`, `pending_count`, `oldest_pending_ts` optional ISO string,
-`pane_alive`) and a tz-aware UTC `now`. Branch
-conditions, in short-circuit order:
+Pure function of one watched-member scan row (`member_id`, `name`, `pane_id`
+optional, `interval_seconds`, `last_ping_at` optional ISO string, `enabled`,
+`pending_count`, `oldest_pending_ts` optional ISO string, `pane_alive`) and a
+tz-aware UTC `now`. Branch conditions, in short-circuit order:
 
 1. `enabled` false → false.
 2. `pane_id` absent **or** `pane_alive` false → false (unplaced or dead/missing
@@ -2034,7 +2025,6 @@ conditions, in short-circuit order:
 4. Otherwise → true. A never-pinged (`last_ping_at` absent) live, enabled member
    is **immediately due** — the elapsed check is skipped entirely.
 
-`is_director` is **not** consulted (retained only for status labeling);
 `pending_count` and `oldest_pending_ts` are **not** consulted (due-ness is
 interval-driven). The monitoring member never appears as a `target` — it is
 the unenrolled watcher.
@@ -2784,10 +2774,10 @@ numbered files `V<N>__<slug>.sql` appended to the chain; the chain stays
 contiguous from 1 with exactly one baseline.
 
 A fresh DB starts with **no rows in any application table** (only
-`refinery_schema_history` holds its per-migration rows); monitor enrollment is written
-at runtime (the Director at 180s by `create_fleet`, pane-bound members at 720s
-by `register_member`, §6.2), never seeded by the schema. `asset_installs` rows
-are written at install time, not by the schema.
+`refinery_schema_history` holds its per-migration rows); monitor enrollment is
+written at runtime (pane-bound members at 720s by `register_member`, §6.2),
+never seeded by the schema. `asset_installs` rows are written at install time,
+not by the schema.
 
 **`setup` db-migration driver** (the db half of `setup`, §6.3). Procedure: (1)
 validate the URL scheme is `sqlite` (§6.1); (2) extract the DB file path — if
@@ -2965,7 +2955,7 @@ specified in the cited section):
 - **Member kind** unified in §5.4 (three distinct representations, not one enum).
 - **`enabled`** stored INTEGER 0/1, exposed as boolean at the broker boundary
   (§6.1/§6.2/§6.6/§6.8).
-- **Policy tunables** (180/720/3/15) have a single home in the broker module,
+- **Policy tunables** (720/3/15) have a single home in the broker module,
   re-exported by the monitor module.
 - **`settings` singleton** is config-module-owned and reachable from every
   module, not webui-local.

--- a/cafleet/migrations/V2__drop_director_monitor_enrollment.sql
+++ b/cafleet/migrations/V2__drop_director_monitor_enrollment.sql
@@ -1,0 +1,8 @@
+-- Drop the root Director from the monitor watched set: ordinary pane-bound
+-- members are the sole enrollment class (SPEC.md §6.2). Soft-deleted fleets
+-- already had their monitor_config rows cascaded away by delete_fleet.
+
+DELETE FROM monitor_config
+WHERE member_id IN (
+    SELECT director_member_id FROM fleets WHERE director_member_id IS NOT NULL
+);

--- a/cafleet/src/broker/fleets.rs
+++ b/cafleet/src/broker/fleets.rs
@@ -5,7 +5,7 @@
 use rusqlite::{Connection, OptionalExtension, params};
 use serde_json::{Value, json};
 
-use super::members::{DIRECTOR_PING_INTERVAL_SECONDS, db_err, enroll, member_card};
+use super::members::{db_err, member_card};
 use crate::error::CafleetError;
 use crate::time::{format_utc, now_utc};
 
@@ -43,7 +43,7 @@ pub(crate) fn fetch_fleet(
 }
 
 /// Atomic fleet + root-Director bootstrap: fleet row → Director member →
-/// placement → `director_member_id` backfill → Director enrollment at 180 s.
+/// placement → `director_member_id` backfill.
 pub fn create_fleet(
     conn: &mut Connection,
     name: Option<&str>,
@@ -89,7 +89,6 @@ pub fn create_fleet(
         params![director_id, fleet_id],
     )
     .map_err(db_err)?;
-    enroll(&tx, director_id, DIRECTOR_PING_INTERVAL_SECONDS)?;
     tx.commit().map_err(db_err)?;
     Ok(json!({
         "fleet_id": fleet_id,

--- a/cafleet/src/broker/fleets.rs
+++ b/cafleet/src/broker/fleets.rs
@@ -250,16 +250,16 @@ mod tests {
     }
 
     #[test]
-    fn create_fleet_enrolls_the_director_at_180() {
+    fn create_fleet_leaves_the_director_unenrolled() {
         let dir = TempDir::new().unwrap();
         let mut conn = migrated_conn(&dir);
         let (fleet_id, director_id) = create_fleet(&mut conn, "alpha");
-        let config = broker::get_monitor_config(&conn, fleet_id, director_id)
-            .unwrap()
-            .unwrap();
-        assert_eq!(config["interval_seconds"], 180);
-        assert_eq!(config["enabled"], true);
-        assert_eq!(config["last_ping_at"], serde_json::Value::Null);
+        assert!(
+            broker::get_monitor_config(&conn, fleet_id, director_id)
+                .unwrap()
+                .is_none(),
+            "the root Director is never enrolled"
+        );
     }
 
     #[test]

--- a/cafleet/src/broker/members.rs
+++ b/cafleet/src/broker/members.rs
@@ -12,9 +12,8 @@ use crate::time::{format_utc, now_utc, parse_lenient};
 
 pub const MONITORING_MEMBER_KIND: &str = "monitoring-member";
 
-/// The auto-enrollment ping cadences (SPEC §6.2) — the policy tunables'
+/// The auto-enrollment ping cadence (SPEC §6.2) — the policy tunables'
 /// single home, re-exported by the monitor module.
-pub const DIRECTOR_PING_INTERVAL_SECONDS: i64 = 180;
 pub const MEMBER_PING_INTERVAL_SECONDS: i64 = 720;
 
 #[derive(Debug, Clone)]
@@ -84,14 +83,10 @@ pub(crate) fn placement_value(
     })
 }
 
-pub(crate) fn enroll(
-    conn: &Connection,
-    member_id: i64,
-    interval_seconds: i64,
-) -> Result<(), CafleetError> {
+pub(crate) fn enroll(conn: &Connection, member_id: i64) -> Result<(), CafleetError> {
     conn.execute(
         "INSERT INTO monitor_config (member_id, interval_seconds, enabled) VALUES (?1, ?2, 1)",
-        params![member_id, interval_seconds],
+        params![member_id, MEMBER_PING_INTERVAL_SECONDS],
     )
     .map_err(db_err)?;
     Ok(())
@@ -189,7 +184,7 @@ pub fn register_member(
         )
         .map_err(db_err)?;
         if !is_monitor {
-            enroll(&tx, member_id, MEMBER_PING_INTERVAL_SECONDS)?;
+            enroll(&tx, member_id)?;
         }
     }
     tx.commit().map_err(db_err)?;

--- a/cafleet/src/broker/monitor.rs
+++ b/cafleet/src/broker/monitor.rs
@@ -245,7 +245,6 @@ pub fn list_monitor_targets(conn: &Connection, fleet_id: i64) -> Result<Vec<Valu
     let mut stmt = conn
         .prepare(&format!(
             "SELECT m.member_id, \
-                    (m.member_id = (SELECT director_member_id FROM fleets WHERE fleet_id=?1)), \
                     m.name, p.mux_pane_id, p.coding_agent, \
                     c.interval_seconds, c.last_ping_at, c.enabled, c.last_stall_check_at, \
                     {PENDING_COUNT_SUBQUERY}, {OLDEST_PENDING_SUBQUERY} \
@@ -259,16 +258,15 @@ pub fn list_monitor_targets(conn: &Connection, fleet_id: i64) -> Result<Vec<Valu
         .query_map([fleet_id], |row| {
             Ok(json!({
                 "member_id": row.get::<_, i64>(0)?,
-                "is_director": row.get::<_, bool>(1)?,
-                "name": row.get::<_, String>(2)?,
-                "pane_id": row.get::<_, Option<String>>(3)?,
-                "coding_agent": row.get::<_, Option<String>>(4)?,
-                "interval_seconds": row.get::<_, i64>(5)?,
-                "last_ping_at": row.get::<_, Option<String>>(6)?,
-                "enabled": row.get::<_, i64>(7)? != 0,
-                "last_stall_check_at": row.get::<_, Option<String>>(8)?,
-                "pending_count": row.get::<_, i64>(9)?,
-                "oldest_pending_ts": row.get::<_, Option<String>>(10)?,
+                "name": row.get::<_, String>(1)?,
+                "pane_id": row.get::<_, Option<String>>(2)?,
+                "coding_agent": row.get::<_, Option<String>>(3)?,
+                "interval_seconds": row.get::<_, i64>(4)?,
+                "last_ping_at": row.get::<_, Option<String>>(5)?,
+                "enabled": row.get::<_, i64>(6)? != 0,
+                "last_stall_check_at": row.get::<_, Option<String>>(7)?,
+                "pending_count": row.get::<_, i64>(8)?,
+                "oldest_pending_ts": row.get::<_, Option<String>>(9)?,
             }))
         })
         .map_err(db_err)?
@@ -439,7 +437,6 @@ pub fn monitor_members_payload(
     let mut stmt = conn
         .prepare(&format!(
             "SELECT m.member_id, m.name, \
-                    (m.member_id = (SELECT director_member_id FROM fleets WHERE fleet_id=?1)), \
                     c.interval_seconds, c.enabled, c.last_ping_at, \
                     {PENDING_COUNT_SUBQUERY}, {OLDEST_PENDING_SUBQUERY} \
              FROM monitor_config c JOIN members m ON m.member_id=c.member_id \
@@ -452,12 +449,11 @@ pub fn monitor_members_payload(
             Ok((
                 row.get::<_, i64>(0)?,
                 row.get::<_, String>(1)?,
-                row.get::<_, bool>(2)?,
+                row.get::<_, i64>(2)?,
                 row.get::<_, i64>(3)?,
-                row.get::<_, i64>(4)?,
-                row.get::<_, Option<String>>(5)?,
-                row.get::<_, i64>(6)?,
-                row.get::<_, Option<String>>(7)?,
+                row.get::<_, Option<String>>(4)?,
+                row.get::<_, i64>(5)?,
+                row.get::<_, Option<String>>(6)?,
             ))
         })
         .map_err(db_err)?
@@ -469,7 +465,6 @@ pub fn monitor_members_payload(
             |(
                 member_id,
                 name,
-                is_director,
                 interval_seconds,
                 enabled,
                 last_ping_at,
@@ -479,7 +474,6 @@ pub fn monitor_members_payload(
                 json!({
                     "member_id": member_id,
                     "name": name,
-                    "role": if is_director { "director" } else { "member" },
                     "interval_seconds": interval_seconds,
                     "enabled": enabled != 0,
                     "last_ping_at": last_ping_at,
@@ -521,8 +515,9 @@ mod tests {
     fn get_monitor_config_is_none_for_unenrolled_or_cross_fleet_members() {
         let dir = TempDir::new().unwrap();
         let mut conn = migrated_conn(&dir);
-        let (fleet_a, director_a) = create_fleet(&mut conn, "alpha");
+        let (fleet_a, _) = create_fleet(&mut conn, "alpha");
         let (fleet_b, _) = create_fleet(&mut conn, "beta");
+        let member_a = register(&mut conn, fleet_a, "worker", Some("%2"));
         let monitor_id = broker::register_member(
             &mut conn,
             fleet_a,
@@ -542,7 +537,7 @@ mod tests {
                 .is_none()
         );
         assert!(
-            broker::get_monitor_config(&conn, fleet_b, director_a)
+            broker::get_monitor_config(&conn, fleet_b, member_a)
                 .unwrap()
                 .is_none(),
             "the fleet gate hides an enrolled member of another fleet"
@@ -553,16 +548,16 @@ mod tests {
     fn update_monitor_config_applies_partial_updates() {
         let dir = TempDir::new().unwrap();
         let mut conn = migrated_conn(&dir);
-        let (fleet_id, director_id) = create_fleet(&mut conn, "alpha");
+        let (fleet_id, _) = create_fleet(&mut conn, "alpha");
+        let member_id = register(&mut conn, fleet_id, "worker", Some("%2"));
 
         let updated =
-            broker::update_monitor_config(&mut conn, fleet_id, director_id, Some(300), None)
-                .unwrap();
+            broker::update_monitor_config(&mut conn, fleet_id, member_id, Some(300), None).unwrap();
         assert_eq!(updated["interval_seconds"], 300);
         assert_eq!(updated["enabled"], true, "unspecified field untouched");
 
         let updated =
-            broker::update_monitor_config(&mut conn, fleet_id, director_id, None, Some(false))
+            broker::update_monitor_config(&mut conn, fleet_id, member_id, None, Some(false))
                 .unwrap();
         assert_eq!(updated["interval_seconds"], 300);
         assert_eq!(updated["enabled"], false);
@@ -572,16 +567,17 @@ mod tests {
     fn disabling_clears_the_stall_check_stamp() {
         let dir = TempDir::new().unwrap();
         let mut conn = migrated_conn(&dir);
-        let (fleet_id, director_id) = create_fleet(&mut conn, "alpha");
+        let (fleet_id, _) = create_fleet(&mut conn, "alpha");
+        let member_id = register(&mut conn, fleet_id, "worker", Some("%2"));
         let when = format_utc(base_time());
-        broker::record_monitor_dispatch(&mut conn, &[], &[director_id], &when).unwrap();
-        let config = broker::get_monitor_config(&conn, fleet_id, director_id)
+        broker::record_monitor_dispatch(&mut conn, &[], &[member_id], &when).unwrap();
+        let config = broker::get_monitor_config(&conn, fleet_id, member_id)
             .unwrap()
             .unwrap();
         assert_eq!(config["last_stall_check_at"], when);
 
-        broker::update_monitor_config(&mut conn, fleet_id, director_id, None, Some(false)).unwrap();
-        let config = broker::get_monitor_config(&conn, fleet_id, director_id)
+        broker::update_monitor_config(&mut conn, fleet_id, member_id, None, Some(false)).unwrap();
+        let config = broker::get_monitor_config(&conn, fleet_id, member_id)
             .unwrap()
             .unwrap();
         assert_eq!(config["last_stall_check_at"], Value::Null);
@@ -605,33 +601,34 @@ mod tests {
     fn list_monitor_configs_returns_every_enrolled_member_with_bool_enabled() {
         let dir = TempDir::new().unwrap();
         let mut conn = migrated_conn(&dir);
-        let (fleet_id, director_id) = create_fleet(&mut conn, "alpha");
-        let member_id = register(&mut conn, fleet_id, "worker", Some("%2"));
+        let (fleet_id, _) = create_fleet(&mut conn, "alpha");
+        let first_id = register(&mut conn, fleet_id, "worker", Some("%2"));
+        let second_id = register(&mut conn, fleet_id, "helper", Some("%4"));
 
         let configs = broker::list_monitor_configs(&conn, fleet_id).unwrap();
         assert_eq!(configs.len(), 2);
         for config in &configs {
             assert!(config["enabled"].is_boolean());
+            assert_eq!(
+                config["interval_seconds"], 720,
+                "the single enrollment class"
+            );
         }
-        let intervals: Vec<i64> = configs
-            .iter()
-            .map(|c| c["interval_seconds"].as_i64().unwrap())
-            .collect();
-        assert!(intervals.contains(&180) && intervals.contains(&720));
-        assert!(configs.iter().any(|c| c["member_id"] == director_id));
-        assert!(configs.iter().any(|c| c["member_id"] == member_id));
+        assert!(configs.iter().any(|c| c["member_id"] == first_id));
+        assert!(configs.iter().any(|c| c["member_id"] == second_id));
     }
 
     #[test]
     fn record_pings_stamps_last_ping_at_and_ignores_an_empty_list() {
         let dir = TempDir::new().unwrap();
         let mut conn = migrated_conn(&dir);
-        let (fleet_id, director_id) = create_fleet(&mut conn, "alpha");
+        let (fleet_id, _) = create_fleet(&mut conn, "alpha");
+        let member_id = register(&mut conn, fleet_id, "worker", Some("%2"));
         let when = format_utc(base_time());
 
         broker::record_pings(&mut conn, &[], &when).unwrap();
-        broker::record_pings(&mut conn, &[director_id], &when).unwrap();
-        let config = broker::get_monitor_config(&conn, fleet_id, director_id)
+        broker::record_pings(&mut conn, &[member_id], &when).unwrap();
+        let config = broker::get_monitor_config(&conn, fleet_id, member_id)
             .unwrap()
             .unwrap();
         assert_eq!(config["last_ping_at"], when);
@@ -641,49 +638,52 @@ mod tests {
     fn record_monitor_dispatch_commits_both_cadences_atomically() {
         let dir = TempDir::new().unwrap();
         let mut conn = migrated_conn(&dir);
-        let (fleet_id, director_id) = create_fleet(&mut conn, "alpha");
-        let member_id = register(&mut conn, fleet_id, "worker", Some("%2"));
+        let (fleet_id, _) = create_fleet(&mut conn, "alpha");
+        let pinged_id = register(&mut conn, fleet_id, "worker", Some("%2"));
+        let checked_id = register(&mut conn, fleet_id, "helper", Some("%4"));
         let when = format_utc(base_time());
 
-        broker::record_monitor_dispatch(&mut conn, &[director_id], &[member_id], &when).unwrap();
+        broker::record_monitor_dispatch(&mut conn, &[pinged_id], &[checked_id], &when).unwrap();
 
-        let director = broker::get_monitor_config(&conn, fleet_id, director_id)
+        let pinged = broker::get_monitor_config(&conn, fleet_id, pinged_id)
             .unwrap()
             .unwrap();
-        assert_eq!(director["last_ping_at"], when);
-        assert_eq!(director["last_stall_check_at"], Value::Null);
-        let member = broker::get_monitor_config(&conn, fleet_id, member_id)
+        assert_eq!(pinged["last_ping_at"], when);
+        assert_eq!(pinged["last_stall_check_at"], Value::Null);
+        let checked = broker::get_monitor_config(&conn, fleet_id, checked_id)
             .unwrap()
             .unwrap();
-        assert_eq!(member["last_ping_at"], Value::Null);
-        assert_eq!(member["last_stall_check_at"], when);
+        assert_eq!(checked["last_ping_at"], Value::Null);
+        assert_eq!(checked["last_stall_check_at"], when);
     }
 
     #[test]
     fn reconcile_monitor_lifecycle_clears_stamps_for_listed_fleet_members_only() {
         let dir = TempDir::new().unwrap();
         let mut conn = migrated_conn(&dir);
-        let (fleet_a, director_a) = create_fleet(&mut conn, "alpha");
+        let (fleet_a, _) = create_fleet(&mut conn, "alpha");
         let member_a = register(&mut conn, fleet_a, "worker", Some("%2"));
-        let (fleet_b, director_b) = create_fleet(&mut conn, "beta");
+        let keeper_a = register(&mut conn, fleet_a, "helper", Some("%4"));
+        let (fleet_b, _) = create_fleet(&mut conn, "beta");
+        let member_b = register(&mut conn, fleet_b, "worker", Some("%5"));
         let when = format_utc(base_time());
-        broker::record_monitor_dispatch(&mut conn, &[], &[director_a, member_a, director_b], &when)
+        broker::record_monitor_dispatch(&mut conn, &[], &[keeper_a, member_a, member_b], &when)
             .unwrap();
 
-        broker::reconcile_monitor_lifecycle(&mut conn, fleet_a, &[member_a, director_b]).unwrap();
+        broker::reconcile_monitor_lifecycle(&mut conn, fleet_a, &[member_a, member_b]).unwrap();
 
         let cleared = broker::get_monitor_config(&conn, fleet_a, member_a)
             .unwrap()
             .unwrap();
         assert_eq!(cleared["last_stall_check_at"], Value::Null);
-        let kept = broker::get_monitor_config(&conn, fleet_a, director_a)
+        let kept = broker::get_monitor_config(&conn, fleet_a, keeper_a)
             .unwrap()
             .unwrap();
         assert_eq!(
             kept["last_stall_check_at"], when,
             "unlisted members keep their stamp"
         );
-        let foreign = broker::get_monitor_config(&conn, fleet_b, director_b)
+        let foreign = broker::get_monitor_config(&conn, fleet_b, member_b)
             .unwrap()
             .unwrap();
         assert_eq!(
@@ -712,29 +712,51 @@ mod tests {
         .unwrap();
 
         let targets = broker::list_monitor_targets(&conn, fleet_id).unwrap();
-        assert_eq!(targets.len(), 2, "the monitoring member is never a target");
+        assert_eq!(
+            targets.len(),
+            1,
+            "only the ordinary member is watched, got: {targets:?}"
+        );
+        assert!(
+            !targets.iter().any(|t| t["member_id"] == director_id),
+            "the root Director is never a target"
+        );
 
-        let director = targets
-            .iter()
-            .find(|t| t["member_id"] == director_id)
-            .unwrap();
-        assert_eq!(director["is_director"], true);
-        assert_eq!(director["name"], "Director");
-        assert_eq!(director["pane_id"], "%0");
-        assert_eq!(director["coding_agent"], "claude");
-        assert_eq!(director["interval_seconds"], 180);
-        assert_eq!(director["last_ping_at"], Value::Null);
-        assert_eq!(director["enabled"], true);
-        assert_eq!(director["last_stall_check_at"], Value::Null);
-        assert_eq!(director["pending_count"], 0);
-        assert_eq!(director["oldest_pending_ts"], Value::Null);
-
-        let worker = targets
-            .iter()
-            .find(|t| t["member_id"] == member_id)
-            .unwrap();
-        assert_eq!(worker["is_director"], false);
+        let worker = &targets[0];
+        assert_eq!(worker["member_id"], member_id);
+        assert_eq!(worker["name"], "worker");
+        assert_eq!(worker["pane_id"], "%2");
+        assert_eq!(worker["coding_agent"], "claude");
         assert_eq!(worker["interval_seconds"], 720);
+        assert_eq!(worker["last_ping_at"], Value::Null);
+        assert_eq!(worker["enabled"], true);
+        assert_eq!(worker["last_stall_check_at"], Value::Null);
+        assert_eq!(worker["pending_count"], 0);
+        assert_eq!(worker["oldest_pending_ts"], Value::Null);
+
+        let keys: std::collections::BTreeSet<&str> = worker
+            .as_object()
+            .unwrap()
+            .keys()
+            .map(String::as_str)
+            .collect();
+        assert_eq!(
+            keys,
+            [
+                "member_id",
+                "name",
+                "pane_id",
+                "coding_agent",
+                "interval_seconds",
+                "last_ping_at",
+                "enabled",
+                "last_stall_check_at",
+                "pending_count",
+                "oldest_pending_ts",
+            ]
+            .into(),
+            "the scan-row key set is pinned, with no is_director key"
+        );
     }
 
     #[test]
@@ -978,31 +1000,40 @@ mod tests {
     }
 
     #[test]
-    fn members_payload_labels_roles_and_truncates_ages() {
+    fn members_payload_truncates_ages() {
         let dir = TempDir::new().unwrap();
         let mut conn = migrated_conn(&dir);
         let (fleet_id, director_id) = create_fleet(&mut conn, "alpha");
         let member_id = register(&mut conn, fleet_id, "worker", Some("%2"));
+        let pinged_id = register(&mut conn, fleet_id, "helper", Some("%4"));
         let notifier = FakeNotifier::succeeding();
         common::send(&mut conn, &notifier, fleet_id, director_id, member_id, "hi");
 
         let now = Utc::now() + Duration::seconds(10);
         let ping_when = format_utc(now - Duration::seconds(30));
-        broker::record_pings(&mut conn, &[director_id], &ping_when).unwrap();
+        broker::record_pings(&mut conn, &[pinged_id], &ping_when).unwrap();
 
         let rows = broker::monitor_members_payload(&conn, fleet_id, now).unwrap();
         assert_eq!(rows.len(), 2);
+        assert!(
+            !rows.iter().any(|r| r["member_id"] == director_id),
+            "the root Director has no row"
+        );
+        for row in &rows {
+            assert!(
+                row.as_object().unwrap().get("role").is_none(),
+                "the row carries no role key, got: {row}"
+            );
+        }
 
-        let director = rows.iter().find(|r| r["member_id"] == director_id).unwrap();
-        assert_eq!(director["role"], "director");
-        assert_eq!(director["last_ping_at"], ping_when);
-        assert_eq!(director["last_ping_age_seconds"], 30);
-        assert_eq!(director["pending_count"], 0);
-        assert_eq!(director["oldest_pending_ts"], Value::Null);
-        assert_eq!(director["oldest_pending_age_seconds"], Value::Null);
+        let pinged = rows.iter().find(|r| r["member_id"] == pinged_id).unwrap();
+        assert_eq!(pinged["last_ping_at"], ping_when);
+        assert_eq!(pinged["last_ping_age_seconds"], 30);
+        assert_eq!(pinged["pending_count"], 0);
+        assert_eq!(pinged["oldest_pending_ts"], Value::Null);
+        assert_eq!(pinged["oldest_pending_age_seconds"], Value::Null);
 
         let worker = rows.iter().find(|r| r["member_id"] == member_id).unwrap();
-        assert_eq!(worker["role"], "member");
         assert_eq!(worker["last_ping_at"], Value::Null);
         assert_eq!(worker["last_ping_age_seconds"], Value::Null);
         assert_eq!(worker["pending_count"], 1);

--- a/cafleet/src/db/mod.rs
+++ b/cafleet/src/db/mod.rs
@@ -42,7 +42,7 @@ pub fn migrate_to_head(conn: &mut Connection) -> Result<u32, CafleetError> {
     Ok(head_version())
 }
 
-/// The embedded chain's head version (`1` at cutover).
+/// The embedded chain's head version.
 pub fn head_version() -> u32 {
     migration_chain()
         .last()
@@ -136,11 +136,11 @@ mod tests {
     }
 
     #[test]
-    fn migrate_reaches_head_version_1_and_is_idempotent() {
+    fn migrate_reaches_head_version_2_and_is_idempotent() {
         let dir = TempDir::new().unwrap();
         let mut conn = connect(&temp_db_url(&dir)).unwrap();
-        assert_eq!(migrate_to_head(&mut conn).unwrap(), 1);
-        assert_eq!(migrate_to_head(&mut conn).unwrap(), 1);
+        assert_eq!(migrate_to_head(&mut conn).unwrap(), 2);
+        assert_eq!(migrate_to_head(&mut conn).unwrap(), 2);
     }
 
     #[test]
@@ -342,14 +342,14 @@ mod tests {
             .unwrap()
             .map(Result::unwrap)
             .collect();
-        assert_eq!(versions, vec![1]);
+        assert_eq!(versions, vec![1, 2]);
     }
 
     // The chain guard reads the refinery-embedded listing, not the filesystem:
     // `migration_chain()` returns the `(version, name)` pairs of the embedded
     // runner's migrations, sorted ascending.
     #[test]
-    fn migration_chain_is_contiguous_from_1_with_exactly_one_baseline_and_head_1() {
+    fn migration_chain_is_contiguous_from_1_with_exactly_one_baseline_and_head_2() {
         let chain = migration_chain();
         let versions: Vec<u32> = chain.iter().map(|(version, _)| *version).collect();
         let contiguous: Vec<u32> = (1..=versions.len() as u32).collect();
@@ -365,6 +365,6 @@ mod tests {
             chain.iter().all(|(_, name)| !name.is_empty()),
             "every migration carries a slug"
         );
-        assert_eq!(versions.last(), Some(&1), "expected head version is 1");
+        assert_eq!(versions.last(), Some(&2), "expected head version is 2");
     }
 }

--- a/cafleet/src/monitor/mod.rs
+++ b/cafleet/src/monitor/mod.rs
@@ -9,9 +9,8 @@
 //! ```text
 //! pub const DEFAULT_TICK_SECONDS: i64 = 5;
 //! // Policy tunables re-exported from their single broker home:
-//! pub use crate::broker::{DIRECTOR_PING_INTERVAL_SECONDS /* 180 */,
-//!     MEMBER_PING_INTERVAL_SECONDS /* 720 */, MONITOR_STALE_FACTOR /* 3 */,
-//!     MONITOR_STALE_FLOOR_SECONDS /* 15 */};
+//! pub use crate::broker::{MEMBER_PING_INTERVAL_SECONDS /* 720 */,
+//!     MONITOR_STALE_FACTOR /* 3 */, MONITOR_STALE_FLOOR_SECONDS /* 15 */};
 //!
 //! // What the tick consumes from the resolved backend.
 //! pub trait MonitorMux {
@@ -51,8 +50,7 @@ use serde_json::{Value, json};
 
 use crate::broker;
 pub use crate::broker::{
-    DIRECTOR_PING_INTERVAL_SECONDS, MEMBER_PING_INTERVAL_SECONDS, MONITOR_STALE_FACTOR,
-    MONITOR_STALE_FLOOR_SECONDS,
+    MEMBER_PING_INTERVAL_SECONDS, MONITOR_STALE_FACTOR, MONITOR_STALE_FLOOR_SECONDS,
 };
 use crate::error::CafleetError;
 use crate::multiplexer::{Multiplexer, MultiplexerError};
@@ -277,7 +275,6 @@ pub fn monitor_tick(
         due.push(json!({
             "member_id": member_id,
             "name": target["name"],
-            "is_director": target["is_director"],
             "coding_agent": target["coding_agent"],
             "wake_reasons": reasons,
         }));
@@ -288,17 +285,11 @@ pub fn monitor_tick(
         let director_id = fleet["director_member_id"]
             .as_i64()
             .expect("a live fleet records its Director");
-        let director_agent = targets
-            .iter()
-            .find(|target| target["member_id"] == director_id)
-            .and_then(|target| target["coding_agent"].as_str().map(str::to_string))
-            .or_else(|| {
-                broker::get_member(conn, director_id, fleet_id)
-                    .ok()
-                    .flatten()
-                    .and_then(|d| d["placement"]["coding_agent"].as_str().map(str::to_string))
-            })
-            .unwrap_or_default();
+        let director_agent = broker::get_member(conn, director_id, fleet_id)?
+            .expect("a live fleet's Director is registered")["placement"]["coding_agent"]
+            .as_str()
+            .expect("the root Director is pane-bound")
+            .to_string();
         let director = json!({"member_id": director_id, "coding_agent": director_agent});
         let watcher_pane = watcher["pane_id"].as_str().expect("the watcher has a pane");
         woke = mux
@@ -432,11 +423,13 @@ mod tests {
     use tempfile::TempDir;
 
     use crate::broker;
-    use crate::broker::test_support::{FakeNotifier, create_fleet, migrated_conn, placement};
+    use crate::broker::test_support::{
+        FakeNotifier, create_fleet, migrated_conn, placement, register,
+    };
     use crate::monitor::{
-        DEFAULT_TICK_SECONDS, DIRECTOR_PING_INTERVAL_SECONDS, MEMBER_PING_INTERVAL_SECONDS,
-        MONITOR_STALE_FACTOR, MONITOR_STALE_FLOOR_SECONDS, MonitorMux, MonitorTickState,
-        TickResult, monitor_tick, run_monitor_loop, should_ping,
+        DEFAULT_TICK_SECONDS, MEMBER_PING_INTERVAL_SECONDS, MONITOR_STALE_FACTOR,
+        MONITOR_STALE_FLOOR_SECONDS, MonitorMux, MonitorTickState, TickResult, monitor_tick,
+        run_monitor_loop, should_ping,
     };
     use crate::multiplexer::MultiplexerError;
     use crate::time::format_utc;
@@ -501,22 +494,12 @@ mod tests {
         }
     }
 
-    /// Fleet with a pane-bound worker (enrolled @720) and a monitoring member
-    /// on `%3`; the Director sits on `%0`.
-    fn monitored_fleet(conn: &mut rusqlite::Connection) -> (i64, i64, i64) {
+    /// Fleet with two pane-bound workers (enrolled @720) on `%2` and `%4` and a
+    /// monitoring member on `%3`; the unenrolled Director sits on `%0`.
+    fn monitored_fleet(conn: &mut rusqlite::Connection) -> (i64, i64, i64, i64) {
         let (fleet_id, director_id) = create_fleet(conn, "alpha");
-        let member_id = broker::register_member(
-            conn,
-            fleet_id,
-            "worker",
-            "d",
-            &[],
-            Some(&placement(Some("%2"))),
-            None,
-        )
-        .unwrap()["member_id"]
-            .as_i64()
-            .unwrap();
+        let member_id = register(conn, fleet_id, "worker", Some("%2"));
+        let second_id = register(conn, fleet_id, "helper", Some("%4"));
         broker::register_member(
             conn,
             fleet_id,
@@ -527,7 +510,7 @@ mod tests {
             Some("monitoring-member"),
         )
         .unwrap();
-        (fleet_id, director_id, member_id)
+        (fleet_id, director_id, member_id, second_id)
     }
 
     fn claim(conn: &mut rusqlite::Connection, fleet_id: i64, pid: i64, now: DateTime<Utc>) {
@@ -575,7 +558,6 @@ mod tests {
         #[test]
         fn the_policy_tunables_are_pinned() {
             assert_eq!(DEFAULT_TICK_SECONDS, 5);
-            assert_eq!(DIRECTOR_PING_INTERVAL_SECONDS, 180);
             assert_eq!(MEMBER_PING_INTERVAL_SECONDS, 720);
             assert_eq!(MONITOR_STALE_FACTOR, 3);
             assert_eq!(MONITOR_STALE_FLOOR_SECONDS, 15);
@@ -595,7 +577,6 @@ mod tests {
             json!({
                 "member_id": 4,
                 "name": "worker",
-                "is_director": false,
                 "pane_id": pane_id,
                 "coding_agent": "claude",
                 "interval_seconds": interval,
@@ -656,8 +637,8 @@ mod tests {
         fn a_displaced_or_unclaimed_heartbeat_stops_the_loop() {
             let dir = TempDir::new().unwrap();
             let mut conn = migrated_conn(&dir);
-            let (fleet_id, _, _) = monitored_fleet(&mut conn);
-            let mux = FakeMux::with_live_panes(&["%0", "%2", "%3"]);
+            let (fleet_id, _, _, _) = monitored_fleet(&mut conn);
+            let mux = FakeMux::with_live_panes(&["%0", "%2", "%3", "%4"]);
             let mut state = MonitorTickState::default();
             let now = base_now();
 
@@ -674,7 +655,7 @@ mod tests {
         fn a_deleted_fleet_stops_the_loop_after_the_heartbeat() {
             let dir = TempDir::new().unwrap();
             let mut conn = migrated_conn(&dir);
-            let (fleet_id, _, _) = monitored_fleet(&mut conn);
+            let (fleet_id, _, _, _) = monitored_fleet(&mut conn);
             let now = base_now();
             claim(&mut conn, fleet_id, own_pid(), now);
             conn.execute(
@@ -684,7 +665,7 @@ mod tests {
             )
             .unwrap();
 
-            let mux = FakeMux::with_live_panes(&["%0", "%2", "%3"]);
+            let mux = FakeMux::with_live_panes(&["%0", "%2", "%3", "%4"]);
             let mut state = MonitorTickState::default();
             let (result, _) = tick(&mut conn, &mux, &mut state, fleet_id, own_pid(), 0, now);
             assert!(matches!(result, TickResult::Stop));
@@ -694,10 +675,10 @@ mod tests {
         fn due_members_produce_one_wake_and_gated_ledger_writes() {
             let dir = TempDir::new().unwrap();
             let mut conn = migrated_conn(&dir);
-            let (fleet_id, director_id, member_id) = monitored_fleet(&mut conn);
+            let (fleet_id, director_id, member_id, second_id) = monitored_fleet(&mut conn);
             let now = base_now();
             claim(&mut conn, fleet_id, own_pid(), now);
-            let mux = FakeMux::with_live_panes(&["%0", "%2", "%3"]);
+            let mux = FakeMux::with_live_panes(&["%0", "%2", "%3", "%4"]);
             let mut state = MonitorTickState::default();
 
             let (result, echo) = tick(&mut conn, &mux, &mut state, fleet_id, own_pid(), 0, now);
@@ -707,31 +688,34 @@ mod tests {
             assert_eq!(wakes.len(), 1, "at most one synchronized wake per tick");
             let (pane, due, director) = &wakes[0];
             assert_eq!(pane, "%3", "the watcher's own pane");
-            assert_eq!(due.len(), 2, "director + worker, never the watcher");
+            assert_eq!(due.len(), 2, "both workers, never the watcher");
             assert_eq!(director["member_id"], director_id);
             assert_eq!(director["coding_agent"], "claude");
-            let director_entry = due.iter().find(|d| d["member_id"] == director_id).unwrap();
-            assert_eq!(director_entry["is_director"], true);
-            assert_eq!(director_entry["wake_reasons"], json!(["interval"]));
+            assert!(
+                due.iter().all(|d| d["member_id"] != director_id),
+                "the Director is never a due entry, got: {due:?}"
+            );
             let worker_entry = due.iter().find(|d| d["member_id"] == member_id).unwrap();
             assert_eq!(worker_entry["wake_reasons"], json!(["interval"]));
+            let second_entry = due.iter().find(|d| d["member_id"] == second_id).unwrap();
+            assert_eq!(second_entry["wake_reasons"], json!(["interval"]));
             drop(wakes);
 
             let iso = format_utc(now);
-            assert!(
-                echo.contains(&format!(
-                    "{iso} due member {director_id} (Director) [interval] -> wake monitor"
-                )),
-                "got: {echo}"
-            );
             assert!(
                 echo.contains(&format!(
                     "{iso} due member {member_id} (worker) [interval] -> wake monitor"
                 )),
                 "got: {echo}"
             );
-            assert_eq!(last_ping(&conn, fleet_id, director_id), json!(iso));
+            assert!(
+                echo.contains(&format!(
+                    "{iso} due member {second_id} (helper) [interval] -> wake monitor"
+                )),
+                "got: {echo}"
+            );
             assert_eq!(last_ping(&conn, fleet_id, member_id), json!(iso));
+            assert_eq!(last_ping(&conn, fleet_id, second_id), json!(iso));
 
             let (_, echo) = tick(
                 &mut conn,
@@ -750,10 +734,10 @@ mod tests {
         fn a_failed_wake_records_nothing_and_retries_next_tick() {
             let dir = TempDir::new().unwrap();
             let mut conn = migrated_conn(&dir);
-            let (fleet_id, director_id, member_id) = monitored_fleet(&mut conn);
+            let (fleet_id, _, member_id, second_id) = monitored_fleet(&mut conn);
             let now = base_now();
             claim(&mut conn, fleet_id, own_pid(), now);
-            let mux = FakeMux::with_live_panes(&["%0", "%2", "%3"]);
+            let mux = FakeMux::with_live_panes(&["%0", "%2", "%3", "%4"]);
             mux.wake_ok.set(false);
             let mut state = MonitorTickState::default();
 
@@ -761,8 +745,8 @@ mod tests {
             assert!(matches!(result, TickResult::Continue));
             assert_eq!(mux.wake_count(), 1);
             assert!(echo.is_empty(), "no echo on a failed wake");
-            assert_eq!(last_ping(&conn, fleet_id, director_id), Value::Null);
             assert_eq!(last_ping(&conn, fleet_id, member_id), Value::Null);
+            assert_eq!(last_ping(&conn, fleet_id, second_id), Value::Null);
 
             mux.wake_ok.set(true);
             let (_, echo) = tick(
@@ -786,7 +770,7 @@ mod tests {
         fn dead_panes_are_reconciled_and_never_due() {
             let dir = TempDir::new().unwrap();
             let mut conn = migrated_conn(&dir);
-            let (fleet_id, director_id, member_id) = monitored_fleet(&mut conn);
+            let (fleet_id, _, member_id, second_id) = monitored_fleet(&mut conn);
             let now = base_now();
             claim(&mut conn, fleet_id, own_pid(), now);
             broker::record_monitor_dispatch(
@@ -797,7 +781,7 @@ mod tests {
             )
             .unwrap();
 
-            let mux = FakeMux::with_live_panes(&["%0", "%3"]);
+            let mux = FakeMux::with_live_panes(&["%0", "%3", "%4"]);
             let mut state = MonitorTickState::default();
             let (_, _) = tick(&mut conn, &mux, &mut state, fleet_id, own_pid(), 240, now);
 
@@ -808,7 +792,7 @@ mod tests {
                 due.iter().all(|d| d["member_id"] != member_id),
                 "the dead-pane worker is skipped"
             );
-            assert!(due.iter().any(|d| d["member_id"] == director_id));
+            assert!(due.iter().any(|d| d["member_id"] == second_id));
             drop(wakes);
 
             let config = broker::get_monitor_config(&conn, fleet_id, member_id)
@@ -825,10 +809,11 @@ mod tests {
         fn no_live_watcher_means_no_wake_and_no_ledger_writes() {
             let dir = TempDir::new().unwrap();
             let mut conn = migrated_conn(&dir);
-            let (fleet_id, director_id) = create_fleet(&mut conn, "alpha");
+            let (fleet_id, _) = create_fleet(&mut conn, "alpha");
+            let member_id = register(&mut conn, fleet_id, "worker", Some("%2"));
             let now = base_now();
             claim(&mut conn, fleet_id, own_pid(), now);
-            let mux = FakeMux::with_live_panes(&["%0"]);
+            let mux = FakeMux::with_live_panes(&["%0", "%2"]);
             let mut state = MonitorTickState::default();
 
             let (result, echo) = tick(&mut conn, &mux, &mut state, fleet_id, own_pid(), 0, now);
@@ -836,7 +821,7 @@ mod tests {
             assert_eq!(mux.wake_count(), 0);
             assert!(echo.is_empty());
             assert_eq!(
-                last_ping(&conn, fleet_id, director_id),
+                last_ping(&conn, fleet_id, member_id),
                 Value::Null,
                 "nothing is recorded without a wake"
             );
@@ -846,13 +831,13 @@ mod tests {
         fn stall_checks_are_durable_and_never_advance_last_ping_at() {
             let dir = TempDir::new().unwrap();
             let mut conn = migrated_conn(&dir);
-            let (fleet_id, director_id, member_id) = monitored_fleet(&mut conn);
+            let (fleet_id, _, member_id, second_id) = monitored_fleet(&mut conn);
             let now = base_now();
             claim(&mut conn, fleet_id, own_pid(), now);
             let recent = now - Duration::seconds(10);
-            ping_at(&mut conn, &[director_id, member_id], recent);
+            ping_at(&mut conn, &[member_id, second_id], recent);
 
-            let mux = FakeMux::with_live_panes(&["%0", "%2", "%3"]);
+            let mux = FakeMux::with_live_panes(&["%0", "%2", "%3", "%4"]);
             let mut state = MonitorTickState::default();
             let (_, echo) = tick(&mut conn, &mux, &mut state, fleet_id, own_pid(), 240, now);
 
@@ -902,16 +887,16 @@ mod tests {
         fn a_zero_stall_interval_disables_the_branch() {
             let dir = TempDir::new().unwrap();
             let mut conn = migrated_conn(&dir);
-            let (fleet_id, director_id, member_id) = monitored_fleet(&mut conn);
+            let (fleet_id, _, member_id, second_id) = monitored_fleet(&mut conn);
             let now = base_now();
             claim(&mut conn, fleet_id, own_pid(), now);
             ping_at(
                 &mut conn,
-                &[director_id, member_id],
+                &[member_id, second_id],
                 now - Duration::seconds(10),
             );
 
-            let mux = FakeMux::with_live_panes(&["%0", "%2", "%3"]);
+            let mux = FakeMux::with_live_panes(&["%0", "%2", "%3", "%4"]);
             let mut state = MonitorTickState::default();
             let (_, _) = tick(&mut conn, &mux, &mut state, fleet_id, own_pid(), 0, now);
             assert_eq!(mux.wake_count(), 0, "no stall-check wakes when disabled");
@@ -921,12 +906,12 @@ mod tests {
         fn a_done_transition_wakes_once_per_episode() {
             let dir = TempDir::new().unwrap();
             let mut conn = migrated_conn(&dir);
-            let (fleet_id, director_id, member_id) = monitored_fleet(&mut conn);
+            let (fleet_id, _, member_id, second_id) = monitored_fleet(&mut conn);
             let now = base_now();
             claim(&mut conn, fleet_id, own_pid(), now);
-            ping_at(&mut conn, &[director_id, member_id], now);
+            ping_at(&mut conn, &[member_id, second_id], now);
 
-            let mux = FakeMux::with_live_panes(&["%0", "%2", "%3"]);
+            let mux = FakeMux::with_live_panes(&["%0", "%2", "%3", "%4"]);
             mux.set_status("%2", "done");
             let mut state = MonitorTickState::default();
 
@@ -971,12 +956,12 @@ mod tests {
         fn a_blocked_transition_is_recorded_but_never_wakes() {
             let dir = TempDir::new().unwrap();
             let mut conn = migrated_conn(&dir);
-            let (fleet_id, director_id, member_id) = monitored_fleet(&mut conn);
+            let (fleet_id, _, member_id, second_id) = monitored_fleet(&mut conn);
             let now = base_now();
             claim(&mut conn, fleet_id, own_pid(), now);
-            ping_at(&mut conn, &[director_id, member_id], now);
+            ping_at(&mut conn, &[member_id, second_id], now);
 
-            let mux = FakeMux::with_live_panes(&["%0", "%2", "%3"]);
+            let mux = FakeMux::with_live_panes(&["%0", "%2", "%3", "%4"]);
             mux.set_status("%2", "blocked");
             let mut state = MonitorTickState::default();
             let (_, _) = tick(
@@ -1011,12 +996,12 @@ mod tests {
         fn a_failed_wake_leaves_the_done_episode_unconsumed() {
             let dir = TempDir::new().unwrap();
             let mut conn = migrated_conn(&dir);
-            let (fleet_id, director_id, member_id) = monitored_fleet(&mut conn);
+            let (fleet_id, _, member_id, second_id) = monitored_fleet(&mut conn);
             let now = base_now();
             claim(&mut conn, fleet_id, own_pid(), now);
-            ping_at(&mut conn, &[director_id, member_id], now);
+            ping_at(&mut conn, &[member_id, second_id], now);
 
-            let mux = FakeMux::with_live_panes(&["%0", "%2", "%3"]);
+            let mux = FakeMux::with_live_panes(&["%0", "%2", "%3", "%4"]);
             mux.set_status("%2", "done");
             mux.wake_ok.set(false);
             let mut state = MonitorTickState::default();
@@ -1051,7 +1036,7 @@ mod tests {
         fn unacked_annotates_but_never_adds_a_row() {
             let dir = TempDir::new().unwrap();
             let mut conn = migrated_conn(&dir);
-            let (fleet_id, director_id, member_id) = monitored_fleet(&mut conn);
+            let (fleet_id, director_id, member_id, second_id) = monitored_fleet(&mut conn);
             let now = base_now();
             claim(&mut conn, fleet_id, own_pid(), now);
             let notifier = FakeNotifier::succeeding();
@@ -1068,9 +1053,9 @@ mod tests {
                 [format_utc(now - Duration::seconds(800))],
             )
             .unwrap();
-            ping_at(&mut conn, &[director_id], now);
+            ping_at(&mut conn, &[second_id], now);
 
-            let mux = FakeMux::with_live_panes(&["%0", "%2", "%3"]);
+            let mux = FakeMux::with_live_panes(&["%0", "%2", "%3", "%4"]);
             let mut state = MonitorTickState::default();
             let (_, echo) = tick(&mut conn, &mux, &mut state, fleet_id, own_pid(), 0, now);
 
@@ -1099,7 +1084,7 @@ mod tests {
         fn a_young_pending_delivery_is_not_annotated() {
             let dir = TempDir::new().unwrap();
             let mut conn = migrated_conn(&dir);
-            let (fleet_id, director_id, member_id) = monitored_fleet(&mut conn);
+            let (fleet_id, director_id, member_id, second_id) = monitored_fleet(&mut conn);
             let now = base_now();
             claim(&mut conn, fleet_id, own_pid(), now);
             let notifier = FakeNotifier::succeeding();
@@ -1116,9 +1101,9 @@ mod tests {
                 [format_utc(now - Duration::seconds(30))],
             )
             .unwrap();
-            ping_at(&mut conn, &[director_id], now);
+            ping_at(&mut conn, &[second_id], now);
 
-            let mux = FakeMux::with_live_panes(&["%0", "%2", "%3"]);
+            let mux = FakeMux::with_live_panes(&["%0", "%2", "%3", "%4"]);
             let mut state = MonitorTickState::default();
             let (_, _) = tick(&mut conn, &mux, &mut state, fleet_id, own_pid(), 0, now);
 
@@ -1139,10 +1124,10 @@ mod tests {
         fn a_live_slot_refuses_a_second_loop() {
             let dir = TempDir::new().unwrap();
             let mut conn = migrated_conn(&dir);
-            let (fleet_id, _, _) = monitored_fleet(&mut conn);
+            let (fleet_id, _, _, _) = monitored_fleet(&mut conn);
             claim(&mut conn, fleet_id, own_pid(), Utc::now());
 
-            let mux = FakeMux::with_live_panes(&["%0", "%2", "%3"]);
+            let mux = FakeMux::with_live_panes(&["%0", "%2", "%3", "%4"]);
             let mut out = Vec::new();
             let err = run_monitor_loop(&mut conn, &mux, &mut out, fleet_id, 5, 0)
                 .expect_err("the atomic claim is authoritative");

--- a/cafleet/src/multiplexer/herdr.rs
+++ b/cafleet/src/multiplexer/herdr.rs
@@ -920,7 +920,6 @@ mod tests {
         let due = [json!({
             "member_id": 4,
             "name": "worker",
-            "is_director": false,
             "coding_agent": "codex",
             "wake_reasons": ["interval"],
         })];

--- a/cafleet/src/multiplexer/mod.rs
+++ b/cafleet/src/multiplexer/mod.rs
@@ -130,11 +130,6 @@ pub fn build_wake_payload(
     let entries = due_members
         .iter()
         .map(|target| {
-            let role = if target["is_director"].as_bool().unwrap_or(false) {
-                "director"
-            } else {
-                "member"
-            };
             let name = target["name"].as_str().unwrap_or("");
             let agent = target["coding_agent"].as_str().unwrap_or("");
             let reasons = target["wake_reasons"]
@@ -148,7 +143,7 @@ pub fn build_wake_payload(
                 })
                 .unwrap_or_default();
             format!(
-                "{role} {} ({}; coding_agent={agent}) [{reasons}]",
+                "member {} ({}; coding_agent={agent}) [{reasons}]",
                 target["member_id"],
                 sanitize_wake_field(name)
             )
@@ -357,17 +352,10 @@ mod tests {
 
     use crate::multiplexer::{build_wake_payload, resolve_multiplexer_name, sanitize_wake_field};
 
-    fn due(
-        member_id: i64,
-        name: &str,
-        is_director: bool,
-        coding_agent: &str,
-        reasons: &[&str],
-    ) -> Value {
+    fn due(member_id: i64, name: &str, coding_agent: &str, reasons: &[&str]) -> Value {
         json!({
             "member_id": member_id,
             "name": name,
-            "is_director": is_director,
             "coding_agent": coding_agent,
             "wake_reasons": reasons,
         })
@@ -419,7 +407,7 @@ mod tests {
         #[test]
         fn single_member_uses_the_singular_noun() {
             let payload = build_wake_payload(
-                &[due(4, "worker", false, "codex", &["interval"])],
+                &[due(4, "worker", "codex", &["interval"])],
                 &director(1, "claude"),
             )
             .unwrap();
@@ -435,15 +423,15 @@ mod tests {
         fn multiple_members_join_entries_with_comma_space() {
             let payload = build_wake_payload(
                 &[
-                    due(1, "Director", true, "claude", &["interval"]),
-                    due(4, "worker", false, "codex", &["interval", "unacked"]),
+                    due(3, "helper", "claude", &["interval"]),
+                    due(4, "worker", "codex", &["interval", "unacked"]),
                 ],
                 &director(1, "claude"),
             )
             .unwrap();
             assert_eq!(
                 payload,
-                "[monitor] wake: 2 members due — director 1 (Director; coding_agent=claude) \
+                "[monitor] wake: 2 members due — member 3 (helper; coding_agent=claude) \
                  [interval], member 4 (worker; coding_agent=codex) [interval,unacked]. \
                  Director: 1 (coding_agent=claude). Follow your monitor role protocol."
             );
@@ -452,7 +440,7 @@ mod tests {
         #[test]
         fn member_names_are_sanitized_in_the_payload() {
             let payload = build_wake_payload(
-                &[due(5, "e`vil$(x)|z\nq", false, "claude", &["interval"])],
+                &[due(5, "e`vil$(x)|z\nq", "claude", &["interval"])],
                 &director(1, "claude"),
             )
             .unwrap();
@@ -468,7 +456,7 @@ mod tests {
         #[test]
         fn an_unregistered_coding_agent_aborts_the_wake() {
             let err = build_wake_payload(
-                &[due(4, "worker", false, "python", &["interval"])],
+                &[due(4, "worker", "python", &["interval"])],
                 &director(1, "claude"),
             )
             .expect_err("an unknown member agent must abort");
@@ -478,7 +466,7 @@ mod tests {
             );
 
             let err = build_wake_payload(
-                &[due(4, "worker", false, "codex", &["interval"])],
+                &[due(4, "worker", "codex", &["interval"])],
                 &director(1, "not-an-agent"),
             )
             .expect_err("an unknown Director agent must abort");

--- a/cafleet/src/multiplexer/tmux.rs
+++ b/cafleet/src/multiplexer/tmux.rs
@@ -555,7 +555,6 @@ mod tests {
         let due = [json!({
             "member_id": 4,
             "name": "worker",
-            "is_director": false,
             "coding_agent": "codex",
             "wake_reasons": ["interval"],
         })];
@@ -581,7 +580,6 @@ mod tests {
         let due = [json!({
             "member_id": 4,
             "name": "worker",
-            "is_director": false,
             "coding_agent": "python",
             "wake_reasons": ["interval"],
         })];

--- a/cafleet/tests/cli_setup_doctor.rs
+++ b/cafleet/tests/cli_setup_doctor.rs
@@ -14,7 +14,7 @@ fn schema_only_setup_migrates_and_reports_the_head() {
     assert_eq!(code(&output), 0, "stderr: {}", stderr(&output));
     let out = stdout(&output);
     assert!(
-        out.contains("applied migrations to head (1)."),
+        out.contains("applied migrations to head (2)."),
         "fresh DB reports the created-and-migrated line, got: {out}"
     );
     assert!(
@@ -27,7 +27,7 @@ fn schema_only_setup_migrates_and_reports_the_head() {
     ]);
     assert_eq!(code(&again), 0);
     assert!(
-        stdout(&again).contains("Already at head (1); nothing to do."),
+        stdout(&again).contains("Already at head (2); nothing to do."),
         "got: {}",
         stdout(&again)
     );

--- a/cafleet/tests/e2e.rs
+++ b/cafleet/tests/e2e.rs
@@ -25,6 +25,7 @@ fn end_to_end_lifecycle_with_one_monitor_tick() {
     assert_eq!(stdout(&output), "1 director=1\n");
 
     let worker_id = cli.create_member(1, "worker");
+    let helper_id = cli.create_member(1, "helper");
     let output = cli.run(&[
         "member",
         "create",
@@ -113,7 +114,7 @@ fn end_to_end_lifecycle_with_one_monitor_tick() {
         "the ready-handshake startup line, got: {loop_stdout}"
     );
     assert!(
-        loop_stdout.contains("due member 1 (Director) ["),
+        loop_stdout.contains(&format!("due member {helper_id} (helper) [")),
         "got: {loop_stdout}"
     );
     assert!(
@@ -133,7 +134,7 @@ fn end_to_end_lifecycle_with_one_monitor_tick() {
     );
 
     let conn = cli.sqlite();
-    for member_id in [1, worker_id] {
+    for member_id in [worker_id, helper_id] {
         let last_ping: Option<String> = conn
             .query_row(
                 "SELECT last_ping_at FROM monitor_config WHERE member_id=?1",

--- a/cafleet/tests/webui_routes.rs
+++ b/cafleet/tests/webui_routes.rs
@@ -240,12 +240,16 @@ async fn the_roster_wraps_members_and_projects_the_monitor_config() {
     );
     assert_eq!(
         director["monitor"],
-        json!({"interval_seconds": 180, "last_ping_at": null, "enabled": true}),
-        "the projection drops member_id and last_stall_check_at"
+        Value::Null,
+        "the root Director is unenrolled"
     );
     let worker = by_id(member_id);
     assert_eq!(worker["kind"], "member");
-    assert_eq!(worker["monitor"]["interval_seconds"], 720);
+    assert_eq!(
+        worker["monitor"],
+        json!({"interval_seconds": 720, "last_ping_at": null, "enabled": true}),
+        "the projection drops member_id and last_stall_check_at"
+    );
     let monitor = by_id(monitor_id);
     assert_eq!(monitor["kind"], "monitor");
     assert_eq!(monitor["monitor"], Value::Null, "the watcher is unenrolled");
@@ -259,7 +263,7 @@ async fn the_roster_wraps_members_and_projects_the_monitor_config() {
 async fn member_monitor_get_returns_the_exact_projection_or_404() {
     let dir = TempDir::new().unwrap();
     let (url, mut conn) = migrated(&dir);
-    let (_, _, member_id, monitor_id) = seeded_fleet(&mut conn);
+    let (_, director_id, member_id, monitor_id) = seeded_fleet(&mut conn);
     let app = app(&url);
 
     let (status, body) = call(
@@ -277,9 +281,20 @@ async fn member_monitor_get_returns_the_exact_projection_or_404() {
     );
 
     let (status, body) = call(
-        app,
+        app.clone(),
         "GET",
         &format!("/api/members/{monitor_id}/monitor"),
+        Some("1"),
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+    assert_eq!(body, r#"{"detail":"Member not enrolled"}"#);
+
+    let (status, body) = call(
+        app,
+        "GET",
+        &format!("/api/members/{director_id}/monitor"),
         Some("1"),
         None,
     )
@@ -525,7 +540,7 @@ async fn post_send_handles_unicast_broadcast_and_the_error_surfaces() {
 async fn the_monitor_endpoint_reports_and_masks_the_runtime() {
     let dir = TempDir::new().unwrap();
     let (url, mut conn) = migrated(&dir);
-    let (fleet_id, _, _, _) = seeded_fleet(&mut conn);
+    let (fleet_id, director_id, _, _) = seeded_fleet(&mut conn);
     let app = app(&url);
 
     let (status, body) = call(app.clone(), "GET", "/api/monitor", Some("1"), None).await;
@@ -534,10 +549,11 @@ async fn the_monitor_endpoint_reports_and_masks_the_runtime() {
     assert_eq!(payload["running"], false);
     assert_eq!(payload["pid"], Value::Null);
     assert_eq!(payload["tick_seconds"], Value::Null, "no row at all");
-    assert_eq!(
-        payload["members"].as_array().unwrap().len(),
-        2,
-        "the watched set rides along"
+    let rows = payload["members"].as_array().unwrap();
+    assert_eq!(rows.len(), 1, "the watched set rides along");
+    assert!(
+        !rows.iter().any(|row| row["member_id"] == director_id),
+        "the root Director is not in the watched set, got: {rows:?}"
     );
 
     let now = cafleet::time::now_utc();

--- a/design-docs/0000156-drop-director-monitor-enrollment/design-doc.md
+++ b/design-docs/0000156-drop-director-monitor-enrollment/design-doc.md
@@ -1,0 +1,357 @@
+# Drop the root Director from the monitor watched set
+
+**Status**: Approved
+**Progress**: 11/35 tasks complete
+**Last Updated**: 2026-08-02
+
+## Overview
+
+The root Director is enrolled in `monitor_config` at 180 s, so it accumulates
+wake reasons, advances `last_ping_at`, and is rendered as a due entry in every
+wake payload — yet the monitoring member is forbidden from capturing or acting
+on a due director entry. This design deletes the Director's enrollment and the
+`DIRECTOR_PING_INTERVAL_SECONDS` constant, leaving exactly one enrollment class
+(ordinary pane-bound members), and removes the director-role fields that become
+unreachable as a result.
+
+## Success Criteria
+
+- [ ] `create_fleet` leaves the root Director unenrolled; `get_monitor_config`
+      for a freshly bootstrapped Director returns `None`.
+- [ ] `DIRECTOR_PING_INTERVAL_SECONDS` does not exist anywhere in the
+      repository.
+- [ ] `V2__drop_director_monitor_enrollment.sql` removes every pre-existing
+      Director row from `monitor_config`, so migrated and fresh databases have
+      identical watched sets.
+- [ ] `is_director` is absent from `list_monitor_targets` scan rows and from
+      wake-payload due entries; `role` is absent from `monitor_members_payload`
+      rows.
+- [ ] `MEMBER_PING_INTERVAL_SECONDS` remains 720 and
+      `CAFLEET_MONITOR_STALL_INTERVAL` remains 240; no new interval knob exists.
+- [ ] `mise //cafleet:test`, `mise //cafleet:lint`, and `mise //cafleet:format`
+      all pass.
+- [ ] No repository surface states that the root Director is watched, pinged,
+      or checked more often than an ordinary member.
+
+---
+
+## Background
+
+Design 0000151 introduced the direct member nudge; design 0000154 deleted the
+stall-episode machine and established that the monitoring member never captures
+or acts on a due director entry. Since then the Director's `monitor_config` row
+has served no purpose beyond pacing the wake cadence: the loop wakes the
+monitoring member every 180 s naming a target it is instructed to ignore. The
+row reads as "the monitor still pings the Director" — an attractive nuisance the
+role protocol has to explicitly defend against.
+
+The Director's supervision does not depend on this row. The monitoring member
+reaches the Director through plain per-event `cafleet message send` calls, and
+the Director descriptor that identifies the report recipient rides in the wake
+payload independently of the watched set.
+
+---
+
+## Specification
+
+### One enrollment class
+
+Enrollment collapses to a single rule: **a pane-bound ordinary member is
+enrolled at `MEMBER_PING_INTERVAL_SECONDS` (720 s) by `register_member`;
+nothing else is enrolled.**
+
+| Member class | Enrolled | `monitor` field on `GET /api/members` |
+|---|---|---|
+| An ordinary member with a placement | yes, at 720 s | A schedule object |
+| The fleet's root Director | no | `null` |
+| The dedicated monitoring member | no — it is the watcher | `null` |
+| A deregistered member | no — the row is deleted on deregistration | `null` |
+| A registry row without a placement | no | `null` |
+
+### Cadence consequences
+
+These are accepted outcomes of the change, not problems to mitigate. Nothing is
+added to compensate: no monitoring-member self-enrollment, no minimum-wake
+floor, no new interval knob.
+
+| Condition | Effective wake cadence |
+|---|---|
+| Default (`CAFLEET_MONITOR_STALL_INTERVAL=240`), ≥1 ordinary member | 240 s — `min(720 interval, 240 stall-check)`, stall-check-driven |
+| `CAFLEET_MONITOR_STALL_INTERVAL=0`, ≥1 ordinary member | 720 s — interval-driven only |
+| Fleet holding only the Director and the monitoring member | no wakes at all |
+
+In the third case the loop still claims the runtime slot, heartbeats
+`monitor_runtime` every tick, and stays alive; the due set is simply empty, so
+`send_wake_trigger` is never called. The monitoring member sits idle after its
+`ready: monitor live` handshake until the first ordinary member is spawned.
+
+### Contract-surface changes
+
+| Surface | Change |
+|---|---|
+| `list_monitor_targets` scan row | `is_director` removed; remaining keys unchanged |
+| Wake-payload due entry | `is_director` removed; `member_id`, `name`, `coding_agent`, `wake_reasons` unchanged |
+| Rendered wake text | **Byte-identical** — the entry prefix becomes the literal `member`, previously derived from a flag that can now only be false |
+| Wake-payload `director` descriptor | **Unchanged** — `{member_id, coding_agent}` identifies the monitoring member's report recipient and was never part of the watched set |
+| `monitor_members_payload` row (`GET /api/monitor`) | `role` removed; the Director's row no longer appears at all |
+| `GET /api/members` | The Director's `monitor` field is `null` |
+| `GET /api/members/{director_id}/monitor` | `404 {"detail":"Member not enrolled"}` |
+
+The admin frontend does not read `role`, so dropping it has no UI impact.
+
+**Explicitly out of scope**: `derive_member_kind`'s own `is_director` parameter
+in the member registry, the `kind` column of `member list`, and the `director`
+value it prints. Those describe registry identity, not monitor enrollment, and
+stay exactly as they are.
+
+### Migration
+
+`cafleet/migrations/V2__drop_director_monitor_enrollment.sql`:
+
+```sql
+DELETE FROM monitor_config
+WHERE member_id IN (
+    SELECT director_member_id FROM fleets WHERE director_member_id IS NOT NULL
+);
+```
+
+The chain becomes contiguous `1..2` with the single baseline at 1. Soft-deleted
+fleets already had their `monitor_config` rows cascaded away by `delete_fleet`,
+so the statement is a no-op for them.
+
+### Loud Director-agent resolution
+
+`monitor_tick` currently resolves the Director's `coding_agent` by searching
+`targets` first, then falling back to `get_member`, then
+`.unwrap_or_default()` — a silent empty string. After this change the targets
+branch is dead (the Director is never a target) and the silent fallback violates
+`.claude/rules/code-quality.md`. Replace the whole chain with:
+
+```rust
+let director_agent = broker::get_member(conn, director_id, fleet_id)?
+    .expect("a live fleet's Director is registered")["placement"]["coding_agent"]
+    .as_str()
+    .expect("the root Director is pane-bound")
+    .to_string();
+```
+
+Both invariants are guaranteed: `create_fleet` always inserts the Director's
+placement, and `member delete` of the root Director is rejected. A genuine DB
+error now propagates via `?` instead of being swallowed by `.ok()`.
+
+### Documentation surfaces
+
+| Surface | Edit |
+|---|---|
+| `docs/docs/concepts/monitoring.md` | Opening paragraph's watched-set parenthetical; the watched-set table; the "checked far more often" sentence; the "Root Director ping interval" knob row; step 1's due-director-entry sentence; new cadence-consequence prose |
+| `SPEC.md` §5 | The `monitor_config` field table's `interval_seconds` row, which names both enrollment values |
+| `SPEC.md` §6.2 | Enrollment intervals; `create_fleet`'s ordered steps; `list_monitor_targets` row shape; `monitor_members_payload` row shape |
+| `SPEC.md` §6.5 | `send_wake_trigger` due-entry field list and entry rendering |
+| `SPEC.md` §6.6 | The re-export list and the "five constants" count; `should_ping`'s row description and its `is_director` sentence |
+| `SPEC.md` §8 | The fresh-DB seeding prose naming the Director at 180 s |
+| `SPEC.md` §11 | The "Policy tunables (180/720/3/15) have a single home" decision line |
+| `skills/cafleet/reference/supervision.md` | The watched-set sentence; the "the Director **and** each freshly-due member" clause; the example wake payload; the Quick Reference "Run work" row |
+| `skills/cafleet/roles/monitor.md` | Step 1's due-director-entry sentence; the `<role>` token in the wake-entry description; the example wake payload |
+
+`README.md` is untouched — the change does not move its pitch, install
+commands, or docs-site section links.
+
+Two of these surfaces extend the list confirmed during clarification, and both
+follow necessarily from the decisions above: `skills/cafleet/roles/monitor.md`
+carries the same due-director-entry defense and example payload as
+`concepts/monitoring.md`, and the additional `SPEC.md` sections are the
+contract text for the `is_director` / `role` fields being removed. Leaving
+either would strand a rule against a state that can no longer occur.
+
+Every rewrite states current behavior. No before/after narration, no note that
+the Director "used to be" watched.
+
+---
+
+## Implementation
+
+> Task format: `- [x] Done task <!-- completed: 2026-02-13T14:30 -->`
+> When completing a task, check the box and record the timestamp in the same edit.
+
+### Step 1: Documentation
+
+- [x] `docs/docs/concepts/monitoring.md` — narrow the opening paragraph's
+      watched set to "every ordinary member, each on its own interval"; replace
+      the Director row in the watched-set table with a `no` / `null` row;
+      delete the "checked far more often than an ordinary member" sentence and
+      point instead at the single ordinary-member default. <!-- completed: 2026-08-02T21:14 -->
+- [x] `docs/docs/concepts/monitoring.md` — drop the "Root Director ping
+      interval | `180s`" row from the knob table; add prose beneath it stating
+      the 240 s stall-check-driven baseline, the 720 s cadence under
+      `CAFLEET_MONITOR_STALL_INTERVAL=0`, and the no-wake Director-plus-monitor
+      fleet. <!-- completed: 2026-08-02T21:14 -->
+- [x] `docs/docs/concepts/monitoring.md` — in the monitoring-member step 1,
+      replace the "A due `director` entry is not captured" sentence with the
+      affirmative statement that the Director descriptor identifies the report
+      recipient only and the monitoring member takes no Director-directed pane
+      action; update the wake-entry rendering from `<role> <id>` to
+      `member <id>`. <!-- completed: 2026-08-02T21:14 -->
+- [x] `SPEC.md` §5 and §11 — rewrite the `monitor_config` field table's
+      `interval_seconds` row to name only the 720 s member enrollment, and
+      narrow the §11 policy-tunables decision line to the surviving
+      `720/3/15`. <!-- completed: 2026-08-02T21:15 -->
+- [x] `SPEC.md` §6.2 — rewrite the enrollment-intervals bullet to the single
+      720 s class and drop `DIRECTOR_PING_INTERVAL_SECONDS`; drop "enroll the
+      Director at 180s" from `create_fleet`'s ordered steps. <!-- completed: 2026-08-02T21:15 -->
+- [x] `SPEC.md` §6.2 — drop `is_director` from the `list_monitor_targets` row
+      shape and `role` (with its `"director"`/`"member"` derivation clause) from
+      the `monitor_members_payload` row shape. <!-- completed: 2026-08-02T21:15 -->
+- [x] `SPEC.md` §6.5 — drop `is_director` from `send_wake_trigger`'s due-entry
+      field list and change the entry rendering to
+      `member <id> (<name>; coding_agent=<agent>) [<reasons>]`. <!-- completed: 2026-08-02T21:15 -->
+- [x] `SPEC.md` §6.6 — remove `DIRECTOR_PING_INTERVAL_SECONDS` from the
+      re-export bullet, change "the five constants" to "the four constants",
+      drop `is_director` from `should_ping`'s row description, and delete the
+      "`is_director` is **not** consulted (retained only for status labeling)"
+      sentence. <!-- completed: 2026-08-02T21:15 -->
+- [x] `SPEC.md` §8 — rewrite the fresh-DB seeding prose to name only
+      "pane-bound members at 720s by `register_member`". <!-- completed: 2026-08-02T21:15 -->
+- [x] `skills/cafleet/reference/supervision.md` — narrow the watched-set
+      sentence to ordinary members at 720 s; drop "the Director **and**" from
+      the monitoring-member paragraph; update the Quick Reference "Run work"
+      row. <!-- completed: 2026-08-02T21:16 -->
+- [x] `skills/cafleet/roles/monitor.md` — replace step 1's due-director-entry
+      sentence with the affirmative report-recipient statement; change the
+      wake-entry description from `<role> <id>` to `member <id>`; rewrite the
+      example wake payload with member entries only. <!-- completed: 2026-08-02T21:16 -->
+
+### Step 2: Migration
+
+- [ ] Add `cafleet/migrations/V2__drop_director_monitor_enrollment.sql` with
+      the `DELETE FROM monitor_config` statement from the Specification.
+      <!-- completed: -->
+- [ ] `cafleet/src/db/mod.rs` — rename
+      `migration_chain_is_contiguous_from_1_with_exactly_one_baseline_and_head_1`
+      to `..._head_2` and change its final assertion to `Some(&2)`; change
+      `refinery_ledger_records_the_baseline`'s expected versions to
+      `vec![1, 2]`. <!-- completed: -->
+- [ ] `cafleet/tests/cli_setup_doctor.rs` — update
+      `schema_only_setup_migrates_and_reports_the_head` to expect
+      `applied migrations to head (2).` and
+      `Already at head (2); nothing to do.`. <!-- completed: -->
+- [ ] `cafleet/src/db/mod.rs` — rename
+      `migrate_reaches_head_version_1_and_is_idempotent` to
+      `migrate_reaches_head_version_2_and_is_idempotent` and change both
+      `migrate_to_head` return assertions to `2`; drop the stale `` (`1` at
+      cutover) `` parenthetical from the `head_version()` doc comment rather
+      than re-pinning it to 2, so the comment does not need editing on every
+      future migration. <!-- completed: -->
+
+### Step 3: Broker enrollment
+
+- [ ] `cafleet/src/broker/members.rs` — delete
+      `DIRECTOR_PING_INTERVAL_SECONDS`; reword the surviving constant's doc
+      comment for a single cadence; change `enroll` to
+      `enroll(conn, member_id)` inserting `MEMBER_PING_INTERVAL_SECONDS`
+      directly, and update its call site in `register_member`. <!-- completed: -->
+- [ ] `cafleet/src/broker/fleets.rs` — delete the
+      `enroll(&tx, director_id, DIRECTOR_PING_INTERVAL_SECONDS)?` call and the
+      now-unused imports; drop the enrollment clause from `create_fleet`'s doc
+      comment. <!-- completed: -->
+- [ ] `cafleet/src/broker/fleets.rs` — replace
+      `create_fleet_enrolls_the_director_at_180` with
+      `create_fleet_leaves_the_director_unenrolled`, asserting
+      `get_monitor_config(&conn, fleet_id, director_id)` returns `None`.
+      <!-- completed: -->
+
+### Step 4: Scan-row and WebUI payload fields
+
+- [ ] `cafleet/src/broker/monitor.rs` — in `list_monitor_targets`, drop the
+      `director_member_id` correlated subquery from the SELECT list, drop the
+      `"is_director"` JSON key, and shift the remaining column indices down by
+      one. <!-- completed: -->
+- [ ] `cafleet/src/broker/monitor.rs` — in `monitor_members_payload`, drop the
+      same subquery, the `is_director` tuple element, and the `"role"` JSON key;
+      shift the remaining indices. <!-- completed: -->
+- [ ] `cafleet/src/broker/monitor.rs` tests — retarget every test that uses the
+      root Director as a stand-in enrolled member to an ordinary registered
+      member: `list_monitor_configs_returns_every_enrolled_member_with_bool_enabled`
+      (drop the 180 interval assertion), `record_pings_stamps_last_ping_at_and_ignores_an_empty_list`,
+      `record_monitor_dispatch_commits_both_cadences_atomically`,
+      `reconcile_monitor_lifecycle_clears_stamps_for_listed_fleet_members_only`,
+      `update_monitor_config` / `get_monitor_config` tests, and
+      `list_monitor_targets_counts_pending_deliveries`. <!-- completed: -->
+- [ ] `cafleet/src/broker/monitor.rs` tests — rewrite
+      `list_monitor_targets_returns_the_watched_set_with_the_scan_row_shape` so
+      the full scan-row shape is pinned on an ordinary member (720 s, no
+      `is_director` key) and add an assertion that the Director's `member_id`
+      is absent from the returned targets. <!-- completed: -->
+- [ ] `cafleet/src/broker/monitor.rs` tests — rename
+      `members_payload_labels_roles_and_truncates_ages` to
+      `members_payload_truncates_ages` (the name must not advertise the removed
+      labeling) and update it to assert the absence of `role` and the absence
+      of the Director's row. <!-- completed: -->
+
+### Step 5: Monitor loop and wake payload
+
+- [ ] `cafleet/src/monitor/mod.rs` — remove `DIRECTOR_PING_INTERVAL_SECONDS`
+      from the `pub use` re-export and from the expected-public-API doc comment;
+      drop `"is_director": target["is_director"]` from the due-entry JSON.
+      <!-- completed: -->
+- [ ] `cafleet/src/monitor/mod.rs` — replace the Director `coding_agent`
+      resolution chain with the loud `get_member` form from the Specification.
+      <!-- completed: -->
+- [ ] `cafleet/src/multiplexer/mod.rs` — in the wake-payload builder, delete the
+      `role` computation and emit the literal `member` prefix, keeping the
+      rendered text byte-identical; drop the `is_director` parameter and JSON
+      key from the test-fixture helper. <!-- completed: -->
+- [ ] `cafleet/src/multiplexer/tmux.rs` and `cafleet/src/multiplexer/herdr.rs`
+      — drop the `"is_director": false` keys from the wake-payload test
+      fixtures. <!-- completed: -->
+- [ ] `cafleet/src/monitor/mod.rs` tests — drop the
+      `DIRECTOR_PING_INTERVAL_SECONDS == 180` assertion from
+      `the_policy_tunables_are_pinned`; drop `"is_director"` from the
+      `should_ping` target fixture. <!-- completed: -->
+- [ ] `cafleet/src/monitor/mod.rs` tests — extend the `monitored_fleet` fixture
+      to register a **second** pane-bound ordinary member, so the tests that
+      need two due entries still have them once the Director leaves the watched
+      set. <!-- completed: -->
+- [ ] `cafleet/src/monitor/mod.rs` tests — purge `director_id` from the
+      `monitor_tick` test module, which breaks in three distinct ways:
+      (1) `last_ping` calls on the Director panic on the missing row
+      (`due_members_produce_one_wake_and_gated_ledger_writes`,
+      `a_failed_wake_records_nothing_and_retries_next_tick`,
+      `no_live_watcher_means_no_wake_and_no_ledger_writes`);
+      (2) due-set membership assertions on the Director now fail
+      (`due_members_produce_one_wake_and_gated_ledger_writes`'s
+      `director_entry` and echo line, `dead_panes_are_reconciled_and_never_due`'s
+      `due.iter().any(...)`); and (3) `ping_at(&[director_id, …])` calls
+      silently match zero rows, so any test relying on them to suppress a due
+      row no longer suppresses anything. Retarget each to an ordinary member,
+      and additionally register one in `no_live_watcher…` (whose fleet is
+      `create_fleet` alone) so its watched set is non-empty and the test stays
+      meaningful. Keep every `director` **descriptor** assertion
+      (`member_id`, `coding_agent`) intact — that surface is unchanged. Assert
+      in at least one tick test that the Director's `member_id` never appears
+      in `due`. <!-- completed: -->
+
+### Step 6: WebUI expectations
+
+- [ ] `cafleet/tests/webui_routes.rs` — in
+      `the_roster_wraps_members_and_projects_the_monitor_config`, assert the
+      Director's `monitor` is `Value::Null` and move the full projection-shape
+      assertion (`{"interval_seconds": 720, "last_ping_at": null, "enabled": true}`)
+      onto the ordinary member's row. <!-- completed: -->
+- [ ] `cafleet/tests/webui_routes.rs` — in
+      `member_monitor_get_returns_the_exact_projection_or_404`, add a case
+      asserting `GET /api/members/{director_id}/monitor` returns `404` with
+      `{"detail":"Member not enrolled"}`. <!-- completed: -->
+- [ ] `cafleet/tests/webui_routes.rs` — in
+      `the_monitor_endpoint_reports_and_masks_the_runtime`, change the expected
+      `members` length to 1 and assert the Director's `member_id` is absent from
+      the rows. <!-- completed: -->
+
+### Step 7: Verification
+
+- [ ] Run `mise //cafleet:format`, `mise //cafleet:lint`, and
+      `mise //cafleet:test`; all pass. <!-- completed: -->
+- [ ] Grep the repository for `DIRECTOR_PING_INTERVAL`, `Root Director ping`,
+      `far more often`, `is_director` under the monitor surfaces, and the bare
+      literal `180`; confirm no residue outside the registry-identity uses
+      named as out of scope. The bare-`180` sweep is the backstop that catches
+      prose naming the value without naming the constant. <!-- completed: -->

--- a/design-docs/0000156-drop-director-monitor-enrollment/design-doc.md
+++ b/design-docs/0000156-drop-director-monitor-enrollment/design-doc.md
@@ -1,7 +1,7 @@
 # Drop the root Director from the monitor watched set
 
 **Status**: Approved
-**Progress**: 11/35 tasks complete
+**Progress**: 15/35 tasks complete
 **Last Updated**: 2026-08-02
 
 ## Overview
@@ -222,25 +222,25 @@ the Director "used to be" watched.
 
 ### Step 2: Migration
 
-- [ ] Add `cafleet/migrations/V2__drop_director_monitor_enrollment.sql` with
+- [x] Add `cafleet/migrations/V2__drop_director_monitor_enrollment.sql` with
       the `DELETE FROM monitor_config` statement from the Specification.
-      <!-- completed: -->
-- [ ] `cafleet/src/db/mod.rs` — rename
+      <!-- completed: 2026-08-02T21:24 -->
+- [x] `cafleet/src/db/mod.rs` — rename
       `migration_chain_is_contiguous_from_1_with_exactly_one_baseline_and_head_1`
       to `..._head_2` and change its final assertion to `Some(&2)`; change
       `refinery_ledger_records_the_baseline`'s expected versions to
-      `vec![1, 2]`. <!-- completed: -->
-- [ ] `cafleet/tests/cli_setup_doctor.rs` — update
+      `vec![1, 2]`. <!-- completed: 2026-08-02T21:24 -->
+- [x] `cafleet/tests/cli_setup_doctor.rs` — update
       `schema_only_setup_migrates_and_reports_the_head` to expect
       `applied migrations to head (2).` and
-      `Already at head (2); nothing to do.`. <!-- completed: -->
-- [ ] `cafleet/src/db/mod.rs` — rename
+      `Already at head (2); nothing to do.`. <!-- completed: 2026-08-02T21:24 -->
+- [x] `cafleet/src/db/mod.rs` — rename
       `migrate_reaches_head_version_1_and_is_idempotent` to
       `migrate_reaches_head_version_2_and_is_idempotent` and change both
       `migrate_to_head` return assertions to `2`; drop the stale `` (`1` at
       cutover) `` parenthetical from the `head_version()` doc comment rather
       than re-pinning it to 2, so the comment does not need editing on every
-      future migration. <!-- completed: -->
+      future migration. <!-- completed: 2026-08-02T21:24 -->
 
 ### Step 3: Broker enrollment
 

--- a/design-docs/0000156-drop-director-monitor-enrollment/design-doc.md
+++ b/design-docs/0000156-drop-director-monitor-enrollment/design-doc.md
@@ -1,6 +1,6 @@
 # Drop the root Director from the monitor watched set
 
-**Status**: Approved
+**Status**: Complete
 **Progress**: 37/37 tasks complete
 **Last Updated**: 2026-08-02
 

--- a/design-docs/0000156-drop-director-monitor-enrollment/design-doc.md
+++ b/design-docs/0000156-drop-director-monitor-enrollment/design-doc.md
@@ -1,7 +1,7 @@
 # Drop the root Director from the monitor watched set
 
 **Status**: Approved
-**Progress**: 18/35 tasks complete
+**Progress**: 37/37 tasks complete
 **Last Updated**: 2026-08-02
 
 ## Overview
@@ -16,21 +16,21 @@ unreachable as a result.
 
 ## Success Criteria
 
-- [ ] `create_fleet` leaves the root Director unenrolled; `get_monitor_config`
+- [x] `create_fleet` leaves the root Director unenrolled; `get_monitor_config`
       for a freshly bootstrapped Director returns `None`.
-- [ ] `DIRECTOR_PING_INTERVAL_SECONDS` does not exist anywhere in the
+- [x] `DIRECTOR_PING_INTERVAL_SECONDS` does not exist anywhere in the
       repository.
-- [ ] `V2__drop_director_monitor_enrollment.sql` removes every pre-existing
+- [x] `V2__drop_director_monitor_enrollment.sql` removes every pre-existing
       Director row from `monitor_config`, so migrated and fresh databases have
       identical watched sets.
-- [ ] `is_director` is absent from `list_monitor_targets` scan rows and from
+- [x] `is_director` is absent from `list_monitor_targets` scan rows and from
       wake-payload due entries; `role` is absent from `monitor_members_payload`
       rows.
-- [ ] `MEMBER_PING_INTERVAL_SECONDS` remains 720 and
+- [x] `MEMBER_PING_INTERVAL_SECONDS` remains 720 and
       `CAFLEET_MONITOR_STALL_INTERVAL` remains 240; no new interval knob exists.
-- [ ] `mise //cafleet:test`, `mise //cafleet:lint`, and `mise //cafleet:format`
+- [x] `mise //cafleet:test`, `mise //cafleet:lint`, and `mise //cafleet:format`
       all pass.
-- [ ] No repository surface states that the root Director is watched, pinged,
+- [x] No repository surface states that the root Director is watched, pinged,
       or checked more often than an ordinary member.
 
 ---
@@ -244,74 +244,76 @@ the Director "used to be" watched.
 
 ### Step 3: Broker enrollment
 
-- [ ] `cafleet/src/broker/members.rs` — delete
+- [x] `cafleet/src/broker/members.rs` — delete
       `DIRECTOR_PING_INTERVAL_SECONDS`; reword the surviving constant's doc
       comment for a single cadence; change `enroll` to
       `enroll(conn, member_id)` inserting `MEMBER_PING_INTERVAL_SECONDS`
-      directly, and update its call site in `register_member`. <!-- completed: -->
-- [ ] `cafleet/src/broker/fleets.rs` — delete the
+      directly, and update its call site in `register_member`. <!-- completed: 2026-08-02T21:32 -->
+- [x] `cafleet/src/broker/fleets.rs` — delete the
       `enroll(&tx, director_id, DIRECTOR_PING_INTERVAL_SECONDS)?` call and the
       now-unused imports; drop the enrollment clause from `create_fleet`'s doc
-      comment. <!-- completed: -->
-- [ ] `cafleet/src/broker/fleets.rs` — replace
+      comment. <!-- completed: 2026-08-02T21:32 -->
+
+- [x] `cafleet/src/broker/fleets.rs` — replace
       `create_fleet_enrolls_the_director_at_180` with
       `create_fleet_leaves_the_director_unenrolled`, asserting
       `get_monitor_config(&conn, fleet_id, director_id)` returns `None`.
-      <!-- completed: -->
+      <!-- completed: 2026-08-02T21:29 -->
 
 ### Step 4: Scan-row and WebUI payload fields
 
-- [ ] `cafleet/src/broker/monitor.rs` — in `list_monitor_targets`, drop the
+- [x] `cafleet/src/broker/monitor.rs` — in `list_monitor_targets`, drop the
       `director_member_id` correlated subquery from the SELECT list, drop the
       `"is_director"` JSON key, and shift the remaining column indices down by
-      one. <!-- completed: -->
-- [ ] `cafleet/src/broker/monitor.rs` — in `monitor_members_payload`, drop the
+      one. <!-- completed: 2026-08-02T21:37 -->
+- [x] `cafleet/src/broker/monitor.rs` — in `monitor_members_payload`, drop the
       same subquery, the `is_director` tuple element, and the `"role"` JSON key;
-      shift the remaining indices. <!-- completed: -->
-- [ ] `cafleet/src/broker/monitor.rs` tests — retarget every test that uses the
+      shift the remaining indices. <!-- completed: 2026-08-02T21:37 -->
+- [x] `cafleet/src/broker/monitor.rs` tests — retarget every test that uses the
       root Director as a stand-in enrolled member to an ordinary registered
       member: `list_monitor_configs_returns_every_enrolled_member_with_bool_enabled`
       (drop the 180 interval assertion), `record_pings_stamps_last_ping_at_and_ignores_an_empty_list`,
       `record_monitor_dispatch_commits_both_cadences_atomically`,
       `reconcile_monitor_lifecycle_clears_stamps_for_listed_fleet_members_only`,
       `update_monitor_config` / `get_monitor_config` tests, and
-      `list_monitor_targets_counts_pending_deliveries`. <!-- completed: -->
-- [ ] `cafleet/src/broker/monitor.rs` tests — rewrite
+      `list_monitor_targets_counts_pending_deliveries`. <!-- completed: 2026-08-02T21:33 -->
+- [x] `cafleet/src/broker/monitor.rs` tests — rewrite
       `list_monitor_targets_returns_the_watched_set_with_the_scan_row_shape` so
       the full scan-row shape is pinned on an ordinary member (720 s, no
       `is_director` key) and add an assertion that the Director's `member_id`
-      is absent from the returned targets. <!-- completed: -->
-- [ ] `cafleet/src/broker/monitor.rs` tests — rename
+      is absent from the returned targets. <!-- completed: 2026-08-02T21:33 -->
+- [x] `cafleet/src/broker/monitor.rs` tests — rename
       `members_payload_labels_roles_and_truncates_ages` to
       `members_payload_truncates_ages` (the name must not advertise the removed
       labeling) and update it to assert the absence of `role` and the absence
-      of the Director's row. <!-- completed: -->
+      of the Director's row. <!-- completed: 2026-08-02T21:33 -->
 
 ### Step 5: Monitor loop and wake payload
 
-- [ ] `cafleet/src/monitor/mod.rs` — remove `DIRECTOR_PING_INTERVAL_SECONDS`
+- [x] `cafleet/src/monitor/mod.rs` — remove `DIRECTOR_PING_INTERVAL_SECONDS`
       from the `pub use` re-export and from the expected-public-API doc comment;
       drop `"is_director": target["is_director"]` from the due-entry JSON.
-      <!-- completed: -->
-- [ ] `cafleet/src/monitor/mod.rs` — replace the Director `coding_agent`
+      <!-- completed: 2026-08-02T21:34 -->
+- [x] `cafleet/src/monitor/mod.rs` — replace the Director `coding_agent`
       resolution chain with the loud `get_member` form from the Specification.
-      <!-- completed: -->
-- [ ] `cafleet/src/multiplexer/mod.rs` — in the wake-payload builder, delete the
+      <!-- completed: 2026-08-02T21:34 -->
+- [x] `cafleet/src/multiplexer/mod.rs` — in the wake-payload builder, delete the
       `role` computation and emit the literal `member` prefix, keeping the
       rendered text byte-identical; drop the `is_director` parameter and JSON
-      key from the test-fixture helper. <!-- completed: -->
-- [ ] `cafleet/src/multiplexer/tmux.rs` and `cafleet/src/multiplexer/herdr.rs`
+      key from the test-fixture helper. <!-- completed: 2026-08-02T21:34 -->
+
+- [x] `cafleet/src/multiplexer/tmux.rs` and `cafleet/src/multiplexer/herdr.rs`
       — drop the `"is_director": false` keys from the wake-payload test
-      fixtures. <!-- completed: -->
-- [ ] `cafleet/src/monitor/mod.rs` tests — drop the
+      fixtures. <!-- completed: 2026-08-02T21:34 -->
+- [x] `cafleet/src/monitor/mod.rs` tests — drop the
       `DIRECTOR_PING_INTERVAL_SECONDS == 180` assertion from
       `the_policy_tunables_are_pinned`; drop `"is_director"` from the
-      `should_ping` target fixture. <!-- completed: -->
-- [ ] `cafleet/src/monitor/mod.rs` tests — extend the `monitored_fleet` fixture
+      `should_ping` target fixture. <!-- completed: 2026-08-02T21:39 -->
+- [x] `cafleet/src/monitor/mod.rs` tests — extend the `monitored_fleet` fixture
       to register a **second** pane-bound ordinary member, so the tests that
       need two due entries still have them once the Director leaves the watched
-      set. <!-- completed: -->
-- [ ] `cafleet/src/monitor/mod.rs` tests — purge `director_id` from the
+      set. <!-- completed: 2026-08-02T21:39 -->
+- [x] `cafleet/src/monitor/mod.rs` tests — purge `director_id` from the
       `monitor_tick` test module, which breaks in three distinct ways:
       (1) `last_ping` calls on the Director panic on the missing row
       (`due_members_produce_one_wake_and_gated_ledger_writes`,
@@ -328,7 +330,12 @@ the Director "used to be" watched.
       meaningful. Keep every `director` **descriptor** assertion
       (`member_id`, `coding_agent`) intact — that surface is unchanged. Assert
       in at least one tick test that the Director's `member_id` never appears
-      in `due`. <!-- completed: -->
+      in `due`. <!-- completed: 2026-08-02T21:39 -->
+- [x] `cafleet/tests/e2e.rs` — register a second ordinary member, retarget the
+      `due member 1 (Director)` stdout assertion to it so the `2 members due`
+      plural path keeps two end-to-end due entries, and drop member 1 from the
+      `last_ping_at` loop — the Director has no `monitor_config` row to read.
+      <!-- completed: 2026-08-02T21:44 -->
 
 ### Step 6: WebUI expectations
 
@@ -348,10 +355,21 @@ the Director "used to be" watched.
 
 ### Step 7: Verification
 
-- [ ] Run `mise //cafleet:format`, `mise //cafleet:lint`, and
-      `mise //cafleet:test`; all pass. <!-- completed: -->
-- [ ] Grep the repository for `DIRECTOR_PING_INTERVAL`, `Root Director ping`,
+- [x] Run `mise //cafleet:format`, `mise //cafleet:lint`, and
+      `mise //cafleet:test`; all pass. <!-- completed: 2026-08-02T21:48 -->
+- [x] Grep the repository for `DIRECTOR_PING_INTERVAL`, `Root Director ping`,
       `far more often`, `is_director` under the monitor surfaces, and the bare
       literal `180`; confirm no residue outside the registry-identity uses
       named as out of scope. The bare-`180` sweep is the backstop that catches
-      prose naming the value without naming the constant. <!-- completed: -->
+      prose naming the value without naming the constant. <!-- completed: 2026-08-02T21:48 -->
+- [x] `docs/docs/spec/webui-api.md` — in the `GET /api/members` response
+      example, set the root Director's `monitor` field to `null`; in the
+      `GET /api/members/{member_id}/monitor` response example, change
+      `interval_seconds` from `180` to `720`. Surfaced by the bare-`180` sweep;
+      the Documentation-surfaces table did not list this page.
+      <!-- completed: 2026-08-02T21:48 -->
+- [x] `.claude/rules/documentation-tables.md` — the Echo rule's illustrative
+      quote is "the Director is checked far more often than an ordinary member",
+      which now describes a state the system cannot reach. Replace it with a
+      qualitative-magnitude example that is still true, keeping the rule's point
+      about magnitude-not-values intact. <!-- completed: 2026-08-02T21:51 -->

--- a/design-docs/0000156-drop-director-monitor-enrollment/design-doc.md
+++ b/design-docs/0000156-drop-director-monitor-enrollment/design-doc.md
@@ -1,7 +1,7 @@
 # Drop the root Director from the monitor watched set
 
 **Status**: Approved
-**Progress**: 15/35 tasks complete
+**Progress**: 18/35 tasks complete
 **Last Updated**: 2026-08-02
 
 ## Overview
@@ -332,19 +332,19 @@ the Director "used to be" watched.
 
 ### Step 6: WebUI expectations
 
-- [ ] `cafleet/tests/webui_routes.rs` — in
+- [x] `cafleet/tests/webui_routes.rs` — in
       `the_roster_wraps_members_and_projects_the_monitor_config`, assert the
       Director's `monitor` is `Value::Null` and move the full projection-shape
       assertion (`{"interval_seconds": 720, "last_ping_at": null, "enabled": true}`)
-      onto the ordinary member's row. <!-- completed: -->
-- [ ] `cafleet/tests/webui_routes.rs` — in
+      onto the ordinary member's row. <!-- completed: 2026-08-02T21:28 -->
+- [x] `cafleet/tests/webui_routes.rs` — in
       `member_monitor_get_returns_the_exact_projection_or_404`, add a case
       asserting `GET /api/members/{director_id}/monitor` returns `404` with
-      `{"detail":"Member not enrolled"}`. <!-- completed: -->
-- [ ] `cafleet/tests/webui_routes.rs` — in
+      `{"detail":"Member not enrolled"}`. <!-- completed: 2026-08-02T21:28 -->
+- [x] `cafleet/tests/webui_routes.rs` — in
       `the_monitor_endpoint_reports_and_masks_the_runtime`, change the expected
       `members` length to 1 and assert the Director's `member_id` is absent from
-      the rows. <!-- completed: -->
+      the rows. <!-- completed: 2026-08-02T21:28 -->
 
 ### Step 7: Verification
 

--- a/design-docs/0000156-drop-director-monitor-enrollment/design-doc.md
+++ b/design-docs/0000156-drop-director-monitor-enrollment/design-doc.md
@@ -1,7 +1,7 @@
 # Drop the root Director from the monitor watched set
 
 **Status**: Complete
-**Progress**: 37/37 tasks complete
+**Progress**: 38/38 tasks complete
 **Last Updated**: 2026-08-02
 
 ## Overview
@@ -150,8 +150,10 @@ error now propagates via `?` instead of being swallowed by `.ok()`.
 | `SPEC.md` §6.6 | The re-export list and the "five constants" count; `should_ping`'s row description and its `is_director` sentence |
 | `SPEC.md` §8 | The fresh-DB seeding prose naming the Director at 180 s |
 | `SPEC.md` §11 | The "Policy tunables (180/720/3/15) have a single home" decision line |
-| `skills/cafleet/reference/supervision.md` | The watched-set sentence; the "the Director **and** each freshly-due member" clause; the example wake payload; the Quick Reference "Run work" row |
+| `skills/cafleet/reference/supervision.md` | The watched-set sentence; the "the Director **and** each freshly-due member" clause; the Quick Reference "Run work" row |
 | `skills/cafleet/roles/monitor.md` | Step 1's due-director-entry sentence; the `<role>` token in the wake-entry description; the example wake payload |
+| `docs/docs/spec/webui-api.md` | The `GET /api/members` response example's Director `monitor` field; the `GET /api/members/{member_id}/monitor` response example's `interval_seconds` |
+| `.claude/rules/documentation-tables.md` | The Echo rule's illustrative quote, which names the Director as the more-often-checked party |
 
 `README.md` is untouched — the change does not move its pitch, install
 commands, or docs-site section links.
@@ -163,6 +165,14 @@ carries the same due-director-entry defense and example payload as
 contract text for the `is_director` / `role` fields being removed. Leaving
 either would strand a rule against a state that can no longer occur.
 
+The last two rows are surfaces the residue sweep finds rather than a reading of
+the code: `webui-api.md` carries the enrollment values only inside JSON response
+examples, and the rules file names the Director in an illustrative quote. A
+surface sweep driven by the changed symbols reaches neither, because neither
+mentions `is_director`, `role`, or the constant — they name the **value** `180`
+and the **behavior** in prose. The bare-`180` grep in Step 7 is what catches the
+first; the `far more often` grep catches the second.
+
 Every rewrite states current behavior. No before/after narration, no note that
 the Director "used to be" watched.
 
@@ -172,6 +182,15 @@ the Director "used to be" watched.
 
 > Task format: `- [x] Done task <!-- completed: 2026-02-13T14:30 -->`
 > When completing a task, check the box and record the timestamp in the same edit.
+
+**Steps 3 and 5 land together.** Deleting `DIRECTOR_PING_INTERVAL_SECONDS` in
+Step 3 breaks its four surviving references in `cafleet/src/monitor/mod.rs` —
+the `pub use` re-export and the expected-public-API doc comment (Step 5's first
+impl bullet), plus the test module's import and its `== 180` assertion (Step 5's
+`the_policy_tunables_are_pinned` bullet). The definition and its last references
+sit in different steps, so **no ordering compiles Step 3 alone**: it reaches
+green only once Step 5's constant removal lands, and the two commit as one unit.
+Steps 4 and 6 are independent of both and may run in any order.
 
 ### Step 1: Documentation
 
@@ -211,6 +230,14 @@ the Director "used to be" watched.
       sentence. <!-- completed: 2026-08-02T21:15 -->
 - [x] `SPEC.md` §8 — rewrite the fresh-DB seeding prose to name only
       "pane-bound members at 720s by `register_member`". <!-- completed: 2026-08-02T21:15 -->
+- [x] `docs/docs/spec/webui-api.md` — in the `GET /api/members` response
+      example, set the root Director's `monitor` field to `null`; in the
+      `GET /api/members/{member_id}/monitor` response example, change
+      `interval_seconds` from `180` to `720`. <!-- completed: 2026-08-02T21:48 -->
+- [x] `.claude/rules/documentation-tables.md` — replace the Echo rule's
+      illustrative quote, which names the Director as the more-often-checked
+      party, with a qualitative-magnitude example that is still true; keep the
+      rule's magnitude-not-values point intact. <!-- completed: 2026-08-02T21:51 -->
 - [x] `skills/cafleet/reference/supervision.md` — narrow the watched-set
       sentence to ordinary members at 720 s; drop "the Director **and**" from
       the monitoring-member paragraph; update the Quick Reference "Run work"
@@ -243,6 +270,8 @@ the Director "used to be" watched.
       future migration. <!-- completed: 2026-08-02T21:24 -->
 
 ### Step 3: Broker enrollment
+
+Reaches green only with Step 5 — see the note under *Implementation*.
 
 - [x] `cafleet/src/broker/members.rs` — delete
       `DIRECTOR_PING_INTERVAL_SECONDS`; reword the surviving constant's doc
@@ -289,6 +318,8 @@ the Director "used to be" watched.
       of the Director's row. <!-- completed: 2026-08-02T21:33 -->
 
 ### Step 5: Monitor loop and wake payload
+
+Carries the constant's last references — see the note under *Implementation*.
 
 - [x] `cafleet/src/monitor/mod.rs` — remove `DIRECTOR_PING_INTERVAL_SECONDS`
       from the `pub use` re-export and from the expected-public-API doc comment;
@@ -360,16 +391,8 @@ the Director "used to be" watched.
 - [x] Grep the repository for `DIRECTOR_PING_INTERVAL`, `Root Director ping`,
       `far more often`, `is_director` under the monitor surfaces, and the bare
       literal `180`; confirm no residue outside the registry-identity uses
-      named as out of scope. The bare-`180` sweep is the backstop that catches
-      prose naming the value without naming the constant. <!-- completed: 2026-08-02T21:48 -->
-- [x] `docs/docs/spec/webui-api.md` — in the `GET /api/members` response
-      example, set the root Director's `monitor` field to `null`; in the
-      `GET /api/members/{member_id}/monitor` response example, change
-      `interval_seconds` from `180` to `720`. Surfaced by the bare-`180` sweep;
-      the Documentation-surfaces table did not list this page.
-      <!-- completed: 2026-08-02T21:48 -->
-- [x] `.claude/rules/documentation-tables.md` — the Echo rule's illustrative
-      quote is "the Director is checked far more often than an ordinary member",
-      which now describes a state the system cannot reach. Replace it with a
-      qualitative-magnitude example that is still true, keeping the rule's point
-      about magnitude-not-values intact. <!-- completed: 2026-08-02T21:51 -->
+      named as out of scope. The last two patterns are the backstops for
+      surfaces a symbol-driven sweep cannot reach: bare `180` catches prose and
+      JSON examples naming the value without naming the constant, and
+      `far more often` catches prose describing the cadence without naming
+      either. <!-- completed: 2026-08-02T21:48 -->

--- a/docs/docs/concepts/monitoring.md
+++ b/docs/docs/concepts/monitoring.md
@@ -3,12 +3,12 @@
 `cafleet monitor` is a fleet-scoped foreground loop — `scan → wake → sleep` —
 that the fleet's dedicated **monitoring member** runs as a background task in
 its own pane. It supplies the **heartbeat** a Director needs to supervise its
-team: a plain loop, not agent reasoning, that scans the **watched set** (the
-root Director and every ordinary member, each on its own interval) and, when at
-least one watched member is due, wakes the monitoring member once by keystroking
-into its pane. While the loop runs it spends no model tokens, and because it is
-just a backgrounded command it works identically on any backend. One monitor
-and one monitoring member per fleet; there is no `monitor stop` — deleting the
+team: a plain loop, not agent reasoning, that scans the **watched set** (every
+ordinary member, each on its own interval) and, when at least one watched
+member is due, wakes the monitoring member once by keystroking into its pane.
+While the loop runs it spends no model tokens, and because it is just a
+backgrounded command it works identically on any backend. One monitor and one
+monitoring member per fleet; there is no `monitor stop` — deleting the
 monitoring member kills its pane and the loop terminates with it.
 
 ## Heartbeat vs facilitation
@@ -24,7 +24,7 @@ and may perform one fixed action; task judgment stays with the Director:
 
 The loop's only keystroke is a **wake trigger** into the monitoring member's
 own pane — a pure trigger, not a protocol payload. It names each due member as
-`<role> <id> (<sanitized-name>; coding_agent=<backend>) [<reasons>]`, carries
+`member <id> (<sanitized-name>; coding_agent=<backend>) [<reasons>]`, carries
 the Director descriptor (identifying the recipient of the monitoring member's
 reports), and closes with a single pointer sentence naming the monitoring
 member's role protocol. The tmux and herdr payloads are byte-identical. The
@@ -49,15 +49,14 @@ Enrollment is by member class:
 
 | Member class | Enrolled | `monitor` field on `GET /api/members` |
 |---|---|---|
-| The fleet's root Director | yes | A schedule object |
-| An ordinary member with a placement | yes | A schedule object |
+| An ordinary member with a placement | yes, at 720 s | A schedule object |
+| The fleet's root Director | no | `null` |
 | The dedicated monitoring member | no — it is the watcher | `null` |
 | A deregistered member | no — the row is hard-deleted on deregistration | `null` |
 | A registry row without a placement | no | `null` |
 
-The root Director is checked far more often than an ordinary member; both
-defaults live in the knob table under
-[Cadence and tick precision](#cadence-and-tick-precision).
+That ordinary-member default, and the rest of the cadence knobs, live in the
+knob table under [Cadence and tick precision](#cadence-and-tick-precision).
 
 A watched member enters the due set only from a normal trigger. The scan order
 is lifecycle reconciliation, `interval`, durable `stall-check`, native herdr
@@ -100,9 +99,10 @@ own conversation notes, not broker state. On each wake it:
 1. **Captures** every named due **ordinary** pane with
    `cafleet monitor capture --lines 120 --no-ansi --json`. Capture JSON
    includes `captured_at` and `content_sha256` of the exact emitted content.
-   Each target's rendered `coding_agent` selects its own overlay cues. A due
-   `director` entry is not captured — the monitoring member takes no
-   Director-directed pane action.
+   Each target's rendered `coding_agent` selects its own overlay cues. The
+   payload's `director` descriptor identifies the recipient of the monitoring
+   member's reports; the monitoring member takes no Director-directed pane
+   action.
 2. **Classifies** content as `awaiting_user`, `unknown`, `finished`, `working`,
    or `stall_candidate`. Any affirmative or ambiguous active-work cue is
    `working`; ambiguity between `awaiting_user` and `finished` resolves to
@@ -144,7 +144,6 @@ judgment, prompted by the monitoring member's plain message.
 
 | Knob | Default | Set by |
 |---|---|---|
-| Root Director ping interval | `180s` | `monitor_config.interval_seconds` (the Director's row) |
 | Ordinary member ping interval | `720s` | `monitor_config.interval_seconds` (each member's row) |
 | Stall-check interval | `240s` | `monitor_stall_interval` / `CAFLEET_MONITOR_STALL_INTERVAL` |
 | Unacked-delivery annotation threshold | the member's own ping interval | `monitor_config.interval_seconds` (no independent trigger) |
@@ -159,6 +158,14 @@ watcher wake commits neither dispatch timestamp.
 `CAFLEET_MONITOR_STALL_INTERVAL=0` disables stall-check wakes and therefore
 monitor pings. Unacked staleness only controls whether the hint is appended to
 a normal due row.
+
+The effective wake cadence is the shorter of the two triggers across the
+watched set. A fleet holding at least one ordinary member therefore wakes every
+240 s under the default stall-check interval, and every 720 s when
+`CAFLEET_MONITOR_STALL_INTERVAL=0` leaves only the interval trigger. A fleet
+holding just the Director and the monitoring member has an empty watched set:
+the loop claims the runtime slot and heartbeats every tick, but no wake fires
+until the first ordinary member is spawned.
 
 ## Single-instance and liveness
 

--- a/docs/docs/spec/webui-api.md
+++ b/docs/docs/spec/webui-api.md
@@ -70,7 +70,7 @@ Returns the selected fleet's roster via `list_roster(include_message_holders=Tru
       "registered_at": "2026-04-15T09:59:00+00:00",
       "kind": "director",
       "placement": null,
-      "monitor": {"interval_seconds": 180, "last_ping_at": null, "enabled": true}
+      "monitor": null
     },
     {
       "member_id": 3,
@@ -162,7 +162,7 @@ Returns one member's monitoring schedule.
 
 ```json
 {
-  "interval_seconds": 180,
+  "interval_seconds": 720,
   "last_ping_at": null,
   "enabled": true
 }

--- a/skills/cafleet/reference/supervision.md
+++ b/skills/cafleet/reference/supervision.md
@@ -26,16 +26,15 @@ The Director's plain output is **not visible to members** — the only Director�
 
 CAFleet members do not act autonomously. The Director drives the team — and the Director needs a way to wake itself up periodically to check inboxes, dispatch queued work, and detect stalls. That heartbeat is supplied by **`cafleet monitor`**, a per-fleet `scan → wake → sleep` loop that the fleet's dedicated **monitoring member** runs as a **background task** in its own pane. Because it is just a backgrounded command, the heartbeat is **backend-agnostic** — a root Director on `claude`, `codex`, or `opencode` gets the identical tick.
 
-Each tick scans the **watched set** — the root Director (default **180 s**) and
-every ordinary member (default **720 s**) — and emits at most one synchronized
-wake to the monitoring member. The loop itself never keystrokes a watched pane.
-Its fixed cadence unions `interval`, durable `stall-check`, and herdr
-`status:done` triggers; only after that union does it append `unacked` as
-annotation-only context to already-due rows. A stale delivery can never create a
-due row or an independent wake.
+Each tick scans the **watched set** — every ordinary member (default **720 s**)
+— and emits at most one synchronized wake to the monitoring member. The loop
+itself never keystrokes a watched pane. Its fixed cadence unions `interval`,
+durable `stall-check`, and herdr `status:done` triggers; only after that union
+does it append `unacked` as annotation-only context to already-due rows. A
+stale delivery can never create a due row or an independent wake.
 
 The byte-identical tmux/herdr wake is a **pure trigger**: it identifies every
-due target as `<role> <id> (<sanitized-name>; coding_agent=<backend>)
+due target as `member <id> (<sanitized-name>; coding_agent=<backend>)
 [<reasons>]`, names the Director, and points the monitoring member at its role
 protocol — nothing else. `coding_agent` selects the **target-specific**
 overlay for capture classification. Durable `last_stall_check_at` preserves
@@ -80,7 +79,7 @@ action is the fixed poll.
 
 ## The monitoring member
 
-The monitoring member is a single, dedicated coding-agent member — spawned **first** in the fleet with `cafleet member create --role monitor --model {monitor_model}` — that owns the heartbeat and applies LLM judgment to the watched members' state (the Director **and** each freshly-due member). `--role monitor` sets `member_card_json.cafleet.kind == "monitoring-member"`; the monitoring member is **not** enrolled in `monitor_config` — it is the watcher, located by that kind marker (`find_monitoring_member`), and carries no interval of its own. Only one is allowed per fleet (a second `--role monitor` spawn is rejected). It is the **one** process that runs `cafleet monitor start` (the Director never runs it — see § Spawn Protocol).
+The monitoring member is a single, dedicated coding-agent member — spawned **first** in the fleet with `cafleet member create --role monitor --model {monitor_model}` — that owns the heartbeat and applies LLM judgment to the watched members' state (each freshly-due member). `--role monitor` sets `member_card_json.cafleet.kind == "monitoring-member"`; the monitoring member is **not** enrolled in `monitor_config` — it is the watcher, located by that kind marker (`find_monitoring_member`), and carries no interval of its own. Only one is allowed per fleet (a second `--role monitor` spawn is rejected). It is the **one** process that runs `cafleet monitor start` (the Director never runs it — see § Spawn Protocol).
 
 The monitoring member's first-person routine — including per-target overlay
 selection, JSON capture identity, the two-wake quiet confirmation, the
@@ -205,7 +204,7 @@ On every supervision tick — whether fired by a monitoring-member escalation me
 |---|---|
 | Spawn the monitoring member (first-in) | The **first** `cafleet member create` in the fleet IS the monitoring member: `cafleet member create --fleet-id <fleet-id> --name monitor --description <…> --role monitor --model {monitor_model} --text-file <rendered monitor prompt>`. It boots, launches `cafleet monitor start` as a background task in its own pane, confirms the loop's startup line — `monitor loop started (fleet <fleet_id>, tick <tick>s, pid <pid>)` — in the task output, and sends `ready: monitor live` to the Director. |
 | Gate ordinary members | Wait for the monitoring member's `ready: monitor live` message before the first ordinary `cafleet member create` (consistent with the async wait rule); the admin WebUI keeps the liveness view. |
-| Run work | The monitor wakes the monitoring member whenever a watched member is due on its own interval (the root Director at 180 s, ordinary members at 720 s); do not intervene unless an escalation arrives. Each monitoring-member escalation message (or inbound work via inline preview) is the Director's cue to run the 5-step facilitation loop above. |
+| Run work | The monitor wakes the monitoring member whenever a watched ordinary member is due on its own interval (default 720 s); do not intervene unless an escalation arrives. Each monitoring-member escalation message (or inbound work via inline preview) is the Director's cue to run the 5-step facilitation loop above. |
 | User review | Keep the monitoring member and its `monitor start` task running during the review cycle — revisions and re-reviews still count as in-progress work. |
 | Teardown (first-out) | Delete the monitoring member FIRST via `cafleet member delete` — the pane kill terminates the `monitor start` loop with it — then delete the ordinary members. The authoritative full ordering is [`reference/recovery.md`](recovery.md) § *Shutdown Protocol*. |
 

--- a/skills/cafleet/roles/monitor.md
+++ b/skills/cafleet/roles/monitor.md
@@ -51,7 +51,7 @@ During a synchronized wake, never call `message broadcast` or `member prompt`, n
 ## On each wake
 
 A wake is one synchronized `[monitor] wake: …` trigger. It names each due
-target as `<role> <id> (<sanitized-name>; coding_agent=<backend>) [<reasons>]`
+target as `member <id> (<sanitized-name>; coding_agent=<backend>) [<reasons>]`
 and includes the standing Director descriptor — the recipient of your step-5
 messages. Reasons are `interval`, `status:done`, `stall-check`, and the
 annotation-only `unacked`. `unacked` never creates a due row and never
@@ -62,9 +62,9 @@ as you go; no broker state backs you.
 Follow this order exactly:
 
 1. **Capture every named due ordinary pane.** Select each target's overlay from
-   its rendered `coding_agent=` value, not from your own backend. A due
-   `director` entry is **not captured** — you take no Director-directed pane
-   action; the descriptor only identifies your report recipient. Capture with:
+   its rendered `coding_agent=` value, not from your own backend. The
+   `director` descriptor identifies your report recipient only — you take no
+   Director-directed pane action. Capture with:
 
    ```bash
    cafleet monitor capture --fleet-id <fleet-id> \
@@ -133,11 +133,11 @@ Follow this order exactly:
 ## The wake trigger you consume
 
 The loop's wake trigger is a byte-identical single line on tmux and herdr — a
-pure trigger with no protocol clauses. For example, when the Director (332)
-and member 336 "alice" are due:
+pure trigger with no protocol clauses. For example, when members 336 "alice"
+and 340 "bob" are due:
 
 ```text
-[monitor] wake: 2 members due — director 332 (Director; coding_agent=codex) [interval], member 336 (alice; coding_agent=claude) [interval,stall-check]. Director: 332 (coding_agent=codex). Follow your monitor role protocol.
+[monitor] wake: 2 members due — member 336 (alice; coding_agent=claude) [interval], member 340 (bob; coding_agent=codex) [interval,stall-check]. Director: 332 (coding_agent=codex). Follow your monitor role protocol.
 ```
 
 The count, sanitized names, `coding_agent` descriptors, reasons, and Director


### PR DESCRIPTION
- **test: repin migration chain guard to head 2**
- **docs: drop the root Director from the monitor watched set**
- **feat: add V2 migration removing Director monitor_config rows**
- **test: expect the Director unenrolled across the WebUI routes**
- **test: assert create_fleet leaves the Director unenrolled**
- **feat: leave the root Director out of the monitor watched set**
