### PR TITLE
feat/0000160 monitor batch capture

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -774,7 +774,8 @@ HTTP status). The exit-code policy is
 ### 6.3 CLI
 
 **Scope:** the entire `cafleet` command tree (16 subcommands across 3 groups +
-4 top-level commands — §1, §10), the shared argument rules, and the `member
+4 top-level commands, `monitor` two-form — §1, §10), the shared argument
+rules, and the `member
 create` spawn orchestration + rollback ladder. Orchestration glue only — it
 wires broker/multiplexer/output/coding-agent. The command/option checklist is
 §10; this section gives the per-command semantics. Exit codes are §7.2;
@@ -805,8 +806,9 @@ The id a command acts on — its **subject** — is a **required positional
 argument**; ids that describe a relationship rather than the subject stay as
 flags. The positional subjects:
 
-- `FLEET_ID` — on `fleet show`, `fleet delete`, `member list`, and `monitor`
-  (the fleet is the subject of the listing / the supervision loop).
+- `FLEET_ID` — on `fleet show`, `fleet delete`, `member list`, and both
+  `monitor` forms (the fleet is the subject of the listing / the supervision
+  loop / the batch scan).
 - `MEMBER_ID` — on `member show` / `delete` / `prompt` / `ping` / `capture`
   (the target) and `message poll` (the requester).
 - `MESSAGE_ID` — on `message ack` and `message show`.
@@ -841,7 +843,8 @@ error (exit 2).
   per-subcommand flag, canonically written **trailing**, after all other
   arguments. On every `message` subcommand; `member create` / `delete` /
   `show` / `list` / `prompt` / `ping` / `capture`; `fleet create` / `list` /
-  `show` / `delete`; and `doctor`. Emits compact single-line JSON instead of
+  `show` / `delete`; `monitor scan`; and `doctor`. Emits compact single-line
+  JSON instead of
   text. JSON is always the **complete, untruncated machine form** — full
   envelopes, full message bodies; text output is always the human/pane form,
   truncated per §6.4. `--json` is the **only** output switch in the tree.
@@ -1228,8 +1231,16 @@ stored.
 
 #### `monitor`
 
-A single top-level command — `cafleet monitor FLEET_ID [--tick N]
-[--interval N]` — with the positional `FLEET_ID` subject. A
+A two-form top-level command: the bare positional form runs the supervision
+loop; the `scan` subcommand is a one-shot batch capture. The loop positionals
+and the subcommand are mutually exclusive (args-conflict-with-subcommands
+parsing): `cafleet monitor <FLEET_ID>` parses the loop form whenever no
+subcommand is given, and `cafleet monitor scan <FLEET_ID>` dispatches the
+subcommand (`FLEET_ID` is an integer and `scan` is not, so the two forms
+cannot collide).
+
+**The loop form** — `cafleet monitor FLEET_ID [--tick N] [--interval N]` —
+with the positional `FLEET_ID` subject. A
 `_require_live_fleet` guard fetches the fleet; missing or soft-deleted
 → application error `fleet <fleet_id> not found`.
 `--tick` (integer ≥1, default 5, shown in help) and `--interval`
@@ -1242,6 +1253,68 @@ after `cafleet fleet create` and before the first `cafleet member create`.
 Immediately after the successful runtime claim, before the first tick, the
 loop prints the startup line the Director confirms before spawning any
 member: `monitor loop started (fleet <fleet_id>, tick <tick>s, pid <pid>)`.
+
+##### `monitor scan`
+
+`cafleet monitor scan FLEET_ID [--lines N] [--ansi] [--json]` — capture the
+Director's pane plus every active member's pane once, print, exit. No loop
+runs, no `monitor_runtime` row is claimed, and the command performs no DB
+writes; capture content is never stored in SQLite. Options: `--lines`
+(integer ≥1, default **20**, shown in help — trailing lines captured per
+pane), `--ansi` (boolean, default `false` — preserve ANSI escapes in every
+captured content; stripping is the default, as in `member capture`), plus the
+shared `--json`.
+
+Guards, in order (the same as the loop form): require a live fleet (missing
+or soft-deleted → application error `fleet <fleet_id> not found`), then
+resolve the multiplexer (`ensure_available` failure → exit 1).
+
+**Roster.** The Director's row first, then every other active member owning a
+placement row, ascending by `member_id`. A member with no placement row (not
+spawned via `member create`) is excluded, mirroring the wake roster's join; a
+placement row with a `NULL` pane (pending placement) stays in the roster as
+an annotated entry. A fleet with no members scans the Director's pane only.
+
+**Per-entry capture**, in roster order: a `NULL` pane → annotated entry
+`pane not available (pending placement)`; a `capture_pane` error (dead pane,
+backend failure — including the Director's own pane) → annotated entry
+`capture failed: <error>`; success → content (ANSI-stripped unless `--ansi`),
+`captured_at` stamped from local UTC at that entry's read boundary, and
+`content_sha256 = sha256(content.encode("utf-8"))` over the exact emitted
+content (mode-exact, as in `member capture`). The scan always completes: an
+annotated entry never aborts the remaining captures, and a scan whose every
+entry is annotated still exits 0.
+
+**Text mode** — one section per roster entry, separated by one blank line.
+`<name>` is the raw DB value (stdout is not a keystroke path, so no
+sanitization). `kind` is `director` or `member`:
+
+```
+=== <member-id> (<name>; kind=<kind>; coding_agent=<coding_agent>; pane=<pane-id>; captured_at=<ts>) ===
+<content>
+```
+
+An annotated entry drops `captured_at` from the header and carries the
+annotation as its body; the pane token is `—` when no pane exists, and a
+failed capture keeps its real pane id:
+
+```
+=== <member-id> (<name>; kind=<kind>; coding_agent=<coding_agent>; pane=—) ===
+pane not available (pending placement)
+```
+
+**JSON mode** — a top-level array, same order, one object per entry mirroring
+`member capture`'s keys plus `name` / `kind` / `coding_agent` / `error`, in
+this pinned key order: `member_id`, `name`, `kind`, `coding_agent`,
+`pane_id`, `lines`, `content`, `captured_at`, `content_sha256`, `error`. On a
+successful entry `error` is `null`. On an annotated entry `content`,
+`captured_at`, and `content_sha256` are `null`; `error` carries the exact
+annotation string from text mode; `pane_id` is `null` for a pending placement
+and the real pane id for a failed capture. `lines` always echoes the
+requested depth.
+
+Exit codes: `0` completed scan (annotated entries included), `1` unknown or
+soft-deleted fleet or multiplexer unreachable, `2` usage errors.
 
 #### `server`
 
@@ -1331,8 +1404,8 @@ An install failure aborts the loop; rows recorded before the failure remain.
 
 Every fleet-scoped surface — the `fleet`, `member`, and `message` groups (at
 the top of the group callback, before any subcommand body runs) and the
-`monitor` command (before its command body) — validates the recorded assets
-installs:
+`monitor` command (both forms, before the command body) — validates the
+recorded assets installs:
 
 1. If the DB file, the `asset_installs` table, or all rows are missing, exit 1
    with:
@@ -1658,12 +1731,15 @@ Director's `MultiplexerContext` and passes it directly.
   else:
 
   ```
-  [cafleet] tick: fleet <fleet_id> — health-check your <N> members: <entries>. Poll your inbox, ACK, dispatch. Resume your work if something was still running.
+  [cafleet] tick: fleet <fleet_id> — health-check your <N> members: <entries>. Scan panes with 'cafleet monitor scan <fleet_id>', poll your inbox, ACK, dispatch. Resume your work if something was still running.
   ```
 
   `N == 1` uses the singular noun (`health-check your 1 member: …`); `N == 0`
   drops the `<entries>` segment and the clause reads `no members to
-  health-check.`. The wake fires whenever the interval has elapsed and the
+  health-check.`, followed by the same scan-poll and resume sentences — the
+  scan clause is unconditional. The scan instruction uses single quotes (no
+  backtick, keeping the payload free of shell-sensitive characters). The wake
+  fires whenever the interval has elapsed and the
   Director's pane is alive — **including when the fleet has no other
   members**. The wake keystroke is literal-then-Enter with `timeout=5`s and
   **Esc-first=YES** (a wake landing on a pending permission prompt clears it
@@ -2698,7 +2774,8 @@ connection is closed when the command finishes (success or failure).
 ## 10. CLI command checklist
 
 The full command surface — **16 subcommands across 3 groups + 4 top-level
-commands**.
+commands**, one of which (`monitor`) is two-form: the bare loop plus its
+`scan` subcommand.
 Each must be reproduced with identical positional/option names, types,
 defaults, required-ness, output shapes, and exit codes. Per-command
 argument semantics are in §6.3.
@@ -2712,7 +2789,8 @@ The shared trailing `--json` flag (§6.3) is listed per row below.
 - [ ] `cafleet setup` (`--skip AGENT` repeatable choice; no positional arguments; runs the db half then the assets half for the fixed target list claude/codex/opencode minus the skipped agents)
 - [ ] `cafleet doctor` (`--json`; emits tmux block + assets-install report)
 - [ ] `cafleet server` (`--host`=settings.broker_host, `--port`=settings.broker_port)
-- [ ] `cafleet monitor FLEET_ID` (`--tick`≥1=5, `--interval`≥0=`CAFLEET_MONITOR_WAKE_INTERVAL` (default 600); prints the startup line after a successful runtime claim)
+- [ ] `cafleet monitor FLEET_ID` (the loop form; `--tick`≥1=5, `--interval`≥0=`CAFLEET_MONITOR_WAKE_INTERVAL` (default 600); prints the startup line after a successful runtime claim)
+- [ ] `cafleet monitor scan FLEET_ID` (`--lines`≥1=**20**, `--ansi`, `--json`; one-shot batch capture — Director first, then members ascending; annotated entries still exit 0)
 
 **`fleet`:**
 

--- a/cafleet/src/cli/monitor.rs
+++ b/cafleet/src/cli/monitor.rs
@@ -1,19 +1,27 @@
-//! The flattened `monitor` command (SPEC §6.3 *monitor*): the live-fleet
-//! guard and the in-process heartbeat loop.
+//! The two-form `monitor` command (SPEC §6.3 *monitor*): the live-fleet
+//! guard, the in-process heartbeat loop, and the one-shot `scan` batch
+//! capture.
 
-use clap::Args;
+use clap::{Args, Subcommand};
+use serde_json::{Value, json};
+use sha2::{Digest, Sha256};
 
-use super::helpers::connect;
+use super::helpers::{connect, emit, resolve_mux};
 use crate::broker;
 use crate::config::Settings;
 use crate::error::CafleetError;
 use crate::multiplexer::Multiplexer;
+use crate::output::strip_ansi;
+use crate::time::{format_utc, now_utc};
 
 #[derive(Args)]
+#[command(args_conflicts_with_subcommands = true, subcommand_negates_reqs = true)]
 pub struct MonitorArgs {
+    #[command(subcommand)]
+    command: Option<MonitorCommand>,
     /// Fleet whose scheduler loop to run.
-    #[arg(value_name = "FLEET_ID")]
-    fleet_id: i64,
+    #[arg(value_name = "FLEET_ID", required = true)]
+    fleet_id: Option<i64>,
     /// Scan-tick cadence in seconds.
     #[arg(long, default_value_t = crate::monitor::DEFAULT_TICK_SECONDS,
           value_parser = clap::value_parser!(i64).range(1..))]
@@ -24,20 +32,64 @@ pub struct MonitorArgs {
     interval: Option<u64>,
 }
 
