### PR TITLE
feat/0000161 deferred first director wake

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -2012,10 +2012,14 @@ of `AgentStateAware` native status.
 
 #### Public surface
 
-- **`wake_due(last_wake_at, wake_interval_seconds, now) -> bool`** — pure
-  due-check for the fleet-level wake; no DB/multiplexer access. A `NULL` or
-  unparsable `last_wake_at` is immediately due; otherwise due iff
-  `now − last_wake_at`, in whole seconds, is `>= wake_interval_seconds`.
+- **`wake_due(last_wake_at, started_at, wake_interval_seconds, now) -> bool`**
+  — pure due-check for the fleet-level wake; no DB/multiplexer access. A
+  present `last_wake_at` always wins as the baseline: parsable → due iff
+  `now − last_wake_at`, in whole seconds, is `>= wake_interval_seconds`;
+  unparsable → immediately due. A `NULL` `last_wake_at` falls back to
+  `started_at` as the baseline: parsable → due iff `now − started_at`, in
+  whole seconds, is `>= wake_interval_seconds`; `NULL` or unparsable →
+  immediately due.
 - **`monitor_tick(fleet_id, now, wake_interval_seconds) -> CONTINUE | STOP`** —
   one scan pass.
 - **`run_monitor_loop(fleet_id, tick_seconds, wake_interval_seconds)`** —
@@ -2047,9 +2051,10 @@ One scan pass, steps in order:
 3. **Wake-interval gate.** `wake_interval_seconds == 0` → return `CONTINUE`
    (a heartbeat-only tick: no due-check, no Director resolution, no
    multiplexer call).
-4. **Compute due-ness.** Read the runtime row's `last_wake_at` and call
-   `wake_due(last_wake_at, wake_interval_seconds, now)`. Not due → return
-   `CONTINUE` with no multiplexer call.
+4. **Compute due-ness.** Read the runtime row's `last_wake_at` and
+   `started_at` and call
+   `wake_due(last_wake_at, started_at, wake_interval_seconds, now)`. Not due →
+   return `CONTINUE` with no multiplexer call.
 5. **Resolve the Director's pane.** Read the fleet's `director_member_id` and
    its placement's `mux_pane_id`. A Director with no pane → return `CONTINUE`
    (nothing recorded — the fleet stays due).