-fn require_live_fleet(conn: &rusqlite::Connection, fleet_id: i64) -> Result<(), CafleetError> {
+#[derive(Subcommand)]
+enum MonitorCommand {
+    /// Capture the Director's pane and every active member's pane once.
+    Scan {
+        /// Fleet whose panes to scan.
+        #[arg(value_name = "FLEET_ID")]
+        fleet_id: i64,
+        /// Trailing lines captured per pane.
+        #[arg(long, default_value_t = 20,
+              value_parser = clap::value_parser!(i64).range(1..))]
+        lines: i64,
+        /// Preserve ANSI escapes in every captured content.
+        #[arg(long)]
+        ansi: bool,
+        /// Output in JSON format.
+        #[arg(long)]
+        json: bool,
+    },
+}
+
+fn require_live_fleet(conn: &rusqlite::Connection, fleet_id: i64) -> Result<Value, CafleetError> {
     match broker::get_fleet(conn, fleet_id)? {
-        Some(fleet) if fleet["deleted_at"].is_null() => Ok(()),
+        Some(fleet) if fleet["deleted_at"].is_null() => Ok(fleet),
         _ => Err(CafleetError::App(format!("fleet {fleet_id} not found"))),
+    }
+}
+
+/// Dispatch the two forms: the `scan` subcommand, else the loop (clap
+/// guarantees the loop positional whenever no subcommand is given).
+pub fn run(settings: &Settings, args: MonitorArgs) -> Result<(), CafleetError> {
+    match args.command {
+        Some(MonitorCommand::Scan {
+            fleet_id,
+            lines,
+            ansi,
+            json,
+        }) => scan(settings, fleet_id, lines, ansi, json),
+        None => run_loop(
+            settings,
+            args.fleet_id
+                .expect("clap guarantees the loop positional when no subcommand is given"),
+            args.tick,
+            args.interval,
+        ),
     }
 }
 
 /// Requires a live fleet, then the multiplexer; blocks in the loop until
 /// stopped or displaced.
-pub fn run(settings: &Settings, args: MonitorArgs) -> Result<(), CafleetError> {
+fn run_loop(
+    settings: &Settings,
+    fleet_id: i64,
+    tick: i64,
+    interval: Option<u64>,
+) -> Result<(), CafleetError> {
     let mut conn = connect(settings)?;
-    require_live_fleet(&conn, args.fleet_id)?;
-    let mux =
-        super::helpers::resolve_mux(settings).map_err(|e| CafleetError::App(e.to_string()))?;
+    require_live_fleet(&conn, fleet_id)?;
+    let mux = resolve_mux(settings).map_err(|e| CafleetError::App(e.to_string()))?;
     mux.ensure_available()
         .map_err(|e| CafleetError::App(e.to_string()))?;
     let mut out = std::io::stdout();
@@ -45,8 +97,112 @@ pub fn run(settings: &Settings, args: MonitorArgs) -> Result<(), CafleetError> {
         &mut conn,
         &mux,
         &mut out,
-        args.fleet_id,
-        args.tick,
-        args.interval.unwrap_or(settings.monitor_wake_interval),
+        fleet_id,
+        tick,
+        interval.unwrap_or(settings.monitor_wake_interval),
     )
+}
+
+/// One-shot batch capture (SPEC §6.3 *monitor scan*): the Director's pane
+/// first, then every other active placement-owning member ascending by
+/// member id. An annotated entry never aborts the scan; no DB writes.
+fn scan(
+    settings: &Settings,
+    fleet_id: i64,
+    lines: i64,
+    ansi: bool,
+    json_output: bool,
+) -> Result<(), CafleetError> {
+    let conn = connect(settings)?;
+    let fleet = require_live_fleet(&conn, fleet_id)?;
+    let mux = resolve_mux(settings).map_err(|e| CafleetError::App(e.to_string()))?;
+    mux.ensure_available()
+        .map_err(|e| CafleetError::App(e.to_string()))?;
+
+    let director_member_id = fleet["director_member_id"].as_i64();
+    let members = broker::list_members(&conn, fleet_id)?;
+    let mut roster: Vec<&Value> = members
+        .iter()
+        .filter(|member| member["member_id"].as_i64() == director_member_id)
+        .collect();
+    let mut rest: Vec<&Value> = members
+        .iter()
+        .filter(|member| {
+            member["member_id"].as_i64() != director_member_id && !member["placement"].is_null()
+        })
+        .collect();
+    rest.sort_by_key(|member| member["member_id"].as_i64());
+    roster.extend(rest);
+
+    let mut sections = Vec::new();
+    let mut entries = Vec::new();
+    for member in roster {
+        let member_id = &member["member_id"];
+        let name = member["name"].as_str().expect("member rows carry a name");
+        let kind = member["kind"].as_str().expect("member rows carry a kind");
+        let placement = &member["placement"];
+        let coding_agent = placement["coding_agent"]
+            .as_str()
+            .expect("roster entries own a placement row recording coding_agent");
+        let pane_id = placement["mux_pane_id"].as_str();
+
+        let outcome = match pane_id {
+            None => Err("pane not available (pending placement)".to_string()),
+            Some(pane) => mux
+                .capture_pane(pane, lines)
+                .map_err(|error| format!("capture failed: {error}"))
+                .map(|raw| if ansi { raw } else { strip_ansi(&raw) }),
+        };
+        match outcome {
+            Ok(content) => {
+                let pane = pane_id.expect("a successful capture has a pane");
+                let captured_at = format_utc(now_utc());
+                let digest = Sha256::digest(content.as_bytes());
+                let content_sha256: String =
+                    digest.iter().map(|byte| format!("{byte:02x}")).collect();
+                sections.push(format!(
+                    "=== {member_id} ({name}; kind={kind}; coding_agent={coding_agent}; \
+                     pane={pane}; captured_at={captured_at}) ===\n{content}"
+                ));
+                entries.push(json!({
+                    "member_id": member_id,
+                    "name": name,
+                    "kind": kind,
+                    "coding_agent": coding_agent,
+                    "pane_id": pane,
+                    "lines": lines,
+                    "content": content,
+                    "captured_at": captured_at,
+                    "content_sha256": content_sha256,
+                    "error": Value::Null,
+                }));
+            }
+            Err(annotation) => {
+                let pane_token = pane_id.unwrap_or("—");
+                sections.push(format!(
+                    "=== {member_id} ({name}; kind={kind}; coding_agent={coding_agent}; \
+                     pane={pane_token}) ===\n{annotation}"
+                ));
+                entries.push(json!({
+                    "member_id": member_id,
+                    "name": name,
+                    "kind": kind,
+                    "coding_agent": coding_agent,
+                    "pane_id": pane_id,
+                    "lines": lines,
+                    "content": Value::Null,
+                    "captured_at": Value::Null,
+                    "content_sha256": Value::Null,
+                    "error": annotation,
+                }));
+            }
+        }
+    }
+
+    if json_output {
+        emit(true, &Value::Array(entries), String::new);
+    } else {
+        println!("{}", sections.join("\n\n"));
+    }
+    Ok(())
 }

--- a/cafleet/src/multiplexer/mod.rs
+++ b/cafleet/src/multiplexer/mod.rs
@@ -398,7 +398,8 @@ mod tests {
                 "[cafleet] tick: fleet 3 — health-check your 2 members: \
                  4 (drafter; coding_agent=claude; unacked=2), \
                  5 (reviewer; coding_agent=codex; unacked=0). \
-                 Poll your inbox, ACK, dispatch. \
+                 Scan panes with 'cafleet monitor scan 3', \
+                 poll your inbox, ACK, dispatch. \
                  Resume your work if something was still running."
             );
         }
@@ -410,7 +411,8 @@ mod tests {
                 payload,
                 "[cafleet] tick: fleet 7 — health-check your 1 member: \
                  4 (worker; coding_agent=opencode; unacked=1). \
-                 Poll your inbox, ACK, dispatch. \
+                 Scan panes with 'cafleet monitor scan 7', \
+                 poll your inbox, ACK, dispatch. \
                  Resume your work if something was still running."
             );
         }
@@ -421,7 +423,8 @@ mod tests {
             assert_eq!(
                 payload,
                 "[cafleet] tick: fleet 7 — no members to health-check. \
-                 Poll your inbox, ACK, dispatch. \
+                 Scan panes with 'cafleet monitor scan 7', \
+                 poll your inbox, ACK, dispatch. \
                  Resume your work if something was still running."
             );
         }

--- a/cafleet/src/multiplexer/mod.rs
+++ b/cafleet/src/multiplexer/mod.rs
@@ -136,7 +136,8 @@ pub fn build_wake_payload(fleet_id: i64, members: &[Value]) -> Result<String, Mu
         format!("health-check your {} {noun}: {entries}.", members.len())
     };
     Ok(format!(
-        "[cafleet] tick: fleet {fleet_id} — {clause} Poll your inbox, ACK, dispatch. \
+        "[cafleet] tick: fleet {fleet_id} — {clause} Scan panes with \
+         'cafleet monitor scan {fleet_id}', poll your inbox, ACK, dispatch. \
          Resume your work if something was still running."
     ))
 }

--- a/cafleet/tests/cli_member.rs
+++ b/cafleet/tests/cli_member.rs
@@ -640,3 +640,321 @@ fn monitor_no_longer_parses_a_capture_subcommand() {
         stderr(&output)
     );
 }
+
+#[test]
+fn monitor_loop_form_still_parses_the_positional_and_flags() {
+    let cli = Cli::new();
+    cli.ready();
+
+    let output = cli.run(&["monitor", "999", "--tick", "1", "--interval", "5"]);
+    assert_eq!(
+        code(&output),
+        1,
+        "the loop form parses and reaches the live-fleet guard"
+    );
+    assert!(
+        stderr(&output).contains("Error: fleet 999 not found"),
+        "got: {}",
+        stderr(&output)
+    );
+
+    let bare = cli.run(&["monitor"]);
+    assert_eq!(code(&bare), 2, "a fleet id or a subcommand is required");
+
+    let leaked = cli.run(&["monitor", "1", "--lines", "20"]);
+    assert_eq!(
+        code(&leaked),
+        2,
+        "scan flags do not parse on the loop form: {}",
+        stderr(&leaked)
+    );
+
+    let no_fleet = cli.run(&["monitor", "scan"]);
+    assert_eq!(
+        code(&no_fleet),
+        2,
+        "the scan form carries its own FLEET_ID positional: {}",
+        stderr(&no_fleet)
+    );
+}
+
+#[test]
+fn monitor_scan_prints_director_first_then_members_ascending() {
+    let cli = Cli::new();
+    let (fleet_id, _) = cli.with_fleet();
+    let alpha_id = cli.create_member(fleet_id, "alpha");
+    let beta_id = cli.create_member(fleet_id, "beta");
+
+    let output = cli.run(&["monitor", "scan", &fleet_id.to_string()]);
+    assert_eq!(code(&output), 0, "stderr: {}", stderr(&output));
+    let out = stdout(&output);
+    assert!(
+        out.starts_with(
+            "=== 1 (Director; kind=director; coding_agent=claude; pane=%0; captured_at="
+        ),
+        "the Director's section leads, got: {out}"
+    );
+
+    let alpha_header =
+        format!("=== {alpha_id} (alpha; kind=member; coding_agent=claude; pane=%7; captured_at=");
+    let beta_header =
+        format!("=== {beta_id} (beta; kind=member; coding_agent=claude; pane=%7; captured_at=");
+    assert!(out.contains(&alpha_header), "got: {out}");
+    assert!(out.contains(&beta_header), "got: {out}");
+    assert!(
+        out.find(&alpha_header).unwrap() < out.find(&beta_header).unwrap(),
+        "members ascend by member_id: {out}"
+    );
+    assert!(
+        out.contains(&format!("line1\nline2\n\n{alpha_header}")),
+        "one blank line separates sections, got: {out}"
+    );
+
+    let with_ansi = cli.run(&["monitor", "scan", &fleet_id.to_string(), "--ansi"]);
+    assert_eq!(code(&with_ansi), 0, "--ansi is accepted");
+}
+
+#[test]
+fn monitor_scan_json_pins_the_key_order() {
+    let cli = Cli::new();
+    let (fleet_id, _) = cli.with_fleet();
+    let member_id = cli.create_member(fleet_id, "worker");
+
+    let output = cli.run(&["monitor", "scan", &fleet_id.to_string(), "--json"]);
+    assert_eq!(code(&output), 0, "stderr: {}", stderr(&output));
+    let payload: serde_json::Value = serde_json::from_str(stdout(&output).trim()).unwrap();
+    let entries = payload.as_array().expect("a top-level array");
+    assert_eq!(entries.len(), 2, "the Director plus one member");
+
+    for entry in entries {
+        let keys: Vec<&str> = entry
+            .as_object()
+            .unwrap()
+            .keys()
+            .map(String::as_str)
+            .collect();
+        assert_eq!(
+            keys,
+            [
+                "member_id",
+                "name",
+                "kind",
+                "coding_agent",
+                "pane_id",
+                "lines",
+                "content",
+                "captured_at",
+                "content_sha256",
+                "error",
+            ],
+            "the scan key order is pinned"
+        );
+    }
+
+    let director = &entries[0];
+    assert_eq!(director["member_id"], 1);
+    assert_eq!(director["name"], "Director");
+    assert_eq!(director["kind"], "director");
+    assert_eq!(director["coding_agent"], "claude");
+    assert_eq!(director["pane_id"], "%0");
+    assert_eq!(director["lines"], 20);
+    assert_eq!(director["error"], serde_json::Value::Null);
+    assert!(
+        director["captured_at"].as_str().is_some(),
+        "captured_at is stamped on a successful capture"
+    );
+
+    let content = director["content"].as_str().unwrap();
+    assert!(
+        content.contains("line1"),
+        "the shim's canned buffer, got: {content}"
+    );
+    use sha2::{Digest, Sha256};
+    let digest = Sha256::digest(content.as_bytes());
+    let expected: String = digest.iter().map(|b| format!("{b:02x}")).collect();
+    assert_eq!(
+        director["content_sha256"], expected,
+        "mode-exact hash of the emitted content"
+    );
+
+    let member = &entries[1];
+    assert_eq!(member["member_id"], member_id);
+    assert_eq!(member["kind"], "member");
+    assert_eq!(member["pane_id"], "%7");
+}
+
+#[test]
+fn monitor_scan_annotates_a_pending_placement_and_exits_zero() {
+    let cli = Cli::new();
+    let (fleet_id, _) = cli.with_fleet();
+    let member_id = cli.create_member(fleet_id, "worker");
+    cli.sqlite()
+        .execute(
+            "UPDATE member_placements SET mux_pane_id=NULL WHERE member_id=?1",
+            [member_id],
+        )
+        .unwrap();
+
+    let output = cli.run(&["monitor", "scan", &fleet_id.to_string()]);
+    assert_eq!(
+        code(&output),
+        0,
+        "an annotated entry never aborts the scan: {}",
+        stderr(&output)
+    );
+    assert!(
+        stdout(&output).contains(&format!(
+            "=== {member_id} (worker; kind=member; coding_agent=claude; pane=—) ===\n\
+             pane not available (pending placement)"
+        )),
+        "got: {}",
+        stdout(&output)
+    );
+
+    let output = cli.run(&["monitor", "scan", &fleet_id.to_string(), "--json"]);
+    let payload: serde_json::Value = serde_json::from_str(stdout(&output).trim()).unwrap();
+    let entry = payload
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|entry| entry["member_id"] == member_id)
+        .expect("the pending-placement member stays in the roster");
+    assert_eq!(entry["pane_id"], serde_json::Value::Null);
+    assert_eq!(entry["lines"], 20, "lines echoes the requested depth");
+    assert_eq!(entry["content"], serde_json::Value::Null);
+    assert_eq!(entry["captured_at"], serde_json::Value::Null);
+    assert_eq!(entry["content_sha256"], serde_json::Value::Null);
+    assert_eq!(entry["error"], "pane not available (pending placement)");
+}
+
+#[test]
+fn monitor_scan_annotates_failed_captures_and_exits_zero() {
+    let mut cli = Cli::new();
+    let (fleet_id, _) = cli.with_fleet();
+    cli.create_member(fleet_id, "worker");
+    cli.fail_subcommand = Some("capture-pane".to_string());
+
+    let output = cli.run(&["monitor", "scan", &fleet_id.to_string()]);
+    assert_eq!(
+        code(&output),
+        0,
+        "a scan whose every entry is annotated still exits 0: {}",
+        stderr(&output)
+    );
+    let out = stdout(&output);
+    assert!(
+        out.contains(
+            "=== 1 (Director; kind=director; coding_agent=claude; pane=%0) ===\ncapture failed: "
+        ),
+        "a failed capture keeps its real pane id, got: {out}"
+    );
+    assert!(
+        out.contains("forced failure"),
+        "the backend error rides the annotation, got: {out}"
+    );
+
+    let output = cli.run(&["monitor", "scan", &fleet_id.to_string(), "--json"]);
+    let payload: serde_json::Value = serde_json::from_str(stdout(&output).trim()).unwrap();
+    let entries = payload.as_array().unwrap();
+    assert_eq!(entries[0]["pane_id"], "%0", "the real pane id is kept");
+    for entry in entries {
+        assert_eq!(entry["content"], serde_json::Value::Null);
+        assert_eq!(entry["captured_at"], serde_json::Value::Null);
+        assert_eq!(entry["content_sha256"], serde_json::Value::Null);
+        assert!(
+            entry["error"]
+                .as_str()
+                .unwrap()
+                .starts_with("capture failed: "),
+            "got: {}",
+            entry["error"]
+        );
+    }
+}
+
+#[test]
+fn monitor_scan_excludes_a_member_without_a_placement_row() {
+    let cli = Cli::new();
+    let (fleet_id, _) = cli.with_fleet();
+    let member_id = cli.create_member(fleet_id, "worker");
+    cli.sqlite()
+        .execute(
+            "DELETE FROM member_placements WHERE member_id=?1",
+            [member_id],
+        )
+        .unwrap();
+
+    let output = cli.run(&["monitor", "scan", &fleet_id.to_string()]);
+    assert_eq!(code(&output), 0, "stderr: {}", stderr(&output));
+    assert!(
+        !stdout(&output).contains(&format!("=== {member_id} ")),
+        "a placementless member is excluded, got: {}",
+        stdout(&output)
+    );
+}
+
+#[test]
+fn monitor_scan_of_a_memberless_fleet_captures_the_director_only() {
+    let cli = Cli::new();
+    let (fleet_id, _) = cli.with_fleet();
+
+    let output = cli.run(&["monitor", "scan", &fleet_id.to_string()]);
+    assert_eq!(code(&output), 0, "stderr: {}", stderr(&output));
+    let out = stdout(&output);
+    assert!(
+        out.starts_with("=== 1 (Director; kind=director;"),
+        "got: {out}"
+    );
+    assert_eq!(
+        out.matches("=== 1 (").count(),
+        1,
+        "exactly one section, got: {out}"
+    );
+    assert!(
+        !out[3..].contains("\n=== "),
+        "no member sections follow, got: {out}"
+    );
+}
+
+#[test]
+fn monitor_scan_rejects_an_unknown_or_deleted_fleet() {
+    let cli = Cli::new();
+    let (fleet_id, _) = cli.with_fleet();
+
+    let output = cli.run(&["monitor", "scan", "999"]);
+    assert_eq!(code(&output), 1);
+    assert!(
+        stderr(&output).contains("Error: fleet 999 not found"),
+        "got: {}",
+        stderr(&output)
+    );
+
+    let deleted = cli.run(&["fleet", "delete", &fleet_id.to_string()]);
+    assert_eq!(code(&deleted), 0, "stderr: {}", stderr(&deleted));
+    let output = cli.run(&["monitor", "scan", &fleet_id.to_string()]);
+    assert_eq!(code(&output), 1, "a soft-deleted fleet is not scannable");
+    assert!(
+        stderr(&output).contains(&format!("Error: fleet {fleet_id} not found")),
+        "got: {}",
+        stderr(&output)
+    );
+}
+
+#[test]
+fn monitor_scan_honors_the_lines_flag() {
+    let cli = Cli::new();
+    let (fleet_id, _) = cli.with_fleet();
+
+    let output = cli.run(&["monitor", "scan", &fleet_id.to_string(), "--lines", "5"]);
+    assert_eq!(code(&output), 0, "stderr: {}", stderr(&output));
+    assert!(
+        cli.shim_calls()
+            .iter()
+            .any(|line| line.contains("capture-pane -p -t %0 -S -1005")),
+        "the requested depth rides the A8 over-fetch: {:?}",
+        cli.shim_calls()
+    );
+
+    let zero = cli.run(&["monitor", "scan", &fleet_id.to_string(), "--lines", "0"]);
+    assert_eq!(code(&zero), 2, "lines must be >= 1: {}", stderr(&zero));
+}

--- a/cafleet/tests/e2e.rs
+++ b/cafleet/tests/e2e.rs
@@ -88,7 +88,8 @@ fn end_to_end_lifecycle_with_one_monitor_tick() {
             "[cafleet] tick: fleet 1 — health-check your 2 members: \
              {worker_id} (worker; coding_agent=claude; unacked=0), \
              {helper_id} (helper; coding_agent=claude; unacked=0). \
-             Poll your inbox, ACK, dispatch. \
+             Scan panes with 'cafleet monitor scan 1', \
+             poll your inbox, ACK, dispatch. \
              Resume your work if something was still running."
         ))),
         "the wake keystroke reached the Director's pane, got: {:?}",

--- a/design-docs/0000160-monitor-batch-capture/design-doc.md
+++ b/design-docs/0000160-monitor-batch-capture/design-doc.md
@@ -1,7 +1,7 @@
 # Batch Capture — `cafleet monitor scan`
 
 **Status**: Approved
-**Progress**: 8/12 tasks complete
+**Progress**: 9/12 tasks complete
 **Last Updated**: 2026-08-04
 
 ## Overview