@@ -2089,7 +2094,9 @@ artifact (no PID file); identity throughout is the OS process id.
    tick_seconds, now-as-ISO)`. On refusal (returns false) → application error
    (exit 1) `monitor already running for fleet {fleet_id}`. There is no silent
    fallback. A reclaim leaves `last_wake_at` untouched (§6.2), so the wake
-   cadence survives a crash/restart cycle. On success, print the startup line
+   cadence survives a crash/restart cycle; it re-stamps `started_at`, so a
+   fleet that never received its first wake waits a fresh full
+   `wake_interval_seconds` from the restart. On success, print the startup line
    `monitor loop started (fleet <fleet_id>, tick <tick>s, pid <pid>)` to
    stdout before the first tick — the line the Director confirms before its
    first `cafleet member create`.
@@ -2747,10 +2754,11 @@ connection is closed when the command finishes (success or failure).
   - *Coding-agent* — assert each `build_spawn_argv` argv, the opencode model
     validation, and each backend's `ensure_available` preconditions (PATH
     check; opencode's preset-existence check) against a temp HOME.
-  - *Monitor* — `wake_due` is pure (table-test interval/`last_wake_at`/
-    `started_at`/zero-interval states); `monitor_tick` against a fake
-    broker+multiplexer asserting the `woke`-gated `record_monitor_wake` and
-    the `STOP` paths.
+  - *Monitor* — `wake_due` is pure (table-test interval gating,
+    `last_wake_at` precedence, the `started_at` baseline, and corrupt
+    stamps); `monitor_tick` against a fake broker+multiplexer asserting the
+    zero-interval heartbeat-only tick, the `woke`-gated `record_monitor_wake`,
+    and the `STOP` paths.
   - *Config* — env-var parsing, the default-URL home expansion, and loud failure
     on non-integer port/len.
 - **Integration:**

--- a/cafleet/src/monitor/mod.rs
+++ b/cafleet/src/monitor/mod.rs
@@ -348,20 +348,68 @@ mod tests {
 
         #[test]
         fn a_missing_or_unparsable_stamp_is_immediately_due() {
-            assert!(wake_due(None, 600, base_now()));
-            assert!(wake_due(Some("not-a-timestamp"), 600, base_now()));
+            let now = base_now();
+            let fresh = format_utc(now);
+            assert!(
+                wake_due(Some("not-a-timestamp"), Some(&fresh), 600, now),
+                "an unparsable last_wake_at is due regardless of started_at"
+            );
+            assert!(wake_due(Some("not-a-timestamp"), None, 600, now));
+            assert!(
+                wake_due(None, None, 600, now),
+                "no stamp at all → immediately due"
+            );
+            assert!(
+                wake_due(None, Some("not-a-timestamp"), 600, now),
+                "a NULL last_wake_at with a corrupt started_at → immediately due"
+            );
+        }
+
+        #[test]
+        fn a_null_last_wake_defers_to_the_started_at_baseline() {
+            let now = base_now();
+            let recent = format_utc(now - Duration::seconds(599));
+            assert!(
+                !wake_due(None, Some(&recent), 600, now),
+                "elapsed 599 < 600 since started_at → not yet due"
+            );
+            let old = format_utc(now - Duration::seconds(600));
+            assert!(
+                wake_due(None, Some(&old), 600, now),
+                "elapsed 600 >= 600 since started_at → due"
+            );
+        }
+
+        #[test]
+        fn a_present_last_wake_wins_over_a_fresher_started_at() {
+            let now = base_now();
+            let started = format_utc(now - Duration::seconds(1));
+            let old_wake = format_utc(now - Duration::seconds(600));
+            assert!(
+                wake_due(Some(&old_wake), Some(&started), 600, now),
+                "post-reclaim: the old last_wake_at drives due-ness, not the fresh started_at"
+            );
+            let recent_wake = format_utc(now - Duration::seconds(599));
+            assert!(
+                !wake_due(Some(&recent_wake), Some(&started), 600, now),
+                "elapsed 599 < 600 since last_wake_at → not due"
+            );
         }
 
         #[test]
         fn the_interval_gates_a_stamped_fleet() {
             let now = base_now();
+            let started = format_utc(now - Duration::seconds(1_000));
             let recent = format_utc(now - Duration::seconds(599));
             assert!(
-                !wake_due(Some(&recent), 600, now),
+                !wake_due(Some(&recent), Some(&started), 600, now),
                 "elapsed 599 < 600 → not yet due"
             );
             let old = format_utc(now - Duration::seconds(600));
-            assert!(wake_due(Some(&old), 600, now), "elapsed 600 >= 600 → due");
+            assert!(
+                wake_due(Some(&old), Some(&started), 600, now),
+                "elapsed 600 >= 600 → due"
+            );
         }
     }
 
@@ -413,7 +461,8 @@ mod tests {
             claim(&mut conn, fleet_id, own_pid(), now);
             let mux = FakeMux::with_live_panes(&["%0", "%2", "%4"]);
 
-            let (result, echo) = tick(&mut conn, &mux, fleet_id, own_pid(), 600, now);
+            let due_at = now + Duration::seconds(600);
+            let (result, echo) = tick(&mut conn, &mux, fleet_id, own_pid(), 600, due_at);
             assert!(matches!(result, TickResult::Continue));
 
             let wakes = mux.wakes.borrow();
@@ -430,7 +479,7 @@ mod tests {
             );
             drop(wakes);
 
-            let iso = format_utc(now);
+            let iso = format_utc(due_at);
             assert_eq!(
                 echo,
                 format!("{iso} tick -> wake director {director_id} (2 members)\n")
@@ -447,8 +496,13 @@ mod tests {
             claim(&mut conn, fleet_id, own_pid(), now);
             let mux = FakeMux::with_live_panes(&["%0", "%2", "%4"]);
 
-            let (_, _) = tick(&mut conn, &mux, fleet_id, own_pid(), 600, now);
-            assert_eq!(mux.wake_count(), 1, "a NULL stamp is immediately due");
+            let (_, echo) = tick(&mut conn, &mux, fleet_id, own_pid(), 600, now);
+            assert_eq!(
+                mux.wake_count(),
+                0,
+                "the first wake is deferred past the claim tick"
+            );
+            assert!(echo.is_empty());
 
             let (_, echo) = tick(
                 &mut conn,
@@ -458,7 +512,7 @@ mod tests {
                 600,
                 now + Duration::seconds(599),
             );
-            assert_eq!(mux.wake_count(), 1, "599 < 600 → not due");
+            assert_eq!(mux.wake_count(), 0, "599 < 600 since started_at → not due");
             assert!(echo.is_empty());
 
             let (_, _) = tick(
@@ -469,7 +523,32 @@ mod tests {
                 600,
                 now + Duration::seconds(600),
             );
-            assert_eq!(mux.wake_count(), 2, "600 >= 600 → due again");
+            assert_eq!(
+                mux.wake_count(),
+                1,
+                "600 >= 600 since started_at → first wake"
+            );
+
+            let (_, echo) = tick(
+                &mut conn,
+                &mux,
+                fleet_id,
+                own_pid(),
+                600,
+                now + Duration::seconds(1199),
+            );
+            assert_eq!(mux.wake_count(), 1, "599 since the first wake → not due");
+            assert!(echo.is_empty());
+
+            let (_, _) = tick(
+                &mut conn,
+                &mux,
+                fleet_id,
+                own_pid(),
+                600,
+                now + Duration::seconds(1200),
+            );
+            assert_eq!(mux.wake_count(), 2, "600 since the first wake → second wake");
         }
 
         #[test]
@@ -507,7 +586,14 @@ mod tests {
             claim(&mut conn, fleet_id, own_pid(), now);
             let mux = FakeMux::with_live_panes(&["%2", "%4"]);
 
-            let (result, echo) = tick(&mut conn, &mux, fleet_id, own_pid(), 600, now);
+            let (result, echo) = tick(
+                &mut conn,
+                &mux,
+                fleet_id,
+                own_pid(),
+                600,
+                now + Duration::seconds(600),
+            );
             assert!(matches!(result, TickResult::Continue));
             assert_eq!(mux.wake_count(), 0, "no live Director pane → no wake");
             assert!(echo.is_empty());
@@ -528,7 +614,14 @@ mod tests {
             let mux = FakeMux::with_live_panes(&["%0", "%2", "%4"]);
             mux.wake_ok.set(false);
 
-            let (result, echo) = tick(&mut conn, &mux, fleet_id, own_pid(), 600, now);
+            let (result, echo) = tick(
+                &mut conn,
+                &mux,
+                fleet_id,
+                own_pid(),
+                600,
+                now + Duration::seconds(600),
+            );
             assert!(matches!(result, TickResult::Continue));
             assert_eq!(mux.wake_count(), 1);
             assert!(echo.is_empty(), "no echo on a failed wake");
@@ -541,13 +634,13 @@ mod tests {
                 fleet_id,
                 own_pid(),
                 600,
-                now + Duration::seconds(5),
+                now + Duration::seconds(605),
             );
             assert_eq!(mux.wake_count(), 2, "the unstamped fleet stays due");
             assert!(!echo.is_empty());
             assert_eq!(
                 last_wake_at(&conn, fleet_id),
-                format_utc(now + Duration::seconds(5)).as_str()
+                format_utc(now + Duration::seconds(605)).as_str()
             );
         }
 
@@ -560,7 +653,8 @@ mod tests {
             claim(&mut conn, fleet_id, own_pid(), now);
             let mux = FakeMux::with_live_panes(&["%0"]);
 
-            let (result, echo) = tick(&mut conn, &mux, fleet_id, own_pid(), 600, now);
+            let due_at = now + Duration::seconds(600);
+            let (result, echo) = tick(&mut conn, &mux, fleet_id, own_pid(), 600, due_at);
             assert!(matches!(result, TickResult::Continue));
 
             let wakes = mux.wakes.borrow();
@@ -570,7 +664,7 @@ mod tests {
             assert!(members.is_empty(), "the N == 0 roster is empty");
             drop(wakes);
 
-            let iso = format_utc(now);
+            let iso = format_utc(due_at);
             assert_eq!(
                 echo,
                 format!("{iso} tick -> wake director {director_id} (0 members)\n")

--- a/cafleet/src/monitor/mod.rs
+++ b/cafleet/src/monitor/mod.rs
@@ -561,7 +561,11 @@ mod tests {
                 600,
                 now + Duration::seconds(1200),
             );
-            assert_eq!(mux.wake_count(), 2, "600 since the first wake → second wake");
+            assert_eq!(
+                mux.wake_count(),
+                2,
+                "600 since the first wake → second wake"
+            );
         }
 
         #[test]

--- a/cafleet/src/monitor/mod.rs
+++ b/cafleet/src/monitor/mod.rs
@@ -20,10 +20,11 @@
 //!
 //! pub enum TickResult { Continue, Stop }
 //!
-//! // Pure due-check for the fleet-level wake: a NULL or unparsable stamp is
-//! // immediately due.
-//! pub fn wake_due(last_wake_at: Option<&str>, wake_interval: u64,
-//!     now: DateTime<Utc>) -> bool;
+//! // Pure due-check for the fleet-level wake: a present last_wake_at always
+//! // wins as the baseline (unparsable → immediately due); a NULL last_wake_at
+//! // falls back to started_at (NULL or unparsable → immediately due).
+//! pub fn wake_due(last_wake_at: Option<&str>, started_at: Option<&str>,
+//!     wake_interval: u64, now: DateTime<Utc>) -> bool;
 //!
 //! pub fn monitor_tick(conn: &mut Connection, mux: &dyn MonitorMux,
 //!     out: &mut dyn std::io::Write, fleet_id: i64, pid: i64,
@@ -88,14 +89,21 @@ fn mux_err(error: MultiplexerError) -> CafleetError {
     CafleetError::App(error.to_string())
 }
 
-/// Pure due-check for the fleet-level wake: a `NULL` or unparsable
-/// `last_wake_at` is immediately due; otherwise due once the interval has
-/// elapsed.
-pub fn wake_due(last_wake_at: Option<&str>, wake_interval: u64, now: DateTime<Utc>) -> bool {
-    let Some(last_wake_at) = last_wake_at else {
+/// Pure due-check for the fleet-level wake. A present `last_wake_at` always
+/// wins as the baseline, even over a fresher post-reclaim `started_at`
+/// (unparsable → immediately due); a `NULL` `last_wake_at` falls back to
+/// `started_at` (`NULL` or unparsable → immediately due, corrupt state);
+/// otherwise due once the interval has elapsed since the baseline.
+pub fn wake_due(
+    last_wake_at: Option<&str>,
+    started_at: Option<&str>,
+    wake_interval: u64,
+    now: DateTime<Utc>,
+) -> bool {
+    let Some(baseline) = last_wake_at.or(started_at) else {
         return true;
     };
-    let Ok(parsed) = parse_lenient(last_wake_at) else {
+    let Ok(parsed) = parse_lenient(baseline) else {
         return true;
     };
     (now - parsed).num_seconds() >= wake_interval as i64
@@ -132,7 +140,12 @@ pub fn monitor_tick(
     }
     let runtime = broker::read_monitor_runtime(conn, fleet_id)?
         .expect("the heartbeat just matched this fleet's runtime row");
-    if !wake_due(runtime["last_wake_at"].as_str(), wake_interval, now) {
+    if !wake_due(
+        runtime["last_wake_at"].as_str(),
+        runtime["started_at"].as_str(),
+        wake_interval,
+        now,
+    ) {
         return Ok(TickResult::Continue);
     }
 

--- a/cafleet/tests/e2e.rs
+++ b/cafleet/tests/e2e.rs
@@ -59,7 +59,7 @@ fn end_to_end_lifecycle_with_one_monitor_tick() {
     let output = cli.run(&["message", "poll", &worker_id.to_string()]);
     assert!(stdout(&output).contains("No messages found."));
 
-    let mut child = cli.spawn(&["monitor", "1", "--tick", "1"]);
+    let mut child = cli.spawn(&["monitor", "1", "--tick", "1", "--interval", "1"]);
     std::thread::sleep(Duration::from_secs(1));
 
     let second = cli.run(&["monitor", "1", "--tick", "1"]);

--- a/design-docs/0000161-deferred-first-director-wake/design-doc.md
+++ b/design-docs/0000161-deferred-first-director-wake/design-doc.md
@@ -1,0 +1,150 @@
+# Deferred First Director Wake
+
+**Status**: Approved
+**Progress**: 1/12 tasks complete
+**Last Updated**: 2026-08-06
+
+## Overview
+
+Defer the monitor's first fleet-level Director wake: when `monitor_runtime.last_wake_at` is `NULL`, the due-check falls back to `monitor_runtime.started_at` as the baseline, so the first wake fires at `started_at + wake_interval` instead of on the first tick. Today that first-tick wake lands right after fleet creation, while the Director is still spawning members, and is pure noise.
+
+## Success Criteria
+
+- [ ] A freshly claimed monitor (`last_wake_at` `NULL`) fires its first wake only once `wake_interval` has elapsed since `started_at`, not on the first tick.
+- [ ] `last_wake_at` remains the `woke`-gated delivery ledger: it is never written at claim time and only records delivered wakes (its `GET /api/monitor` exposure is unchanged).
+- [ ] An unparsable `last_wake_at` remains immediately due; a `NULL` `last_wake_at` paired with a `NULL` or unparsable `started_at` is also immediately due (corrupt state, no panic).
+- [ ] A present `last_wake_at` always wins as the baseline — the cadence-survives-restart behavior is unchanged.
+- [ ] SPEC.md §6.6 (and the §10 monitor test-plan line), the docs monitoring concepts page, and the colocated tests all reflect the new contract; `mise //cafleet:test` and `mise //cafleet:lint` pass.
+
+---
+
+## Background
+
+`wake_due` (`cafleet/src/monitor/mod.rs`) treats a `NULL` or unparsable `last_wake_at` as immediately due. Since `claim_monitor_runtime` (`cafleet/src/broker/monitor.rs`) inserts a fresh slot with `last_wake_at` `NULL`, the first wake fires on the first tick after `cafleet monitor` starts — immediately after `cafleet fleet create`, before any member exists. The claim already stamps `started_at`, giving the due-check a natural baseline for the not-yet-woken state without any schema change.
+
+---
+
+## Specification
+
+### `wake_due` — new signature and policy
+
+The pure check gains a `started_at` parameter; the whole baseline policy lives inside the function (no call-site branching):
+
+```rust
+pub fn wake_due(
+    last_wake_at: Option<&str>,
+    started_at: Option<&str>,
+    wake_interval: u64,
+    now: DateTime<Utc>,
+) -> bool;
+```
+
+| `last_wake_at` | `started_at` | Outcome |
+|---|---|---|
+| present, parsable | (ignored) | due iff `now − last_wake_at` ≥ `wake_interval` (whole seconds, unchanged comparison) |
+| present, unparsable | (ignored) | immediately due (corrupt state, unchanged) |
+| `NULL` | present, parsable | due iff `now − started_at` ≥ `wake_interval` |
+| `NULL` | `NULL` or unparsable | immediately due (corrupt state — in a running loop the claim has just stamped `started_at`, so this cannot happen on the healthy path; degrading to today's behavior beats a panic in the heartbeat loop) |
+
+Precedence rationale: a present `last_wake_at` always wins, even when it is older than a fresh post-reclaim `started_at` — that preserves the existing "an immediate restart honors the remaining wake cadence rather than firing instantly" behavior for fleets that have already received a wake.
+
+### `monitor_tick` — call-site change
+
+Step 4 (compute due-ness) reads both stamps from the runtime row it already fetched and passes them through:
+
+```rust
+if !wake_due(
+    runtime["last_wake_at"].as_str(),
+    runtime["started_at"].as_str(),
+    wake_interval,
+    now,
+) {
+    return Ok(TickResult::Continue);
+}
+```
+
+No other tick step changes. The `woke`-gated `record_monitor_wake` + echo ordering invariant is untouched; skipped wakes (dead Director pane, failed keystroke) still stamp nothing, so an unstamped-but-due fleet stays due on the next tick.
+
+### Accepted trade-off: reclaim resets the first-wake timer
+
+`claim_monitor_runtime` re-stamps `started_at` on every claim and reclaim while preserving `last_wake_at` (both unchanged). Consequently a fleet that has **never** received its first wake and whose monitor crashes/restarts waits a fresh full `wake_interval` from the new `started_at`. This is accepted: the first-wake state is exactly the state in which a deferred wake is wanted, and the alternative (persisting a first-deadline stamp) would require a schema change. The trade-off is documented on the docs monitoring concepts page and in SPEC §6.6.
+
+### Broker layer — no change
+
+`claim_monitor_runtime`, `record_monitor_wake`, `clear_monitor_runtime`, and the `GET /api/monitor` payloads are untouched. `last_wake_at` stays never-pre-stamped, preserved across reclaim and clear; `started_at` stays stamped at claim and nulled at clear. No schema change, no CLI flag change, no API payload change.
+
+### Contract-surface edits
+
+| Surface | Edit |
+|---|---|
+| SPEC.md §6.6 *Public surface* (`wake_due`) | New four-parameter signature; state the full baseline policy table above: present `last_wake_at` wins (unparsable → immediately due); `NULL` `last_wake_at` → baseline `started_at`; `NULL`/unparsable `started_at` with `NULL` `last_wake_at` → immediately due. |
+| SPEC.md §6.6 `monitor_tick` step 4 | "Read the runtime row's `last_wake_at` **and `started_at`** and call `wake_due(last_wake_at, started_at, wake_interval_seconds, now)`." |
+| SPEC.md §6.6 `run_monitor_loop` step 2 (reclaim note) | Extend the existing "a reclaim leaves `last_wake_at` untouched" sentence: a reclaim re-stamps `started_at`, so a fleet that never received its first wake waits a fresh full interval from the restart. |
+| SPEC.md §10 test-plan *Monitor* line | The `wake_due` clause enumerates only states the pure function sees — interval gating / `last_wake_at` precedence / `started_at` baseline / corrupt stamps; the zero-interval state moves to the `monitor_tick` clause (the interval-0 gate precedes the due-check, so `wake_due` never sees interval 0). |
+| `docs/docs/concepts/monitoring.md` § Cadence and tick precision | State the first-wake baseline: the first wake fires once the interval has elapsed since the monitor started, so a freshly created fleet gets its Director's spawning window undisturbed. Extend the restart-durability sentence with the trade-off: a fleet that has already been woken keeps its remaining cadence across restarts; a fleet that has never been woken restarts its first-wake timer. |
+
+The doc row for `last_wake_at` in SPEC §6.2 and `docs/docs/spec/data-model.md` ("timestamp of the last successfully delivered Director wake") stays accurate as-is; no other page pins the first-tick behavior.
+
+### Test changes (colocated, `cafleet/src/monitor/mod.rs`)
+
+`wake_due_tests`:
+
+| Test | Change |
+|---|---|
+| `a_missing_or_unparsable_stamp_is_immediately_due` | Replace: an unparsable `last_wake_at` stays immediately due regardless of `started_at`; `NULL` `last_wake_at` with `NULL` or unparsable `started_at` is immediately due. |
+| new: `a_null_last_wake_defers_to_the_started_at_baseline` | `NULL` `last_wake_at` + parsable `started_at`: not due at `started_at + interval − 1`, due at `started_at + interval`. |
+| new: `a_present_last_wake_wins_over_a_fresher_started_at` | `last_wake_at` older than `started_at` (post-reclaim shape): due-ness follows `last_wake_at`. |
+| `the_interval_gates_a_stamped_fleet` | Pass a `started_at` argument; assertions unchanged. |
+
+`monitor_tick_tests` — every test that relied on "`NULL` stamp → due at claim time" now advances `now` past the interval (the fleets are claimed at `base_now()`, so ticking at `base_now() + 600s` makes them due):
+
+| Test | Change |
+|---|---|
+| `a_due_tick_wakes_the_director_and_stamps_last_wake_at` | Tick at `now + 600s`; echo/stamp assertions follow the new tick time. |
+| `the_wake_interval_gates_the_next_wake` | New sequence pinning the deferral: tick at claim time → **no** wake; at `+599s` → not due; at `+600s` → first wake; at `+1199s` → not due; at `+1200s` → second wake. |
+| `a_dead_director_pane_skips_the_wake_without_stamping` | Tick at `now + 600s` so the fleet is due; skip/no-stamp assertions unchanged. |
+| `a_failed_wake_commits_nothing_and_retries_next_tick` | First (failed) wake at `now + 600s`, retry at `now + 605s`; assertions otherwise unchanged. |
+| `a_fleet_with_no_members_still_wakes_the_director` | Tick at `now + 600s`; assertions follow. |
+| `a_zero_interval_heartbeats_without_waking` | Unchanged (the interval gate precedes the due-check). |
+
+`cafleet/src/broker/monitor.rs` tests (`last_wake_at_survives_a_reclaim`, `claim_inserts_a_fresh_slot_and_refuses_a_live_one`, `clear_is_ownership_checked_and_preserves_tick_seconds_and_last_wake_at`) already pin the unchanged broker semantics and need no edits.
+
+---
+
+## Implementation
+
+> Task format: `- [x] Done task <!-- completed: 2026-02-13T14:30 -->`
+> When completing a task, check the box and record the timestamp in the same edit.
+
+### Step 1: Documentation (docs first)
+
+- [x] Update `docs/docs/concepts/monitoring.md`: first-wake baseline in § Cadence and tick precision, and the restart-durability sentence extended with the never-woken-fleet trade-off <!-- completed: 2026-08-06T12:20 -->
+
+### Step 2: SPEC.md
+
+- [ ] Update §6.6 *Public surface*: the four-parameter `wake_due` signature and the full baseline policy <!-- completed: -->
+- [ ] Update §6.6 `monitor_tick` step 4 to read and pass both stamps <!-- completed: -->
+- [ ] Extend §6.6 `run_monitor_loop` step 2 with the reclaim first-wake trade-off <!-- completed: -->
+- [ ] Reword the §10 test-plan *Monitor* line: the `wake_due` clause carries interval gating / `last_wake_at` precedence / `started_at` baseline / corrupt stamps; zero-interval moves to the `monitor_tick` clause <!-- completed: -->
+
+### Step 3: Code
+
+- [ ] Extend `wake_due` in `cafleet/src/monitor/mod.rs` with the `started_at` parameter and the baseline policy, restating the new policy in both the module-header API sketch and `wake_due`'s own `///` contract comment <!-- completed: -->
+- [ ] Update the `monitor_tick` call site to pass `runtime["started_at"].as_str()` <!-- completed: -->
+
+### Step 4: Tests and verification
+
+- [ ] Rework `wake_due_tests`: corrupt-state test, `started_at`-baseline test, `last_wake_at`-precedence test, extended-signature gating test <!-- completed: -->
+- [ ] Rework the five `monitor_tick_tests` that assumed first-tick due-ness; pin the deferred first wake in `the_wake_interval_gates_the_next_wake` <!-- completed: -->
+- [ ] Confirm the broker-layer tests still pass unchanged <!-- completed: -->
+- [ ] `mise //cafleet:test` passes <!-- completed: -->
+- [ ] `mise //cafleet:lint` passes <!-- completed: -->
+
+---
+
+## Changelog
+
+| Date | Changes |
+|------|---------|
+| 2026-08-06 | Initial draft |
+| 2026-08-06 | Reviewer fixes (§10 test-plan attribution, `///` contract-comment task); approved |

--- a/design-docs/0000161-deferred-first-director-wake/design-doc.md
+++ b/design-docs/0000161-deferred-first-director-wake/design-doc.md
@@ -1,6 +1,6 @@
 # Deferred First Director Wake
 
-**Status**: Approved
+**Status**: Complete
 **Progress**: 12/12 tasks complete
 **Last Updated**: 2026-08-06
 
@@ -150,3 +150,4 @@ The doc row for `last_wake_at` in SPEC §6.2 and `docs/docs/spec/data-model.md` 
 |------|---------|
 | 2026-08-06 | Initial draft |
 | 2026-08-06 | Reviewer fixes (§10 test-plan attribution, `///` contract-comment task); approved |
+| 2026-08-06 | Implemented (E2E first-wake window added to § Test changes during execution); Reviewer approved; PR #279; complete |

--- a/design-docs/0000161-deferred-first-director-wake/design-doc.md
+++ b/design-docs/0000161-deferred-first-director-wake/design-doc.md
@@ -1,7 +1,7 @@
 # Deferred First Director Wake
 
 **Status**: Approved
-**Progress**: 5/12 tasks complete
+**Progress**: 7/12 tasks complete
 **Last Updated**: 2026-08-06
 
 ## Overview
@@ -107,6 +107,8 @@ The doc row for `last_wake_at` in SPEC §6.2 and `docs/docs/spec/data-model.md` 
 | `a_fleet_with_no_members_still_wakes_the_director` | Tick at `now + 600s`; assertions follow. |
 | `a_zero_interval_heartbeats_without_waking` | Unchanged (the interval gate precedes the due-check). |
 
+`cafleet/tests/e2e.rs` — `end_to_end_lifecycle_with_one_monitor_tick` asserted the old first-tick wake (default 600 s interval, ~3 s observation window). It now spawns the monitor with `--interval 1` alongside `--tick 1`, so the deferred first wake fires at `started_at + 1s`, within the existing sleep window; all its assertions are otherwise unchanged.
+
 `cafleet/src/broker/monitor.rs` tests (`last_wake_at_survives_a_reclaim`, `claim_inserts_a_fresh_slot_and_refuses_a_live_one`, `clear_is_ownership_checked_and_preserves_tick_seconds_and_last_wake_at`) already pin the unchanged broker semantics and need no edits.
 
 ---
@@ -129,8 +131,8 @@ The doc row for `last_wake_at` in SPEC §6.2 and `docs/docs/spec/data-model.md` 
 
 ### Step 3: Code
 
-- [ ] Extend `wake_due` in `cafleet/src/monitor/mod.rs` with the `started_at` parameter and the baseline policy, restating the new policy in both the module-header API sketch and `wake_due`'s own `///` contract comment <!-- completed: -->
-- [ ] Update the `monitor_tick` call site to pass `runtime["started_at"].as_str()` <!-- completed: -->
+- [x] Extend `wake_due` in `cafleet/src/monitor/mod.rs` with the `started_at` parameter and the baseline policy, restating the new policy in both the module-header API sketch and `wake_due`'s own `///` contract comment <!-- completed: 2026-08-06T12:28 -->
+- [x] Update the `monitor_tick` call site to pass `runtime["started_at"].as_str()` <!-- completed: 2026-08-06T12:28 -->
 
 ### Step 4: Tests and verification
 

--- a/design-docs/0000161-deferred-first-director-wake/design-doc.md
+++ b/design-docs/0000161-deferred-first-director-wake/design-doc.md
@@ -1,7 +1,7 @@
 # Deferred First Director Wake
 
 **Status**: Approved
-**Progress**: 1/12 tasks complete
+**Progress**: 5/12 tasks complete
 **Last Updated**: 2026-08-06
 
 ## Overview
@@ -122,10 +122,10 @@ The doc row for `last_wake_at` in SPEC §6.2 and `docs/docs/spec/data-model.md` 
 
 ### Step 2: SPEC.md
 
-- [ ] Update §6.6 *Public surface*: the four-parameter `wake_due` signature and the full baseline policy <!-- completed: -->
-- [ ] Update §6.6 `monitor_tick` step 4 to read and pass both stamps <!-- completed: -->
-- [ ] Extend §6.6 `run_monitor_loop` step 2 with the reclaim first-wake trade-off <!-- completed: -->
-- [ ] Reword the §10 test-plan *Monitor* line: the `wake_due` clause carries interval gating / `last_wake_at` precedence / `started_at` baseline / corrupt stamps; zero-interval moves to the `monitor_tick` clause <!-- completed: -->
+- [x] Update §6.6 *Public surface*: the four-parameter `wake_due` signature and the full baseline policy <!-- completed: 2026-08-06T12:24 -->
+- [x] Update §6.6 `monitor_tick` step 4 to read and pass both stamps <!-- completed: 2026-08-06T12:24 -->
+- [x] Extend §6.6 `run_monitor_loop` step 2 with the reclaim first-wake trade-off <!-- completed: 2026-08-06T12:24 -->
+- [x] Reword the §10 test-plan *Monitor* line: the `wake_due` clause carries interval gating / `last_wake_at` precedence / `started_at` baseline / corrupt stamps; zero-interval moves to the `monitor_tick` clause <!-- completed: 2026-08-06T12:24 -->
 
 ### Step 3: Code
 

--- a/design-docs/0000161-deferred-first-director-wake/design-doc.md
+++ b/design-docs/0000161-deferred-first-director-wake/design-doc.md
@@ -1,7 +1,7 @@
 # Deferred First Director Wake
 
 **Status**: Approved
-**Progress**: 7/12 tasks complete
+**Progress**: 12/12 tasks complete
 **Last Updated**: 2026-08-06
 
 ## Overview
@@ -10,11 +10,11 @@ Defer the monitor's first fleet-level Director wake: when `monitor_runtime.last_
 
 ## Success Criteria
 
-- [ ] A freshly claimed monitor (`last_wake_at` `NULL`) fires its first wake only once `wake_interval` has elapsed since `started_at`, not on the first tick.
-- [ ] `last_wake_at` remains the `woke`-gated delivery ledger: it is never written at claim time and only records delivered wakes (its `GET /api/monitor` exposure is unchanged).
-- [ ] An unparsable `last_wake_at` remains immediately due; a `NULL` `last_wake_at` paired with a `NULL` or unparsable `started_at` is also immediately due (corrupt state, no panic).
-- [ ] A present `last_wake_at` always wins as the baseline — the cadence-survives-restart behavior is unchanged.
-- [ ] SPEC.md §6.6 (and the §10 monitor test-plan line), the docs monitoring concepts page, and the colocated tests all reflect the new contract; `mise //cafleet:test` and `mise //cafleet:lint` pass.
+- [x] A freshly claimed monitor (`last_wake_at` `NULL`) fires its first wake only once `wake_interval` has elapsed since `started_at`, not on the first tick.
+- [x] `last_wake_at` remains the `woke`-gated delivery ledger: it is never written at claim time and only records delivered wakes (its `GET /api/monitor` exposure is unchanged).
+- [x] An unparsable `last_wake_at` remains immediately due; a `NULL` `last_wake_at` paired with a `NULL` or unparsable `started_at` is also immediately due (corrupt state, no panic).
+- [x] A present `last_wake_at` always wins as the baseline — the cadence-survives-restart behavior is unchanged.
+- [x] SPEC.md §6.6 (and the §10 monitor test-plan line), the docs monitoring concepts page, and the colocated tests all reflect the new contract; `mise //cafleet:test` and `mise //cafleet:lint` pass.
 
 ---
 
@@ -136,11 +136,11 @@ The doc row for `last_wake_at` in SPEC §6.2 and `docs/docs/spec/data-model.md` 
 
 ### Step 4: Tests and verification
 
-- [ ] Rework `wake_due_tests`: corrupt-state test, `started_at`-baseline test, `last_wake_at`-precedence test, extended-signature gating test <!-- completed: -->
-- [ ] Rework the five `monitor_tick_tests` that assumed first-tick due-ness; pin the deferred first wake in `the_wake_interval_gates_the_next_wake` <!-- completed: -->
-- [ ] Confirm the broker-layer tests still pass unchanged <!-- completed: -->
-- [ ] `mise //cafleet:test` passes <!-- completed: -->
-- [ ] `mise //cafleet:lint` passes <!-- completed: -->
+- [x] Rework `wake_due_tests`: corrupt-state test, `started_at`-baseline test, `last_wake_at`-precedence test, extended-signature gating test <!-- completed: 2026-08-06T12:36 -->
+- [x] Rework the five `monitor_tick_tests` that assumed first-tick due-ness; pin the deferred first wake in `the_wake_interval_gates_the_next_wake` <!-- completed: 2026-08-06T12:36 -->
+- [x] Confirm the broker-layer tests still pass unchanged <!-- completed: 2026-08-06T12:36 -->
+- [x] `mise //cafleet:test` passes <!-- completed: 2026-08-06T12:36 -->
+- [x] `mise //cafleet:lint` passes <!-- completed: 2026-08-06T12:36 -->
 
 ---
 

--- a/docs/docs/concepts/monitoring.md
+++ b/docs/docs/concepts/monitoring.md
@@ -71,18 +71,23 @@ it re-engages a member.
 
 The monitor scans once per **tick** and the wake fires at the first tick
 boundary on which the wake interval has elapsed, so the tick is the floor on
-interval precision. `CAFLEET_MONITOR_WAKE_INTERVAL=0` (or `--interval 0`)
-disables the wake while the loop keeps claiming the runtime slot and
-heartbeating every tick.
+interval precision. The first wake is measured from the moment the monitor
+started: it fires only once the interval has elapsed since launch, so a
+freshly created fleet gets its Director's spawning window undisturbed. Every
+later wake is measured from the last delivered wake.
+`CAFLEET_MONITOR_WAKE_INTERVAL=0` (or `--interval 0`) disables the wake while
+the loop keeps claiming the runtime slot and heartbeating every tick.
 
 The wake is unconditional: it fires whenever the interval has elapsed and the
 Director's pane is alive, **including when the fleet has no other members**.
 The Director is itself a supervision target — the resume clause is the remedy
 for a stalled Director — and a fleet with no members is a transient bootstrap
 state, not a steady state (the Director stops the loop at teardown). The last
-wake timestamp is durable across loop restarts, so an immediate restart honors
-the remaining wake cadence rather than firing instantly. A failed wake commits
-nothing and retries on the next tick.
+wake timestamp is durable across loop restarts, so a fleet that has already
+been woken keeps its remaining wake cadence across an immediate restart rather
+than being woken instantly; a fleet that has never been woken restarts its
+first-wake timer from the new launch. A failed wake commits nothing and
+retries on the next tick.
 
 ## Keystroke safety
 


### PR DESCRIPTION
- **docs: document deferred first Director wake baseline on monitoring page**
- **test: add tests for deferred first Director wake baseline**
- **docs: specify deferred first Director wake in SPEC 6.6 and test plan**
- **feat: defer the first Director wake to started_at plus wake_interval**
- **fix: correct tests for the e2e first-wake window under the deferred wake**
- **chore: format monitor tests and check off verification tasks and success criteria**