@@ -159,7 +159,7 @@ Loop cadence and flags, the `monitor_runtime` schema and wake ledger, `member ca
 
 ### Step 4: Wake payload (code)
 
-- [ ] `cafleet/src/multiplexer/mod.rs`: add the scan clause to the poll sentence in `build_wake_payload` (both the roster and `N == 0` forms); update the colocated payload tests and the verbatim payload assertion in `cafleet/tests/e2e.rs` (the tmux/herdr colocated tests compare against `build_wake_payload` output and need no edit) <!-- completed: -->
+- [x] `cafleet/src/multiplexer/mod.rs`: add the scan clause to the poll sentence in `build_wake_payload` (both the roster and `N == 0` forms); update the colocated payload tests and the verbatim payload assertion in `cafleet/tests/e2e.rs` (the tmux/herdr colocated tests compare against `build_wake_payload` output and need no edit) <!-- completed: 2026-08-04T12:39 -->
 
 ### Step 5: `cafleet monitor scan` (code)
 

--- a/design-docs/0000160-monitor-batch-capture/design-doc.md
+++ b/design-docs/0000160-monitor-batch-capture/design-doc.md
@@ -10,12 +10,12 @@ Add `cafleet monitor scan`, a one-shot command that captures the Director's own 
 
 ## Success Criteria
 
-- [ ] `cafleet monitor scan <FLEET_ID>` prints one section per pane — Director first, then members ascending by `member_id` — in a single invocation; `--json` emits the pinned array shape.
-- [ ] A pending placement or a failed pane capture renders an annotated entry and the scan still completes with exit 0.
-- [ ] The loop form `cafleet monitor <FLEET_ID> [--tick N] [--interval N]` parses and behaves exactly as before.
-- [ ] The wake payload carries the scan instruction, byte-identical on tmux and herdr.
-- [ ] The supervision protocol documents one fresh scan per facilitation turn as satisfying the pre-ping capture gate for all members; `cafleet member capture` remains the targeted deeper-investigation primitive.
-- [ ] `docs/`, `SPEC.md`, and the affected `skills/` pages are updated with zero drift; `mise //cafleet:test`, `mise //cafleet:lint`, and `mise //cafleet:typecheck` pass.
+- [x] `cafleet monitor scan <FLEET_ID>` prints one section per pane — Director first, then members ascending by `member_id` — in a single invocation; `--json` emits the pinned array shape.
+- [x] A pending placement or a failed pane capture renders an annotated entry and the scan still completes with exit 0.
+- [x] The loop form `cafleet monitor <FLEET_ID> [--tick N] [--interval N]` parses and behaves exactly as before.
+- [x] The wake payload carries the scan instruction, byte-identical on tmux and herdr.
+- [x] The supervision protocol documents one fresh scan per facilitation turn as satisfying the pre-ping capture gate for all members; `cafleet member capture` remains the targeted deeper-investigation primitive.
+- [x] `docs/`, `SPEC.md`, and the affected `skills/` pages are updated with zero drift; `mise //cafleet:test`, `mise //cafleet:lint`, and `mise //cafleet:typecheck` pass.
 
 ---
 

--- a/design-docs/0000160-monitor-batch-capture/design-doc.md
+++ b/design-docs/0000160-monitor-batch-capture/design-doc.md
@@ -1,0 +1,180 @@
+# Batch Capture — `cafleet monitor scan`
+
+**Status**: Approved
+**Progress**: 3/12 tasks complete
+**Last Updated**: 2026-08-04
+
+## Overview
+
+Add `cafleet monitor scan`, a one-shot command that captures the Director's own pane and every active member's pane in a single invocation — one synchronized fleet snapshot instead of N sequential `cafleet member capture` calls. The periodic wake payload gains an instruction to run it, and one fresh scan satisfies the Director's pre-ping capture gate for every member for that facilitation turn. Implements GitHub issue #269.
+
+## Success Criteria
+
+- [ ] `cafleet monitor scan <FLEET_ID>` prints one section per pane — Director first, then members ascending by `member_id` — in a single invocation; `--json` emits the pinned array shape.
+- [ ] A pending placement or a failed pane capture renders an annotated entry and the scan still completes with exit 0.
+- [ ] The loop form `cafleet monitor <FLEET_ID> [--tick N] [--interval N]` parses and behaves exactly as before.
+- [ ] The wake payload carries the scan instruction, byte-identical on tmux and herdr.
+- [ ] The supervision protocol documents one fresh scan per facilitation turn as satisfying the pre-ping capture gate for all members; `cafleet member capture` remains the targeted deeper-investigation primitive.
+- [ ] `docs/`, `SPEC.md`, and the affected `skills/` pages are updated with zero drift; `mise //cafleet:test`, `mise //cafleet:lint`, and `mise //cafleet:typecheck` pass.
+
+---
+
+## Background
+
+Issue #269 lists four bullets. The first two — "drop per-member monitor interval" and "common global monitor interval" — are already satisfied by design 0000158, which removed the dedicated monitoring member and the per-member schedule (migration `V4__fleet_level_wake_schedule.sql`) and left a single fleet-level wake interval. This design delivers only the remaining bullets: "self + all members monitor at the same time" via the new `cafleet monitor scan` command (user decision).
+
+Today the Director's on-wake health check reads panes one at a time: `cafleet member capture <member-id> --lines 120` per member, so a 5-member fleet costs 6 CLI calls (including a self check) and the captures are taken at different moments. The batch scan replaces that with one invocation capturing all panes back-to-back — milliseconds apart, which the user confirmed satisfies "at the same time".
+
+---
+
+## Specification
+
+### CLI surface
+
+`cafleet monitor` becomes a two-form command. The bare positional form stays the loop; `scan` is a new one-shot subcommand. Both run behind the existing stale-assets guard.
+
+| Form | Behavior |
+|---|---|
+| `cafleet monitor FLEET_ID [--tick N] [--interval N]` | Unchanged: the in-process scheduler loop. |
+| `cafleet monitor scan FLEET_ID [--lines N] [--ansi] [--json]` | New: capture the Director's pane + every active member's pane once, print, exit. No loop, no `monitor_runtime` claim, no DB writes. |
+
+clap wiring: `MonitorArgs` gains `#[command(subcommand)] command: Option<MonitorCommand>` with `args_conflicts_with_subcommands = true` and `subcommand_negates_reqs = true`, so `cafleet monitor 16` still parses the loop positionals while `cafleet monitor scan 16` dispatches the subcommand. `FLEET_ID` is an integer and `scan` is not, so the two forms cannot collide. Because the `scan` form supplies no loop positional, the loop's `fleet_id: i64` field becomes `Option<i64>` — the `Scan` variant carries its own `FLEET_ID` positional plus the three flags — and the loop dispatch unwraps it with `.expect(...)` (clap guarantees the positional whenever no subcommand is given).
+
+Scan flags:
+
+| Flag | Required | Notes |
+|---|---|---|
+| `--lines` | no | Trailing lines captured per pane (an integer ≥ 1 via `value_parser` range, default **20** — user decision). |
+| `--ansi` | no | Preserve ANSI escapes in every captured content (default: stripped, as in `member capture`). |
+| `--json` | no | Emit the JSON array below instead of the text sections. |
+
+### Scan roster
+
+1. Require a live fleet (soft-deleted or unknown → `Error: fleet <id> not found`, exit 1) and resolve the multiplexer (`ensure_available` failure → exit 1) — the same guards as the loop form.
+2. Read the fleet's `director_member_id` and `broker::list_members(fleet_id)` (active members only).
+3. Roster = the Director's row first, then every other active member **owning a placement row**, ascending by `member_id`. A member with no placement row (not spawned via `member create`) is excluded, mirroring the wake roster's join. A placement row with a `NULL` pane (pending placement) stays in the roster as an annotated entry.
+4. A fleet with no members scans the Director's pane only (user decision).
+
+### Per-entry capture
+
+For each roster entry, in order:
+
+| Condition | Entry outcome |
+|---|---|
+| `mux_pane_id` is `NULL` (pending placement) | Annotated entry: `pane not available (pending placement)`. |
+| `capture_pane(pane, lines)` errors (dead pane, backend failure — includes the Director's own pane) | Annotated entry: `capture failed: <error>`. |
+| Capture succeeds | Content (ANSI-stripped unless `--ansi`), `captured_at` stamped from local UTC at that entry's read boundary, `content_sha256` over the emitted content. |
+
+The scan always completes: an annotated entry never aborts the remaining captures, and a scan whose every entry is annotated still exits 0 (user decision). Capture content is never stored in SQLite; the command performs no DB writes (user decision).
+
+### Output contract
+
+**Text mode** — one section per roster entry, separated by one blank line. `<name>` is the raw DB value (stdout is not a keystroke path, so no sanitization). `kind` is `director` or `member`, making the Director row self-identifying beyond its first position.
+
+```text
+=== <member-id> (<name>; kind=<kind>; coding_agent=<coding_agent>; pane=<pane-id>; captured_at=<ts>) ===
+<content>
+```
+
+Annotated entry (pane token is `—` when no pane exists; a failed capture keeps its real pane id):
+
+```text
+=== <member-id> (<name>; kind=<kind>; coding_agent=<coding_agent>; pane=—) ===
+pane not available (pending placement)
+```
+
+**JSON mode** — a top-level array, same order, one object per entry mirroring `member capture`'s keys plus `name` / `kind` / `coding_agent` / `error`, in this pinned key order:
+
+```json
+{
+  "member_id": 4,
+  "name": "drafter",
+  "kind": "member",
+  "coding_agent": "claude",
+  "pane_id": "%2",
+  "lines": 20,
+  "content": "…",
+  "captured_at": "2026-08-04T11:20:00.000000+00:00",
+  "content_sha256": "…",
+  "error": null
+}
+```
+
+On an annotated entry: `content`, `captured_at`, and `content_sha256` are `null`; `error` carries the exact annotation string from text mode; `pane_id` is `null` for a pending placement and the real pane id for a failed capture. `lines` always echoes the requested depth.
+
+Exit codes: `0` completed scan (annotated entries included), `1` unknown/deleted fleet or multiplexer unreachable, `2` usage errors.
+
+### Wake payload
+
+In `build_wake_payload`, the poll sentence gains a leading scan clause — `Poll your inbox, ACK, dispatch.` becomes `Scan panes with 'cafleet monitor scan <fleet-id>', poll your inbox, ACK, dispatch.` — so the instruction travels with the trigger (user decision). The clause is unconditional (present in the `N == 0` form too), keeps the payload single-line and byte-identical on tmux and herdr, and uses single quotes (no backticks, keeping the envelope free of shell-sensitive characters like the sanitized name fields). The pinned block below is normative:
+
+```text
+[cafleet] tick: fleet <fleet-id> — health-check your <N> members: <entries>. Scan panes with 'cafleet monitor scan <fleet-id>', poll your inbox, ACK, dispatch. Resume your work if something was still running.
+```
+
+`N == 0` clause unchanged in shape: `no members to health-check.` followed by the same scan-poll sentence and resume sentence. Entry grammar (`<member-id> (<name>; coding_agent=<agent>; unacked=<pending-count>)`), sanitization, and the fail-closed unregistered-coding-agent check are unchanged.
+
+### Supervision-gate semantics
+
+The pre-ping capture gate's normative capture becomes the batch scan (user decision):
+
+- One fresh `cafleet monitor scan <fleet-id>` at the default depth (20 lines per pane) satisfies the gate for **every** member for that facilitation turn.
+- The gate depth is **20 lines everywhere**: the previous normative `--lines 120` single-member capture is retired, and a default-depth capture — batch scan or single-member `member capture` — satisfies the gate. Deeper captures remain valid gate captures.
+- Per-target freshness caveat: once the Director keystrokes a pane (`ping` / non-exempt `send` / `prompt`), the scan snapshot of that pane is stale — a further re-engagement of the same member within the turn needs a fresh capture (single-member `member capture` or a new scan).
+- `cafleet member capture` stays unchanged as the targeted deeper-investigation primitive ("scan for all and capture if you need to investigate more" — user decision); a fresh single-member capture at default depth or deeper satisfies the gate for that one member.
+- The Stage-2 "doubles as the gate capture" note in `skills/cafleet/reference/supervision.md` becomes: a Stage-2 `member capture` doubles as the gate capture for that member while still fresh (same facilitation turn, no intervening keystroke into that pane) — the depth qualifier disappears with the 120-line rule.
+- Classification cues, the classification table, the skip rules, and the broadcast all-recipients rule are untouched.
+
+### Permission coverage
+
+The claude-side `permissions.allow` set is mechanical prefix patterns (`docs/docs/spec/cli-options.md` § `permissions.allow` coverage), so the loop form's existing `Bash(cafleet monitor *)` pattern already covers `cafleet monitor scan …` — no new pattern is required, and no permission prompt fires on the per-wake scan. The coverage section gains one sentence stating that both `monitor` forms ride the single pattern (Step 1). The opencode preset's `cafleet *` allow rule likewise already covers the subcommand.
+
+### Out of scope / unchanged
+
+Loop cadence and flags, the `monitor_runtime` schema and wake ledger, `member capture` / `ping` / `prompt`, the WebUI API, the data model, environment variables, and `README.md` (thin surface untouched).
+
+---
+
+## Implementation
+
+> Task format: `- [x] Done task <!-- completed: 2026-02-13T14:30 -->`
+> When completing a task, check the box and record the timestamp in the same edit.
+
+### Step 1: User-facing docs
+
+- [x] `docs/docs/concepts/monitoring.md`: describe the batch scan as the facilitation snapshot (heartbeat/facilitation split unchanged), update the wake-payload description and the capture-gate paragraph to the scan-based gate <!-- completed: 2026-08-04T12:25 -->
+- [x] `docs/docs/spec/cli-options.md`: rewrite § `cafleet monitor` as the two-form command; add the `cafleet monitor scan` subsection (flags, roster, output contract, exit codes) with anchor `#cafleet-monitor-scan`; update the command summary row and the Error Messages rows; add the § `permissions.allow` coverage sentence stating both `monitor` forms ride the single `Bash(cafleet monitor *)` pattern <!-- completed: 2026-08-04T12:25 -->
+- [x] `docs/docs/spec/multiplexer-backends.md`: update the wake payload grammar block and the example to the scan-instruction form <!-- completed: 2026-08-04T12:25 -->
+
+### Step 2: SPEC.md
+
+- [ ] Update the CLI surface (§6.3): the `monitor` two-form spec, scan flags, roster rules, text/JSON output shapes with pinned key order, exit codes, and the capture-never-stored note <!-- completed: -->
+- [ ] Update the wake-payload text everywhere SPEC pins it (`build_wake_payload`, the §6.5/§6.6 payload grammar and examples) <!-- completed: -->
+
+### Step 3: Skills
+
+- [ ] `skills/cafleet/reference/supervision.md`: make the fresh scan the normative gate capture (one scan per facilitation turn covers all members; gate depth 20 everywhere per § Supervision-gate semantics, retiring the `--lines 120` rule; per-target freshness caveat after any keystroke); update health-check step 4(c) and the Quick Reference table; replace the Stage-2 "doubles as the gate capture" note with the freshness-only form pinned in § Supervision-gate semantics <!-- completed: -->
+- [ ] `skills/cafleet/reference/cli.md`: document `monitor scan` in the monitor paragraph and reposition `member capture` as the targeted deeper-investigation primitive <!-- completed: -->
+- [ ] `skills/cafleet/reference/director.md`: add the batch scan as the fleet-wide read primitive alongside the `member capture` section <!-- completed: -->
+
+### Step 4: Wake payload (code)
+
+- [ ] `cafleet/src/multiplexer/mod.rs`: add the scan clause to the poll sentence in `build_wake_payload` (both the roster and `N == 0` forms); update the colocated payload tests and the verbatim payload assertion in `cafleet/tests/e2e.rs` (the tmux/herdr colocated tests compare against `build_wake_payload` output and need no edit) <!-- completed: -->
+
+### Step 5: `cafleet monitor scan` (code)
+
+- [ ] `cafleet/src/cli/monitor.rs`: restructure `MonitorArgs` with `args_conflicts_with_subcommands` + `subcommand_negates_reqs`, turning the loop's `fleet_id` positional into `Option<i64>` (the `Scan` variant carries its own `FLEET_ID` positional; the loop dispatch unwraps); implement the scan handler (live-fleet guard, mux resolution, roster, per-entry capture with annotations, text/JSON emit) <!-- completed: -->
+- [ ] Tests: loop-form parse/behavior regression; scan text sections and ordering (Director first); scan JSON key set and key order; annotated entries (pending placement, failed capture) with exit 0; unknown fleet error <!-- completed: -->
+
+### Step 6: Verification
+
+- [ ] `mise //cafleet:format`, `mise //cafleet:lint`, `mise //cafleet:typecheck`, `mise //cafleet:test` all green <!-- completed: -->
+
+---
+
+## Changelog
+
+| Date | Changes |
+|------|---------|
+| 2026-08-04 | Initial draft |
+| 2026-08-04 | Review round 1: pinned the `Option<i64>` clap field change, the normative wake-payload block (scan clause folded into the poll sentence), the 20-line gate depth everywhere with the new Stage-2 note text, the `Bash(cafleet monitor *)` permission-coverage outcome, and the `e2e.rs` payload assertion; dropped the unresolvable decision letter codes |

--- a/design-docs/0000160-monitor-batch-capture/design-doc.md
+++ b/design-docs/0000160-monitor-batch-capture/design-doc.md
@@ -1,7 +1,7 @@
 # Batch Capture — `cafleet monitor scan`
 
 **Status**: Approved
-**Progress**: 3/12 tasks complete
+**Progress**: 5/12 tasks complete
 **Last Updated**: 2026-08-04
 
 ## Overview
@@ -148,8 +148,8 @@ Loop cadence and flags, the `monitor_runtime` schema and wake ledger, `member ca
 
 ### Step 2: SPEC.md
 
-- [ ] Update the CLI surface (§6.3): the `monitor` two-form spec, scan flags, roster rules, text/JSON output shapes with pinned key order, exit codes, and the capture-never-stored note <!-- completed: -->
-- [ ] Update the wake-payload text everywhere SPEC pins it (`build_wake_payload`, the §6.5/§6.6 payload grammar and examples) <!-- completed: -->
+- [x] Update the CLI surface (§6.3): the `monitor` two-form spec, scan flags, roster rules, text/JSON output shapes with pinned key order, exit codes, and the capture-never-stored note <!-- completed: 2026-08-04T12:30 -->
+- [x] Update the wake-payload text everywhere SPEC pins it (`build_wake_payload`, the §6.5/§6.6 payload grammar and examples) <!-- completed: 2026-08-04T12:30 -->
 
 ### Step 3: Skills
 

--- a/design-docs/0000160-monitor-batch-capture/design-doc.md
+++ b/design-docs/0000160-monitor-batch-capture/design-doc.md
@@ -1,6 +1,6 @@
 # Batch Capture — `cafleet monitor scan`
 
-**Status**: Approved
+**Status**: Complete
 **Progress**: 12/12 tasks complete
 **Last Updated**: 2026-08-04
 
@@ -178,3 +178,4 @@ Loop cadence and flags, the `monitor_runtime` schema and wake ledger, `member ca
 |------|---------|
 | 2026-08-04 | Initial draft |
 | 2026-08-04 | Review round 1: pinned the `Option<i64>` clap field change, the normative wake-payload block (scan clause folded into the poll sentence), the 20-line gate depth everywhere with the new Stage-2 note text, the `Bash(cafleet monitor *)` permission-coverage outcome, and the `e2e.rs` payload assertion; dropped the unresolvable decision letter codes |
+| 2026-08-04 | Implementation complete: 12/12 tasks, Phase D E2E 6/6 criteria, Reviewer approved round 1, PR #272 opened; status → Complete |

--- a/design-docs/0000160-monitor-batch-capture/design-doc.md
+++ b/design-docs/0000160-monitor-batch-capture/design-doc.md
@@ -1,7 +1,7 @@
 # Batch Capture — `cafleet monitor scan`
 
 **Status**: Approved
-**Progress**: 9/12 tasks complete
+**Progress**: 11/12 tasks complete
 **Last Updated**: 2026-08-04
 
 ## Overview
@@ -163,8 +163,8 @@ Loop cadence and flags, the `monitor_runtime` schema and wake ledger, `member ca
 
 ### Step 5: `cafleet monitor scan` (code)
 
-- [ ] `cafleet/src/cli/monitor.rs`: restructure `MonitorArgs` with `args_conflicts_with_subcommands` + `subcommand_negates_reqs`, turning the loop's `fleet_id` positional into `Option<i64>` (the `Scan` variant carries its own `FLEET_ID` positional; the loop dispatch unwraps); implement the scan handler (live-fleet guard, mux resolution, roster, per-entry capture with annotations, text/JSON emit) <!-- completed: -->
-- [ ] Tests: loop-form parse/behavior regression; scan text sections and ordering (Director first); scan JSON key set and key order; annotated entries (pending placement, failed capture) with exit 0; unknown fleet error <!-- completed: -->
+- [x] `cafleet/src/cli/monitor.rs`: restructure `MonitorArgs` with `args_conflicts_with_subcommands` + `subcommand_negates_reqs`, turning the loop's `fleet_id` positional into `Option<i64>` (the `Scan` variant carries its own `FLEET_ID` positional; the loop dispatch unwraps); implement the scan handler (live-fleet guard, mux resolution, roster, per-entry capture with annotations, text/JSON emit) <!-- completed: 2026-08-04T12:52 -->
+- [x] Tests: loop-form parse/behavior regression; scan text sections and ordering (Director first); scan JSON key set and key order; annotated entries (pending placement, failed capture) with exit 0; unknown fleet error <!-- completed: 2026-08-04T12:52 -->
 
 ### Step 6: Verification
 

--- a/design-docs/0000160-monitor-batch-capture/design-doc.md
+++ b/design-docs/0000160-monitor-batch-capture/design-doc.md
@@ -1,7 +1,7 @@
 # Batch Capture — `cafleet monitor scan`
 
 **Status**: Approved
-**Progress**: 11/12 tasks complete
+**Progress**: 12/12 tasks complete
 **Last Updated**: 2026-08-04
 
 ## Overview
@@ -168,7 +168,7 @@ Loop cadence and flags, the `monitor_runtime` schema and wake ledger, `member ca
 
 ### Step 6: Verification
 
-- [ ] `mise //cafleet:format`, `mise //cafleet:lint`, `mise //cafleet:typecheck`, `mise //cafleet:test` all green <!-- completed: -->
+- [x] `mise //cafleet:format`, `mise //cafleet:lint`, `mise //cafleet:typecheck`, `mise //cafleet:test` all green <!-- completed: 2026-08-04T12:55 -->
 
 ---
 

--- a/design-docs/0000160-monitor-batch-capture/design-doc.md
+++ b/design-docs/0000160-monitor-batch-capture/design-doc.md
@@ -1,7 +1,7 @@
 # Batch Capture — `cafleet monitor scan`
 
 **Status**: Approved
-**Progress**: 5/12 tasks complete
+**Progress**: 8/12 tasks complete
 **Last Updated**: 2026-08-04
 
 ## Overview
@@ -153,9 +153,9 @@ Loop cadence and flags, the `monitor_runtime` schema and wake ledger, `member ca
 
 ### Step 3: Skills
 
-- [ ] `skills/cafleet/reference/supervision.md`: make the fresh scan the normative gate capture (one scan per facilitation turn covers all members; gate depth 20 everywhere per § Supervision-gate semantics, retiring the `--lines 120` rule; per-target freshness caveat after any keystroke); update health-check step 4(c) and the Quick Reference table; replace the Stage-2 "doubles as the gate capture" note with the freshness-only form pinned in § Supervision-gate semantics <!-- completed: -->
-- [ ] `skills/cafleet/reference/cli.md`: document `monitor scan` in the monitor paragraph and reposition `member capture` as the targeted deeper-investigation primitive <!-- completed: -->
-- [ ] `skills/cafleet/reference/director.md`: add the batch scan as the fleet-wide read primitive alongside the `member capture` section <!-- completed: -->
+- [x] `skills/cafleet/reference/supervision.md`: make the fresh scan the normative gate capture (one scan per facilitation turn covers all members; gate depth 20 everywhere per § Supervision-gate semantics, retiring the `--lines 120` rule; per-target freshness caveat after any keystroke); update health-check step 4(c) and the Quick Reference table; replace the Stage-2 "doubles as the gate capture" note with the freshness-only form pinned in § Supervision-gate semantics <!-- completed: 2026-08-04T12:33 -->
+- [x] `skills/cafleet/reference/cli.md`: document `monitor scan` in the monitor paragraph and reposition `member capture` as the targeted deeper-investigation primitive <!-- completed: 2026-08-04T12:33 -->
+- [x] `skills/cafleet/reference/director.md`: add the batch scan as the fleet-wide read primitive alongside the `member capture` section <!-- completed: 2026-08-04T12:33 -->
 
 ### Step 4: Wake payload (code)
 

--- a/docs/docs/concepts/monitoring.md
+++ b/docs/docs/concepts/monitoring.md
@@ -24,23 +24,40 @@ The loop's only keystroke is a **wake trigger** into the Director's own pane —
 a pure trigger, not a protocol payload. It opens `[cafleet] tick:`, names every
 active non-Director member as
 `<member-id> (<name>; coding_agent=<agent>; unacked=<pending-count>)` in
-ascending member-id order, tells the Director to poll its inbox, ACK, and
-dispatch, and closes with the resume clause:
-`Resume your work if something was still running.` A fleet with no other
-members receives the `no members to health-check.` form. The tmux and herdr
-payloads are byte-identical; the exact grammar is pinned in
+ascending member-id order, tells the Director to scan panes with
+`cafleet monitor scan`, poll its inbox, ACK, and dispatch, and closes with the
+resume clause: `Resume your work if something was still running.` A fleet with
+no other members receives the `no members to health-check.` form, still
+carrying the scan instruction. The tmux and herdr payloads are byte-identical;
+the exact grammar is pinned in
 [Multiplexer backends](../spec/multiplexer-backends.md). The loop never
 keystrokes any member pane — `cafleet member ping` stays a manual Director
 primitive.
 
+The scan the payload instructs is the **facilitation snapshot**:
+`cafleet monitor scan <fleet-id>` is a one-shot, read-only command that
+captures the Director's own pane and every active member's pane in a single
+invocation — Director first, then members in ascending member-id order — so
+the Director reads one synchronized fleet snapshot instead of one pane at a
+time. A pending placement or a failed pane capture renders an annotated entry
+and the scan still completes; the command performs no DB writes and stores no
+capture content. The heartbeat/facilitation split is unchanged: the scan is a
+facilitation primitive the Director runs on wake, not part of the loop.
+`cafleet member capture` remains the targeted deeper-investigation primitive
+for a single pane.
+
 The Director's re-engagement is itself **capture-gated**: before the Director
 fires a re-engagement keystroke at a member (`cafleet member ping`, a
-non-exempt `cafleet message send`, or a `cafleet message broadcast`), it takes
-a fresh read-only `cafleet member capture` of the target and classifies the
-content as `awaiting_user`, `finished`, `working`, or `stall_candidate` using
-the capture cues of the target's backend overlay, firing only on `finished` or
-a confirmed stall — a pane classified `awaiting_user` or `working` has its
-round skipped and the entire send deferred to a later facilitation tick. The
+non-exempt `cafleet message send`, or a `cafleet message broadcast`), it reads
+a fresh capture of the target's pane and classifies the content as
+`awaiting_user`, `finished`, `working`, or `stall_candidate` using the capture
+cues of the target's backend overlay, firing only on `finished` or a confirmed
+stall — a pane classified `awaiting_user` or `working` has its round skipped
+and the entire send deferred to a later facilitation tick. One fresh
+`cafleet monitor scan` satisfies the gate for every member for that
+facilitation turn; once the Director keystrokes a pane, that pane's snapshot
+is stale, and a further re-engagement of the same member within the turn needs
+a fresh capture — a single-member `cafleet member capture` or a new scan. The
 full pre-ping capture gate is part of the cafleet skill's supervision
 protocol, which the Director follows on each on-tick health check and whenever
 it re-engages a member.
@@ -120,4 +137,6 @@ goes stale and the process probe reports no such process — so a fresh
 removes the row unconditionally. No manual cleanup step exists or is needed.
 
 See [Data model](../spec/data-model.md) for the backing table and
-[CLI options](../spec/cli-options.md#cafleet-monitor) for the command surface.
+[CLI options](../spec/cli-options.md#cafleet-monitor) for the command surface
+of both the loop and the one-shot
+[`monitor scan`](../spec/cli-options.md#cafleet-monitor-scan).

--- a/docs/docs/spec/cli-options.md
+++ b/docs/docs/spec/cli-options.md
@@ -18,6 +18,7 @@ fleet the new member joins) and the two-party pair `--from-member-id`
 | `doctor` | Print the resolved multiplexer backend + the calling pane's identifiers + the assets-install report | — | — | [doctor](#cafleet-doctor) |
 | `server` | Start the admin WebUI server | — | — | [server](#cafleet-server) |
 | `monitor` | Run the per-fleet scheduler loop in-process (launch as a background task) | `FLEET_ID` | — | [monitor](#cafleet-monitor) |
+| `monitor scan` | Capture the Director's pane and every active member's pane once | `FLEET_ID` | — | [monitor scan](#cafleet-monitor-scan) |
 | `fleet create` | Create a fleet with its root Director | — | — | [fleet create](#fleet-create) |
 | `fleet list` | List non-deleted fleets | — | — | [fleet list](#fleet-list) |
 | `fleet show` | Show one fleet (soft-deleted included) | `FLEET_ID` | — | [fleet show](#fleet-show) |
@@ -93,10 +94,11 @@ is the complete, untruncated machine form.
 | `member prompt` | `Sent prompt '<text>' to member <name> (<pane_id>).`, or `Sent shell prompt '<text>' …` with `--shell` | `{member_id, pane_id, text, shell}` |
 | `member ping` | `Pinged member <name> (<pane_id>) — poll keystroke dispatched.`, or the pending-placement skip line — see [member ping](#member-ping) | `{member_id, pane_id, skipped}` — `skipped` present on both success paths |
 | `member capture` | The captured content alone | `{member_id, pane_id, lines, content, captured_at, content_sha256}` in that key order |
+| `monitor scan` | One `===`-header section per roster entry, separated by one blank line — see [monitor scan](#cafleet-monitor-scan) | A top-level array, one object per entry in the pinned key order |
 | `doctor` | The `multiplexer:` and `assets:` blocks | Output as JSON |
 
-`setup`, `server`, and `monitor` are absent by design — they stream
-progress or run a loop rather than emitting a one-shot payload — so the
+`setup`, `server`, and the `monitor` loop form are absent by design — they
+stream progress or run a loop rather than emitting a one-shot payload — so the
 [Subcommand summary](#subcommand-summary) legitimately carries three more rows
 than this table.
 
@@ -140,6 +142,7 @@ Subcommands accepting `--json`, one row per subcommand:
 | `member prompt` | `member` |
 | `member ping` | `member` |
 | `member capture` | `member` |
+| `monitor scan` | `monitor` |
 
 All other subcommands reject `--json` with the parser's unknown-argument
 error (exit 2) — including the root group itself, so a
@@ -149,7 +152,7 @@ pre-subcommand `cafleet --json <grp> <cmd>` does not parse.
 
 The id a command acts on rides as a required positional integer immediately
 after the subcommand name: `FLEET_ID` on `fleet show` / `fleet delete` /
-`member list` / `monitor`, `MEMBER_ID` on `member show` / `delete` / `prompt`
+`member list` / both `monitor` forms, `MEMBER_ID` on `member show` / `delete` / `prompt`
 / `ping` / `capture` and `message poll`, `MESSAGE_ID` on `message ack` /
 `show`. Everything else is derived from the subject row: a member id is
 globally unique, so the member row names its fleet; a message row names its
@@ -184,7 +187,9 @@ allow-listed subcommand:
 
 - **One pattern per subcommand**, matching the subcommand prefix —
   `Bash(cafleet <grp> <cmd> *)`. The positional subject id and trailing flags
-  such as [`--json`](#json-output) are covered by the same pattern.
+  such as [`--json`](#json-output) are covered by the same pattern. Both
+  `monitor` forms ride the single `Bash(cafleet monitor *)` pattern —
+  `cafleet monitor scan` needs no pattern of its own.
 - **`member prompt` is excluded** so it stays under `permissions.ask` — its
   positional text body is operator-controlled, in both the plain and the
   `--shell` form.
@@ -731,9 +736,19 @@ after the selected mode, and capture content is never stored in SQLite.
 
 ## `cafleet monitor` — Supervision Scheduler {#cafleet-monitor}
 
-`cafleet monitor FLEET_ID [--tick N] [--interval N]` — a single top-level
-command with the positional `FLEET_ID` subject. It runs
-behind the [stale-assets guard](#stale-assets-guard). The conceptual model is
+`cafleet monitor` is a two-form command. The bare positional form runs the
+supervision loop; the `scan` subcommand is a one-shot batch capture. Both
+forms run behind the [stale-assets guard](#stale-assets-guard).
+
+| Form | Behavior |
+|---|---|
+| `cafleet monitor FLEET_ID [--tick N] [--interval N]` | The in-process scheduler loop. |
+| `cafleet monitor scan FLEET_ID [--lines N] [--ansi] [--json]` | Capture the Director's pane + every active member's pane once, print, exit. No loop, no `monitor_runtime` claim, no DB writes. |
+
+### The loop form
+
+`cafleet monitor FLEET_ID [--tick N] [--interval N]` takes the positional
+`FLEET_ID` subject. The conceptual model is
 canonical on the [Monitoring](../concepts/monitoring.md) concepts page; there
 is no stop subcommand — the Director stops the background task hosting the
 loop, and a still-running loop self-terminates on its next tick after
@@ -762,6 +777,89 @@ monitor loop started (fleet <fleet_id>, tick <tick>s, pid <pid>)
 | `0` | Clean exit |
 | `1` | A monitor is already running for the fleet |
 | `1` | Unknown fleet |
+| `1` | Multiplexer unreachable |
+| `2` | Usage errors |
+
+### `cafleet monitor scan` {#cafleet-monitor-scan}
+
+`cafleet monitor scan FLEET_ID [--lines N] [--ansi] [--json]` — a one-shot
+batch capture of the whole fleet: the Director's pane plus every active
+member's pane, captured back-to-back and printed in a single invocation.
+No loop runs, no `monitor_runtime` row is claimed, the command performs no
+DB writes, and capture content is never stored in SQLite.
+
+| Flag | Required | Notes |
+|---|---|---|
+| `--lines` | no | Trailing lines captured per pane (an integer ≥ 1, default **20**). |
+| `--ansi` | no | Preserve ANSI escapes in every captured content. The default strips ANSI escapes, as in [`member capture`](#member-capture). |
+| `--json` | no | Emit the JSON array instead of the text sections. |
+
+**Roster.** The scan requires a live fleet (a soft-deleted or unknown fleet
+errors — see [Error Messages](#error-messages)) and a resolvable
+multiplexer — the same guards as the loop form. The roster is the Director's
+row first, then every other active member owning a placement row, ascending
+by `member_id`. A member with no placement row (not spawned via
+`cafleet member create`) is excluded, mirroring the wake roster's join; a
+placement row with a `NULL` pane (pending placement) stays in the roster as
+an annotated entry. A fleet with no members scans the Director's pane only.
+
+**Per-entry capture.** For each roster entry, in order:
+
+| Condition | Entry outcome |
+|---|---|
+| The pane id is `NULL` (pending placement) | Annotated entry: `pane not available (pending placement)`. |
+| The pane capture errors (dead pane, backend failure — including the Director's own pane) | Annotated entry: `capture failed: <error>`. |
+| The capture succeeds | Content (ANSI-stripped unless `--ansi`), `captured_at` stamped from local UTC at that entry's read boundary, `content_sha256` over the emitted content. |
+
+The scan always completes: an annotated entry never aborts the remaining
+captures, and a scan whose every entry is annotated still exits 0.
+
+**Text mode** — one section per roster entry, separated by one blank line.
+`<name>` is the raw DB value (stdout is not a keystroke path, so no
+sanitization). `kind` is `director` or `member`, making the Director row
+self-identifying beyond its first position.
+
+```text
+=== <member-id> (<name>; kind=<kind>; coding_agent=<coding_agent>; pane=<pane-id>; captured_at=<ts>) ===
+<content>
+```
+
+An annotated entry (the pane token is `—` when no pane exists; a failed
+capture keeps its real pane id):
+
+```text
+=== <member-id> (<name>; kind=<kind>; coding_agent=<coding_agent>; pane=—) ===
+pane not available (pending placement)
+```
+
+**JSON mode** — a top-level array, same order, one object per entry
+mirroring [`member capture`](#member-capture)'s keys plus `name` / `kind` /
+`coding_agent` / `error`, in this pinned key order:
+
+```json
+{
+  "member_id": 4,
+  "name": "drafter",
+  "kind": "member",
+  "coding_agent": "claude",
+  "pane_id": "%2",
+  "lines": 20,
+  "content": "…",
+  "captured_at": "2026-08-04T11:20:00.000000+00:00",
+  "content_sha256": "…",
+  "error": null
+}
+```
+
+On an annotated entry `content`, `captured_at`, and `content_sha256` are
+`null`; `error` carries the exact annotation string from text mode;
+`pane_id` is `null` for a pending placement and the real pane id for a
+failed capture. `lines` always echoes the requested depth.
+
+| Exit | Meaning |
+|---|---|
+| `0` | Completed scan (annotated entries included) |
+| `1` | Unknown or soft-deleted fleet |
 | `1` | Multiplexer unreachable |
 | `2` | Usage errors |
 
@@ -811,5 +909,5 @@ monitor loop started (fleet <fleet_id>, tick <tick>s, pid <pid>)
 | `member create` | A malformed brace expression in the prompt | `Error: Malformed custom prompt: <detail>. Double literal braces ({{, }}) to keep them as text.` | 2 | The just-registered member is rolled back |
 | `member create` | `--coding-agent` omitted and the spawning Director not found in the fleet | `Error: cannot resolve the member's coding agent: Director <director-id> not found in fleet <fleet-id>. Re-run with an explicit --coding-agent.` | 1 | Nothing spawned |
 | `member create` | `--coding-agent` omitted and the spawning Director has no placement row | `Error: cannot resolve the member's coding agent: Director <director-id> has no placement row recording its backend. Re-run with an explicit --coding-agent.` | 1 | Nothing spawned |
-| `monitor` | The fleet already has a live monitor | `Error: monitor already running for fleet <id>` | 1 | — |
-| `monitor` | An unknown or soft-deleted fleet | `Error: fleet <id> not found` | 1 | — |
+| `monitor` (loop form) | The fleet already has a live monitor | `Error: monitor already running for fleet <id>` | 1 | — |
+| `monitor` / `monitor scan` | An unknown or soft-deleted fleet | `Error: fleet <id> not found` | 1 | — |

--- a/docs/docs/spec/multiplexer-backends.md
+++ b/docs/docs/spec/multiplexer-backends.md
@@ -102,7 +102,7 @@ backend name fails the wake closed. tmux and herdr emit the payload
 byte-identically:
 
 ```text
-[cafleet] tick: fleet <fleet-id> — health-check your <N> members: <entries>. Poll your inbox, ACK, dispatch. Resume your work if something was still running.
+[cafleet] tick: fleet <fleet-id> — health-check your <N> members: <entries>. Scan panes with 'cafleet monitor scan <fleet-id>', poll your inbox, ACK, dispatch. Resume your work if something was still running.
 ```
 
 With `N == 1` the noun is singular (`health-check your 1 member: …`); with
@@ -112,7 +112,7 @@ With `N == 1` the noun is singular (`health-check your 1 member: …`); with
 Example:
 
 ```text
-[cafleet] tick: fleet 3 — health-check your 2 members: 4 (drafter; coding_agent=claude; unacked=2), 5 (reviewer; coding_agent=codex; unacked=0). Poll your inbox, ACK, dispatch. Resume your work if something was still running.
+[cafleet] tick: fleet 3 — health-check your 2 members: 4 (drafter; coding_agent=claude; unacked=2), 5 (reviewer; coding_agent=codex; unacked=0). Scan panes with 'cafleet monitor scan 3', poll your inbox, ACK, dispatch. Resume your work if something was still running.
 ```
 
 `cafleet member ping` is a Director-only manual primitive, unchanged on both

--- a/skills/cafleet/SKILL.md
+++ b/skills/cafleet/SKILL.md
@@ -93,7 +93,7 @@ CLI environment variables (the `CAFLEET_`-prefixed `CAFLEET_DATABASE_URL`, `CAFL
 
 ## Team supervision
 
-Before spawning a team, the Director launches the heartbeat itself: immediately after `cafleet fleet create` and before the first `cafleet member create`, it runs `cafleet monitor <fleet-id>` as a background task in its own pane ({bg_run}) and confirms the loop's startup line — `monitor loop started (fleet <fleet_id>, tick <tick>s, pid <pid>)` — in the task output. That confirmation gates the first `member create`. The loop wakes the Director's own pane once per wake interval; each wake is the cue to poll, ACK, dispatch, health-check the members it names, and then resume any interrupted work.
+Before spawning a team, the Director launches the heartbeat itself: immediately after `cafleet fleet create` and before the first `cafleet member create`, it runs `cafleet monitor <fleet-id>` as a background task in its own pane ({bg_run}) and confirms the loop's startup line — `monitor loop started (fleet <fleet_id>, tick <tick>s, pid <pid>)` — in the task output. That confirmation gates the first `member create`. The loop wakes the Director's own pane once per wake interval; each wake is the cue to scan the fleet's panes (`cafleet monitor scan <fleet-id>`), poll, ACK, dispatch, health-check the members it names, and then resume any interrupted work.
 
 For the full governance + heartbeat mechanism (Core Principle, Communication Model, Idle Semantics, Authorization-Scope Guard, Spawn Protocol, Stall Response, Cleanup, the 5-step facilitation loop, Monitor Lifecycle), Read [`reference/supervision.md`](reference/supervision.md).
 

--- a/skills/cafleet/reference/cli.md
+++ b/skills/cafleet/reference/cli.md
@@ -94,15 +94,18 @@ cafleet doctor --json
 
 ## Monitor
 
-`cafleet monitor` is the supervision scheduler — a single command with a positional fleet id:
+`cafleet monitor` is the supervision scheduler — a two-form command with a positional fleet id:
 
 ```bash
 cafleet monitor <fleet-id>          # the scheduler loop (launched by the Director as a background task in its own pane)
+cafleet monitor scan <fleet-id>     # one-shot batch capture: the Director's pane + every active member's pane, print, exit
 ```
 
-It takes `--interval N` (the Director wake interval in seconds; omitted → `CAFLEET_MONITOR_WAKE_INTERVAL`, default `600`; `0` disables the wake) and `--tick N` (scan cadence, default `5`). It prints `monitor loop started (fleet <fleet_id>, tick <tick>s, pid <pid>)` immediately after claiming the runtime row — the line the Director confirms before its first `member create`.
+The loop form takes `--interval N` (the Director wake interval in seconds; omitted → `CAFLEET_MONITOR_WAKE_INTERVAL`, default `600`; `0` disables the wake) and `--tick N` (scan cadence, default `5`). It prints `monitor loop started (fleet <fleet_id>, tick <tick>s, pid <pid>)` immediately after claiming the runtime row — the line the Director confirms before its first `member create`.
 
-The read-only pane capture is `cafleet member capture <target-member-id>` (default `--lines 20`; `--json` adds `captured_at` and `content_sha256`; `--ansi` preserves escapes), used by the Director's pre-ping capture gate; a pending-placement target is a hard error.
+`cafleet monitor scan` is the fleet-wide read: one section per pane — Director first, then members ascending by member id — with `--lines N` (per-pane depth, default `20`), `--ansi`, and `--json` (a top-level array). A pending placement or a failed capture renders an annotated entry and the scan still completes with exit 0; the command performs no DB writes. One fresh scan satisfies the Director's pre-ping capture gate for every member for that facilitation turn.
+
+`cafleet member capture <target-member-id>` is the targeted deeper-investigation primitive — a single pane, read-only (default `--lines 20`; `--json` adds `captured_at` and `content_sha256`; `--ansi` preserves escapes); a fresh one at default depth or deeper also satisfies the gate for that one member. A pending-placement target is a hard error.
 
 `cafleet member ping` is a Director write primitive. Against a pending-placement member it skips the keystroke and exits 0 — the member polls its inbox on spawn — with the stable `skipped` JSON key on both success paths.
 

--- a/skills/cafleet/reference/director.md
+++ b/skills/cafleet/reference/director.md
@@ -1,6 +1,6 @@
 # tmux-backed member commands (`cafleet member *`)
 
-Reference page for the Director-only lifecycle and pane-interaction commands — `member create`, `member delete`, `member list`, `member capture`, `member prompt`, `member ping`. All run inside a tmux or herdr session (`member list` and `member show` are registry reads with no multiplexer requirement). `member create` takes **no identity flag** — the CLI auto-resolves the spawning Director from `fleets.director_member_id`, and `--fleet-id` names the fleet the new member joins; every other lifecycle verb identifies its **target** by the positional `MEMBER_ID` (the fleet is derived from the member row).
+Reference page for the Director-only lifecycle and pane-interaction commands — `member create`, `member delete`, `member list`, `monitor scan`, `member capture`, `member prompt`, `member ping`. All run inside a tmux or herdr session (`member list` and `member show` are registry reads with no multiplexer requirement). `member create` takes **no identity flag** — the CLI auto-resolves the spawning Director from `fleets.director_member_id`, and `--fleet-id` names the fleet the new member joins; every other lifecycle verb identifies its **target** by the positional `MEMBER_ID` (the fleet is derived from the member row).
 
 Members do NOT need to read this file. Member-side flows (poll / send / ack / receive shell-dispatch from the Director) live in `skills/cafleet/SKILL.md` (core) and `skills/cafleet/reference/prompt-routing.md`.
 
@@ -152,9 +152,17 @@ cafleet member list <fleet-id>
 
 One output shape: every **active** registry entry of the fleet (the root Director, ordinary members, placementless rows), one row each with `member_id`, `name`, `kind` (`director` / `member`), `backend`, `pane_id` (a pending placement renders `(pending)`; placementless rows render `-` placement cells), and `idle` — the humanized wall-time since the member's most recent message activity (`Ns`/`Nm`/`Nh`, `-` when none). `--json` adds the underlying `last_sent` / `last_recv` / `last_ack` timestamps (output shape in [`cli-options.md`](../../../docs/docs/spec/cli-options.md#member-list)). Use the `idle` column for routine supervision ticks instead of capturing every member every tick — capture is reserved for the cases the idle column flags.
 
+## Fleet Scan
+
+Capture the Director's own pane and every active member's pane in one invocation (read-only): one section per pane, Director first, then members ascending by member id. `--lines` defaults `20` per pane; `--ansi` preserves escapes; `--json` emits a top-level array. A pending placement or a failed capture renders an annotated entry and the scan still completes with exit 0; no DB writes. This is the fleet-wide read primitive: one fresh scan satisfies the pre-ping capture gate for every member for that facilitation turn ([`reference/supervision.md`](supervision.md) § *The pre-ping capture gate*), and the periodic wake payload instructs you to run it.
+
+```bash
+cafleet monitor scan <fleet-id>
+```
+
 ## Member Capture
 
-Capture the last N lines of a member's pane buffer (read-only). `--lines` defaults `20`; ANSI escapes are stripped and carriage returns de-fragmented by default (`--ansi` preserves escapes). Output is the raw buffer in text mode, `{member_id, pane_id, lines, content, captured_at, content_sha256}` in JSON. This is the read primitive behind the pre-ping capture gate ([`reference/supervision.md`](supervision.md) § *The pre-ping capture gate*).
+Capture the last N lines of a member's pane buffer (read-only). `--lines` defaults `20`; ANSI escapes are stripped and carriage returns de-fragmented by default (`--ansi` preserves escapes). Output is the raw buffer in text mode, `{member_id, pane_id, lines, content, captured_at, content_sha256}` in JSON. This is the targeted deeper-investigation primitive — scan for all, capture when one member needs a closer look; a fresh capture at default depth or deeper satisfies the pre-ping capture gate for that one member ([`reference/supervision.md`](supervision.md) § *The pre-ping capture gate*).
 
 ```bash
 cafleet member capture <member-id>

--- a/skills/cafleet/reference/supervision.md
+++ b/skills/cafleet/reference/supervision.md
@@ -18,7 +18,7 @@ Supervision happens over the CAFleet message broker: the Director `cafleet messa
 
 **Facilitation cue (load-bearing).** The monitor loop wakes **you** directly: once per wake interval it keystrokes the `[cafleet] tick:` payload into your own pane (see § The monitor heartbeat). **Treat each wake — and each inbound broker auto-fire — as the cue to run the entire 5-step facilitation loop** (poll → ACK → dispatch → health-check → escalate), NOT to read the inbox and stop. Then honor the wake's closing clause: resume your own work if something was still running when the keystroke landed.
 
-The Director never polls a member's pane via raw `tmux`. Inspection is via `cafleet member capture`; write is via `cafleet member prompt` / `cafleet member ping`. See [`SKILL.md`](../SKILL.md) and [`reference/cli.md`](cli.md) for the canonical command surface.
+The Director never polls a member's pane via raw `tmux`. Inspection is via `cafleet monitor scan` (the whole fleet at once) and `cafleet member capture` (one pane, deeper); write is via `cafleet member prompt` / `cafleet member ping`. See [`SKILL.md`](../SKILL.md) and [`reference/cli.md`](cli.md) for the canonical command surface.
 
 The Director's plain output is **not visible to members** — the only Director→member channel is `cafleet message send` (and the Director-only keystroke primitives above for special cases).
 
@@ -60,12 +60,21 @@ Every **Director-initiated** re-engagement keystroke at a member — `cafleet
 member ping`, a non-exempt `cafleet message send`, and `cafleet message
 broadcast` — is capture-gated immediately before firing. Classify from
 content only using the **target member's** backend
-overlay; mixed fleets make this target-specific. The gate capture depth is
-normative:
+overlay; mixed fleets make this target-specific. The normative gate capture
+is the batch scan:
 
 ```bash
-cafleet member capture <target-member-id> --lines 120
+cafleet monitor scan <fleet-id>
 ```
+
+One fresh scan at the default depth (20 lines per pane) satisfies the gate
+for **every** member for that facilitation turn. A fresh single-member
+`cafleet member capture` at default depth or deeper satisfies the gate for
+that one member. Per-target freshness: once you keystroke a pane (`cafleet
+member ping`, a non-exempt `cafleet message send`, a `cafleet member
+prompt`), the scan snapshot of that pane is stale — a further re-engagement
+of the same member within the turn needs a fresh capture (a single-member
+`cafleet member capture` or a new scan).
 
 | Capture classifies | Director action |
 |---|---|
@@ -77,7 +86,7 @@ cafleet member capture <target-member-id> --lines 120
 
 The ambiguity tie-break: a capture that cannot distinguish `awaiting_user` from `finished` classifies `awaiting_user`. When in doubt between `stalled` and `working`, treat as `working` (skip the round) — a deferred ping costs one tick; an `Esc` into an in-flight turn destroys work. For the gate, `stalled` means the capture shows a quiet pane with no pending prompt and no in-flight work, in a context where your own prior capture showed the same content; your conversation notes across wakes are the baseline.
 
-The gate is judgment applied at use time: knowledge from an earlier capture is *stale* and never substitutes for the fresh capture immediately before the keystroke.
+The gate is judgment applied at use time: a capture is *fresh* only within the same facilitation turn and with no intervening keystroke into that pane; anything older is stale and never substitutes for a fresh capture.
 
 A `cafleet message broadcast` fires the same `Esc`-first preview into every recipient pane, and recipients cannot be skipped individually within one send — so the broadcast fires only when **every** recipient's fresh capture classifies `finished` or `stalled`; otherwise defer the entire broadcast, or replace it with per-recipient gated unicasts.
 
@@ -140,7 +149,7 @@ On every supervision tick — whether fired by the periodic monitor wake, by inb
 1. **Poll inbox.** `cafleet message poll <director-member-id>` returns only the un-acked (`input_required`) deliveries; ACKing each one (step 2) consumes it — the poll semantics are canonical at § Stall Response → Stage 1.
 2. **ACK every message** that requires no further action: `cafleet message ack <message-id>`. Unacknowledged messages accumulate in the Director's inbox and obscure new arrivals.
 3. **Dispatch queued work.** If a member is idle and inputs are available (review comments to route, the next implementation step in a design doc, reviewer feedback waiting at the Drafter, a teammate reply waiting to be acted on), send the instruction immediately via `cafleet message send`. **Do not wait for a fresh "go" from the user** — the user's original authorization persists across ticks; see § Authorization-Scope Guard.
-4. **Run the health-check sequence** for any member that has not reported recent progress — cheapest, least-intrusive check first: (a) `cafleet member list` (enumerate members + pane status); (b) `cafleet message poll` (progress reports / help requests); (c) for a member silent since the last check, a fresh `cafleet member capture --lines 120` classified per § Idle Semantics → *The pre-ping capture gate* (a decision-prompt frame → see Stall Response for the decision-relay escape hatch); (d) `cafleet message send` a specific instruction — (c) is the gating precondition: (d) fires only for a member whose (c) capture classified `finished` or `stalled`; on `awaiting_user` or `working`, skip the round and defer the send; (e) once all members report completion, tell the user "All deliverables are ready for review."
+4. **Run the health-check sequence** for any member that has not reported recent progress — cheapest, least-intrusive check first: (a) `cafleet member list` (enumerate members + pane status); (b) `cafleet message poll` (progress reports / help requests); (c) the facilitation turn's fresh `cafleet monitor scan <fleet-id>` — its section for the member, or a targeted `cafleet member capture` for deeper investigation — classified per § Idle Semantics → *The pre-ping capture gate* (a decision-prompt frame → see Stall Response for the decision-relay escape hatch); (d) `cafleet message send` a specific instruction — (c) is the gating precondition: (d) fires only for a member whose (c) capture classified `finished` or `stalled`; on `awaiting_user` or `working`, skip the round and defer the send; (e) once all members report completion, tell the user "All deliverables are ready for review."
 5. **Escalate** to the user via {decision_surface} whenever a queued action requires a *new* user decision (option choice, risky/remote-visible operation, ambiguous teammate question); for the stall path (two fired sends with no progress) see § Stall Response → Escalation. Do **not** emit passive-hold messages like `Skipping. Holding for go.` — the tick is a health check, not a permission renewal.
 
 After the five steps, honor the wake's resume clause: if the keystroke landed while your own task was mid-flight, pick that task back up before ending the turn.
@@ -186,7 +195,7 @@ The `cafleet member capture` default is `--lines 20`; bump `--lines` to show mor
 
 If `cafleet message poll` shows no recent messages from the member, fall back to capturing the terminal buffer. This is non-intrusive (read-only inspection that works even when the member is mid-task) and replaces raw `tmux capture-pane`.
 
-A Stage-2 capture doubles as the gate capture only when it was taken at `--lines 120` and is still fresh (same facilitation turn, no intervening keystroke into the pane); the default `--lines 20` capture does not satisfy the gate.
+A Stage-2 `member capture` doubles as the gate capture for that member while still fresh (same facilitation turn, no intervening keystroke into that pane).
 
 **Deferred sends.** `cafleet message send` both persists a broker message and fires the inline-preview keystroke; there is no persist-without-keystroke mode. A round the gate skips (`awaiting_user` / `working`) therefore defers the **entire send**: hold each deferred send as queued work and re-evaluate it with a fresh capture on the next facilitation tick, then fire or skip again. No additional wake channel exists for deferrals — the next periodic wake re-opens your turn, so a deferral resolves within at most one wake interval once the pane clears.
 
@@ -238,10 +247,11 @@ A workflow that carries extra teardown — a precondition on when shutdown may b
 |---|---|---|
 | Verify Director pane env | `cafleet doctor` | Pre-spawn precondition; gating. Aborts the spawn protocol when no supported multiplexer (tmux or herdr) resolves. Replaces raw `tmux display-message` and `TMUX` env-var expansion. |
 | Start the supervision tick | {bg_run} `cafleet monitor <s>` in your own pane, immediately after `fleet create` | Confirm the `monitor loop started (…)` startup line in the task output before the first `member create`. |
+| Fleet-wide pane snapshot | `cafleet monitor scan <s>` | One fresh scan per facilitation turn satisfies the pre-ping capture gate for every member (§ Idle Semantics → *The pre-ping capture gate*); run it on wake per the payload's scan instruction. |
 | Spawn member | `cafleet member create --fleet-id <s> --name <n> --description <d> --file <abs path to ${BASE}/.prompts/<role>-<UTC-compact>.md>` | Pre-spawn file IS the audit artifact (see [`reference/director.md`](director.md) § *Member Create — Scratch and audit files*). Verify with `cafleet member list`. An inline positional `"<prompt>"` is still permitted for trivial one-line spawns. |
 | Message member | `cafleet message send --from-member-id <director> --to-member-id <member> "..."` | Broker keystrokes an inline preview into the member's pane. Gated: fresh capture must classify finished/stalled (§ Idle Semantics → *The pre-ping capture gate*; reply-soliciting replies exempt) |
 | ACK reply | `cafleet message ack <message>` | Unacknowledged messages accumulate; ACK every reply you act on |
-| Inspect stalled member | `cafleet member capture <member>` | Replaces raw `tmux capture-pane` |
+| Inspect stalled member | `cafleet member capture <member>` | Targeted deeper investigation of a single pane; replaces raw `tmux capture-pane` |
 | Manual inbox-poll | `cafleet member ping <member>` | Pre-approved; for missed auto-fires and post-`exec` chains. Gated: fresh capture must classify finished/stalled (§ Idle Semantics → *The pre-ping capture gate*) |
 | Shell-dispatch on member's behalf | `cafleet member prompt <member> --shell "<cmd>"` | Per [`reference/prompt-routing.md`](prompt-routing.md); follow with `member ping` |
 | Answer a member's relayed question | {decision_surface} → `cafleet message send` | Ask the user via {decision_surface} first, then relay the answer back to the member as a message; never decide silently |


### PR DESCRIPTION
- **docs: document cafleet monitor scan batch capture and scan-based wake payload (0000160 Step 1)**
- **docs: specify cafleet monitor two-form command and scan contract in SPEC (0000160 Step 2)**
- **docs: make the batch scan the normative gate capture across cafleet skill pages (0000160 Step 3)**
- **test: pin wake payload assertions to the scan-clause form**
- **feat: add the scan instruction to the monitor wake payload (0000160 Step 4)**
- **test: add cafleet monitor scan contract tests and loop-form regression**
- **feat: implement cafleet monitor scan one-shot batch capture (0000160 Step 5)**
- **docs: check off Step 6 verification gates (0000160)**
- **docs: check off all success criteria after Phase D verification (0000160)**
