### PR TITLE
feat/0000162 webui wake interval editing

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -2497,8 +2497,8 @@ same `{"detail": <string>}` shape (a single human-readable string).
   `monitor has never run for this fleet`. The body parse precedes the fleet
   check, matching `POST /api/messages/send`. Success → `200`
   `{wake_interval_seconds: <the stored value>}`. The running loop obeys the
-  new value within one tick (§6.6); the next monitor start re-stamps the
-  column from the CLI/env resolution.
+  new value within one tick (§6.6); the next `cafleet monitor` start re-stamps
+  the column from the CLI/env resolution.
 - **`GET /api/members/{member_id}/inbox`** — fleet-scoped. Member not in fleet →
   `404`, detail `Member not found`; else `{"messages": [ <FormattedMessage>, …
   ]}` over the member's inbox.
@@ -2589,7 +2589,8 @@ binding, so an unrelated `CAFLEET_*` variable never binds by accident.
   non-negative 64-bit integer; anything else fails loudly at startup with
   `CAFLEET_MONITOR_WAKE_INTERVAL must be a non-negative integer (got '<raw>')`.
   The startup-resolved value is stamped into
-  `monitor_runtime.wake_interval_seconds` at each monitor start (§6.6);
+  `monitor_runtime.wake_interval_seconds` at each `cafleet monitor` start
+  (§6.6);
   dispatch cadence is
   persisted in `monitor_runtime.last_wake_at` (§6.2), durable across loop
   restarts.

--- a/SPEC.md
+++ b/SPEC.md
@@ -319,6 +319,7 @@ The unified shapes:
 | `last_tick_at` | optional string | |
 | `tick_seconds` | integer | DDL default 5 |
 | `last_wake_at` | optional string | nullable; the UTC ISO timestamp of the last successfully delivered Director wake, durable across loop restarts; preserved by the runtime clear |
+| `wake_interval_seconds` | optional integer | nullable; the live mirror of the running loop's Director wake interval — stamped at every claim/reclaim, re-read per tick, overwritten by `PATCH /api/monitor`, preserved by the runtime clear; `NULL` only in rows that predate the column and were never re-claimed |
 
 **AssetInstalls** (`coding_agent` TEXT PK, not autoincrement, not FK-linked)
 
@@ -448,7 +449,9 @@ not a no-op. Both must run on every connection the reimplementation opens.
   explicitly): `monitor_runtime.tick_seconds` → `5`.
   `member_placements.coding_agent` carries no DDL default — every writer
   passes an explicit value. `monitor_runtime.last_wake_at` carries no DDL
-  default (nullable, unset until the first successful wake).
+  default (nullable, unset until the first successful wake), and
+  `monitor_runtime.wake_interval_seconds` likewise carries no DDL default
+  (nullable; stamped by every claim).
 - **No-FK message columns.** `messages.from_member_id`, `messages.to_member_id`, and
   `messages.origin_message_id` are plain integer columns with **no** FK constraint;
   only `messages.owner_member_id` is FK-constrained (ON DELETE RESTRICT).
@@ -692,13 +695,17 @@ The `monitor_runtime` table holds **exactly one row per fleet** (PK = fleet_id)
   (`kill(pid, 0)`): no-such-process → `false`, permission-denied (owned by
   another user) → `true`, success → `true`. Heartbeat freshness is
   authoritative; the process probe corroborates.
-- **`claim_monitor_runtime(fleet_id, pid, tick_seconds, when)`** — atomically
+- **`claim_monitor_runtime(fleet_id, pid, tick_seconds, wake_interval_seconds,
+  when)`** — atomically
   claim the slot (the SQLite write lock serializes concurrent claims). No row →
   insert (with `last_wake_at` null) and return `true`; row exists and **live**
   → return `false`; row exists but **stale** → overwrite `pid` / `started_at` /
-  `tick_seconds` and return `true` (reclaim) — **`last_wake_at` is left
+  `tick_seconds` / `wake_interval_seconds` and return `true` (reclaim) —
+  **`last_wake_at` is left
   untouched by a reclaim**, so an immediately-restarted loop honors the
   remaining wake cadence instead of firing an instant wake.
+  `wake_interval_seconds` is stamped in both the insert and the reclaim
+  overwrite, exactly like `tick_seconds`.
 - **`heartbeat_monitor_runtime(fleet_id, pid, when)`** — update `last_tick_at =
   when` **only where the current pid equals the caller's pid**; returns `true`
   iff exactly one row matched. **Ownership-checked** — `false` when the slot was
@@ -707,22 +714,33 @@ The `monitor_runtime` table holds **exactly one row per fleet** (PK = fleet_id)
   for the fleet's runtime row: one unconditional `UPDATE` keyed on
   `fleet_id` — no pid parameter, no ownership check, no return value beyond
   success. Called only after a successful Director wake keystroke (§6.6).
+- **`set_monitor_wake_interval(fleet_id, wake_interval_seconds)`** — one
+  ownership-free `UPDATE monitor_runtime SET wake_interval_seconds = ?1 WHERE
+  fleet_id = ?2`, returning `true` iff exactly one row changed. `false` ⇔ no
+  row — the fleet's monitor has never run (rows are removed only by `fleet
+  delete`, so "no row" is exactly "never run"). Consumed by the WebUI
+  `PATCH /api/monitor` (§6.8); the running loop obeys the new value within
+  one tick (§6.6).
 - **`clear_monitor_runtime(fleet_id, pid)`** — null the slot's `pid` /
   `started_at` / `last_tick_at` **only where the current pid equals the
   caller's pid**. **Ownership-checked** → a non-owner clear is a no-op, so a
-  self-terminating loser never wipes the winner's row. **`last_wake_at` is
-  preserved** (never nulled by a clear) — the wake cadence survives a clean
-  stop/restart cycle.
+  self-terminating loser never wipes the winner's row. **`last_wake_at` and
+  `wake_interval_seconds` are preserved** (never nulled by a clear) — the
+  wake cadence survives a clean stop/restart cycle.
 - **`read_monitor_runtime(fleet_id)`** — `{fleet_id, pid, started_at,
-  last_tick_at, tick_seconds, last_wake_at}` or None.
+  last_tick_at, tick_seconds, wake_interval_seconds, last_wake_at}` or None.
 - **`monitor_is_live(fleet_id, now)`** — `false` if no row, else `_is_live`. An
   advisory pre-check for `cafleet monitor`; the atomic claim is authoritative.
 - **`monitor_runtime_payload(fleet_id, now)`** — the runtime-liveness dict
   consumed by the WebUI `GET /api/monitor`: `{running, pid,
-  tick_seconds, last_tick_at, last_tick_age_seconds, started_at, last_wake_at,
+  tick_seconds, wake_interval_seconds, last_tick_at, last_tick_age_seconds,
+  started_at, last_wake_at,
   last_wake_age_seconds}`, with the process fields — including `last_wake_at` /
   `last_wake_age_seconds` — null when the monitor is not live (no row, or a
   stale/cleared heartbeat), matching the `last_tick_at` masking rule.
+  `wake_interval_seconds` follows the `tick_seconds` preservation rule
+  instead: the row's value when a row exists (even stale or cleared; `null`
+  when the row predates the column and was never re-stamped), else `null`.
 - **`monitor_members_payload(fleet_id, now)`** — the per-member rows consumed
   by the WebUI `GET /api/monitor`: one dict per `list_fleet_wake_targets` row —
   `{member_id, name, pending_count, oldest_pending_ts,
@@ -1244,9 +1262,14 @@ with the positional `FLEET_ID` subject. A
 `_require_live_fleet` guard fetches the fleet; missing or soft-deleted
 → application error `fleet <fleet_id> not found`.
 `--tick` (integer ≥1, default 5, shown in help) and `--interval`
-(integer ≥0, optional; when omitted, falls back to
+(a non-negative 64-bit integer, parser-enforced `0..=i64::MAX` — a negative
+or above-`i64::MAX` value fails the parser's standard invalid-value error,
+exit 2; optional; when omitted, falls back to
 `CAFLEET_MONITOR_WAKE_INTERVAL` §7.1, default 600). `--interval 0` disables
-the Director wake while the loop keeps heartbeating every tick. Requires a
+the Director wake while the loop keeps heartbeating every tick. The
+startup-resolved interval is stamped into the fleet's `monitor_runtime` row
+by the claim and re-read on every tick (§6.6), so a `PATCH /api/monitor`
+edit (§6.8) changes a running loop's cadence within one tick. Requires a
 live fleet, then tmux. Runs the monitor loop in-process (blocking),
 launched by the Director as a background task in its own pane immediately
 after `cafleet fleet create` and before the first `cafleet member create`.
@@ -2013,18 +2036,21 @@ of `AgentStateAware` native status.
 #### Public surface
 
 - **`wake_due(last_wake_at, started_at, wake_interval_seconds, now) -> bool`**
-  — pure due-check for the fleet-level wake; no DB/multiplexer access. A
+  — pure due-check for the fleet-level wake; no DB/multiplexer access. The
+  interval parameter is a non-negative 64-bit integer. A
   present `last_wake_at` always wins as the baseline: parsable → due iff
   `now − last_wake_at`, in whole seconds, is `>= wake_interval_seconds`;
   unparsable → immediately due. A `NULL` `last_wake_at` falls back to
   `started_at` as the baseline: parsable → due iff `now − started_at`, in
   whole seconds, is `>= wake_interval_seconds`; `NULL` or unparsable →
   immediately due.
-- **`monitor_tick(fleet_id, now, wake_interval_seconds) -> CONTINUE | STOP`** —
-  one scan pass.
+- **`monitor_tick(fleet_id, now) -> CONTINUE | STOP`** —
+  one scan pass. Takes no interval parameter — each pass re-reads
+  `wake_interval_seconds` from the fleet's runtime row.
 - **`run_monitor_loop(fleet_id, tick_seconds, wake_interval_seconds)`** —
   foreground driver: claim slot → install signal handlers → `tick → sleep`
-  until signalled → clear slot on exit.
+  until signalled → clear slot on exit. `wake_interval_seconds` is used only
+  to stamp the claim; the ticks read the stored value.
 - **`CONTINUE` / `STOP`** — tick-result markers distinguishing "keep looping"
   from "self-terminate".
 - **`DEFAULT_TICK_SECONDS = 5`** — default scan cadence (seconds).
@@ -2038,7 +2064,7 @@ The stop flag, the sleep helper, the signal handler, and the marker type are
 implementation-private; only the functions, the markers, and the constants
 above are public.
 
-#### `monitor_tick(fleet_id, now, wake_interval_seconds)`
+#### `monitor_tick(fleet_id, now)`
 
 One scan pass, steps in order:
 
@@ -2048,20 +2074,23 @@ One scan pass, steps in order:
    split-brain loser's exit.
 2. **Fleet liveness.** Fetch the fleet; absent **or** `deleted_at` set → return
    `STOP`.
-3. **Wake-interval gate.** `wake_interval_seconds == 0` → return `CONTINUE`
+3. **Read the runtime row.** The heartbeat just matched, so the row exists;
+   take its `wake_interval_seconds` — the owning loop stamped the value at
+   claim, so `NULL` here is corrupt state and fails loudly.
+4. **Wake-interval gate.** `wake_interval_seconds == 0` → return `CONTINUE`
    (a heartbeat-only tick: no due-check, no Director resolution, no
-   multiplexer call).
-4. **Compute due-ness.** Read the runtime row's `last_wake_at` and
-   `started_at` and call
-   `wake_due(last_wake_at, started_at, wake_interval_seconds, now)`. Not due →
+   multiplexer call). Evaluated per tick against the value just read.
+5. **Compute due-ness.** Call
+   `wake_due(last_wake_at, started_at, wake_interval_seconds, now)` on the
+   row's values. Not due →
    return `CONTINUE` with no multiplexer call.
-5. **Resolve the Director's pane.** Read the fleet's `director_member_id` and
+6. **Resolve the Director's pane.** Read the fleet's `director_member_id` and
    its placement's `mux_pane_id`. A Director with no pane → return `CONTINUE`
    (nothing recorded — the fleet stays due).
-6. **Fetch pane liveness once.** A single `list_pane_ids` call against the
+7. **Fetch pane liveness once.** A single `list_pane_ids` call against the
    resolved backend (§6.5). The Director's pane absent from the live set →
    return `CONTINUE` (nothing recorded — the fleet stays due).
-7. **Wake the Director.** Fetch the wake roster via the broker's
+8. **Wake the Director.** Fetch the wake roster via the broker's
    `list_fleet_wake_targets(fleet_id)` (§6.2 — every active, non-Director
    member with its `coding_agent` and `pending_count`), then call the
    multiplexer's wake trigger against the Director's own pane (the loop's
@@ -2076,13 +2105,19 @@ One scan pass, steps in order:
      `N` is the roster size (may be `0`).
    - If `woke` is false: do not record the wake and do not echo — the wake
      stays due, so the next tick retries (no wake-storm, no silent skip).
-8. Return `CONTINUE`.
+9. Return `CONTINUE`.
 
 **Critical ordering invariant:** `record_monitor_wake` and the heartbeat echo
 are both gated behind `woke == true`. Preserve this gating exactly. The wake
 fires **even when the fleet has no other members** (`N == 0`) — the Director
 is itself a supervision target and a fleet with no members yet is a transient
 bootstrap state, not a steady state.
+
+The per-tick re-read is what makes the interval externally editable: an
+`UPDATE` to `wake_interval_seconds` (the WebUI `PATCH /api/monitor`, §6.8)
+changes the running loop's cadence on its next tick — within `tick_seconds` —
+with no restart, gated against the existing `last_wake_at` / `started_at`
+baseline.
 
 #### `run_monitor_loop(fleet_id, tick_seconds, wake_interval_seconds)`
 
@@ -2091,7 +2126,9 @@ artifact (no PID file); identity throughout is the OS process id.
 
 1. Reset the shared stop flag to false. Capture `pid = this-pid`.
 2. **Claim the slot** via the broker's atomic claim `(fleet_id, pid,
-   tick_seconds, now-as-ISO)`. On refusal (returns false) → application error
+   tick_seconds, wake_interval_seconds, now-as-ISO)` — the driver's only use
+   of its `wake_interval_seconds` parameter. On refusal (returns false) →
+   application error
    (exit 1) `monitor already running for fleet {fleet_id}`. There is no silent
    fallback. A reclaim leaves `last_wake_at` untouched (§6.2), so the wake
    cadence survives a crash/restart cycle; it re-stamps `started_at`, so a
@@ -2102,8 +2139,8 @@ artifact (no PID file); identity throughout is the OS process id.
    first `cafleet member create`.
 3. **Install signal handlers** for SIGTERM and SIGINT; each flips the shared stop
    flag to true (the handler is minimal — just a flag flip).
-4. **Loop** while the stop flag is false: if `monitor_tick(fleet_id, now,
-   wake_interval_seconds)` (each pass stamps `now` fresh as tz-aware UTC)
+4. **Loop** while the stop flag is false: if `monitor_tick(fleet_id, now)`
+   (each pass stamps `now` fresh as tz-aware UTC)
    returns `STOP` → break; else call `interruptible_sleep(tick_seconds)`.
 5. **Cleanup (always, in a finally block):** the broker's ownership-checked clear
    `(fleet_id, pid)` — nulls the slot's `pid` / `started_at` / `last_tick_at`
@@ -2416,7 +2453,7 @@ array**; every other list endpoint wraps in an object (member rows under
 `{"detail": <string>}`; a request-validation failure returns `422` with the
 same `{"detail": <string>}` shape (a single human-readable string).
 
-#### The 7 routes
+#### The 8 routes
 
 - **`GET /api/fleets`** — unscoped (no `X-Fleet-Id`). Returns the broker fleet
   list **directly as a bare array**.
@@ -2426,15 +2463,19 @@ same `{"detail": <string>}` shape (a single human-readable string).
   two-value `kind` (§5.4). Response `{"members": [ <member dict>, … ]}`. Roster
   rows carry no `monitor` key.
 - **`GET /api/monitor`** — fleet-scoped. Returns the flat runtime keys
-  `{running, pid, tick_seconds, last_tick_at, last_tick_age_seconds,
+  `{running, pid, tick_seconds, wake_interval_seconds, last_tick_at,
+  last_tick_age_seconds,
   started_at, last_wake_at, last_wake_age_seconds}` plus a top-level `members`
   key. Read the runtime row and
   the live-check (current UTC). If absent **or** not live: `running=false`,
-  `pid=null`, `tick_seconds` = the row's value when a row exists else `null`,
+  `pid=null`, `tick_seconds` and `wake_interval_seconds` = the row's values
+  when a row exists else `null` (`wake_interval_seconds` is also `null` when
+  the row predates the column and was never re-stamped),
   `last_tick_at`/`last_tick_age_seconds`/`started_at`/`last_wake_at`/
   `last_wake_age_seconds` all `null` — **a stale row
   never leaks a lingering pid or start time**. When live: `running=true` with the
-  live `pid`, `tick_seconds`, `last_tick_at`, `started_at`, `last_wake_at`, and
+  live `pid`, `tick_seconds`, `wake_interval_seconds` (a stamped row is
+  non-null), `last_tick_at`, `started_at`, `last_wake_at`, and
   computed `last_tick_age_seconds` / `last_wake_age_seconds` (each null when
   its source timestamp is null; else whole-seconds
   now − parsed timestamp, **integer-truncated**). `members` carries the
@@ -2444,6 +2485,20 @@ same `{"detail": <string>}` shape (a single human-readable string).
   `now` as the runtime fields; the flat runtime keys are unchanged by this
   addition. There is no `GET`/`PATCH` per-member monitor endpoint — supervision
   cadence has no per-member configuration surface.
+- **`PATCH /api/monitor`** — fleet-scoped. Body `{wake_interval_seconds: int}`:
+  a JSON integer in `0..=i64::MAX`, validated as an exact 64-bit integer plus
+  `>= 0` — floats, stringified integers, negatives, and numbers above
+  `i64::MAX` are rejected, not coerced. Resolution order: header errors, then
+  body validation — an unparsable body → `422`, detail
+  `invalid JSON body: <parse error>`; a missing or invalid field → `422`,
+  detail `wake_interval_seconds must be a non-negative integer` — then the
+  fleet check (`404`, `Fleet not found`), then the row update via
+  `set_monitor_wake_interval` (§6.2): no row → `404`, detail
+  `monitor has never run for this fleet`. The body parse precedes the fleet
+  check, matching `POST /api/messages/send`. Success → `200`
+  `{wake_interval_seconds: <the stored value>}`. The running loop obeys the
+  new value within one tick (§6.6); the next monitor start re-stamps the
+  column from the CLI/env resolution.
 - **`GET /api/members/{member_id}/inbox`** — fleet-scoped. Member not in fleet →
   `404`, detail `Member not found`; else `{"messages": [ <FormattedMessage>, …
   ]}` over the member's inbox.
@@ -2498,7 +2553,8 @@ truncation scope — is specified in §7.1.
 3. **Stale monitor never leaks process fields** — when not live, `pid` /
    `started_at` / `last_tick_at` / `last_tick_age_seconds` / `last_wake_at` /
    `last_wake_age_seconds` are all `null` even if
-   a stale row exists; only `tick_seconds` survives from a stale row.
+   a stale row exists; only `tick_seconds` and `wake_interval_seconds`
+   survive from a stale row.
 4. **Field renames are wire contract** — `status_state → status`, `text → body`.
 5. **`list_fleets` returns a bare array**; every other list wraps in
    `{"members"|"messages": [...]}`.
@@ -2521,7 +2577,7 @@ binding, so an unrelated `CAFLEET_*` variable never binds by accident.
 | `broker_port` | `CAFLEET_BROKER_PORT` | integer (16-bit port) | `8000` |
 | `max_text_len` | `CAFLEET_MAX_TEXT_LEN` | non-negative integer | `200` |
 | `multiplexer` | `CAFLEET_MULTIPLEXER` | optional string | `None` (auto-detect) |
-| `monitor_wake_interval` | `CAFLEET_MONITOR_WAKE_INTERVAL` | non-negative integer | `600` |
+| `monitor_wake_interval` | `CAFLEET_MONITOR_WAKE_INTERVAL` | non-negative 64-bit integer | `600` |
 
 - **`multiplexer`** is the explicit backend override consumed by
   `resolve_multiplexer()` (§6.5). `None` (unset) means auto-detect from
@@ -2529,7 +2585,12 @@ binding, so an unrelated `CAFLEET_*` variable never binds by accident.
   A set value must name a registry key (`tmux`/`herdr`) or resolution raises.
 - **`monitor_wake_interval`** is the `cafleet monitor` Director wake interval in
   seconds, overridden per-invocation by `--interval` (§6.3). `0` disables the
-  wake while the loop keeps heartbeating every tick. Dispatch cadence is
+  wake while the loop keeps heartbeating every tick. The value is a
+  non-negative 64-bit integer; anything else fails loudly at startup with
+  `CAFLEET_MONITOR_WAKE_INTERVAL must be a non-negative integer (got '<raw>')`.
+  The startup-resolved value is stamped into
+  `monitor_runtime.wake_interval_seconds` at each monitor start (§6.6);
+  dispatch cadence is
   persisted in `monitor_runtime.last_wake_at` (§6.2), durable across loop
   restarts.
 - **Default DB URL** expands `~` to `$HOME` **only for the factory default**; a
@@ -2664,7 +2725,7 @@ defaults, FK rules, AUTOINCREMENT, and the create-order quirk are in §6.1.
 - `idx_messages_owner_member_status_ts` on `messages(owner_member_id, status_timestamp)`
 - `idx_messages_from_member_status_ts` on `messages(from_member_id, status_timestamp)`
 
-**The migration chain.** Head is **`V4`**, contiguous from 1 with exactly one
+**The migration chain.** Head is **`V5`**, contiguous from 1 with exactly one
 baseline:
 
 1. `V1__baseline.sql` — the baseline, creating the schema in this order:
@@ -2700,7 +2761,10 @@ baseline:
 4. `V4__fleet_level_wake_schedule.sql` — drops the per-member monitor
    schedule table (supervision cadence lives solely on `monitor_runtime`) and
    runs `ALTER TABLE monitor_runtime ADD COLUMN last_wake_at TEXT` (nullable,
-   no DDL default). Head `monitor_runtime` schema:
+   no DDL default).
+5. `V5__monitor_wake_interval.sql` — runs
+   `ALTER TABLE monitor_runtime ADD COLUMN wake_interval_seconds INTEGER`
+   (nullable, no DDL default). Head `monitor_runtime` schema:
    ```sql
    CREATE TABLE monitor_runtime (
        fleet_id INTEGER NOT NULL PRIMARY KEY REFERENCES fleets (fleet_id) ON DELETE RESTRICT,
@@ -2708,7 +2772,8 @@ baseline:
        started_at TEXT,
        last_tick_at TEXT,
        tick_seconds INTEGER NOT NULL DEFAULT 5,
-       last_wake_at TEXT
+       last_wake_at TEXT,
+       wake_interval_seconds INTEGER
    );
    ```
 
@@ -2734,7 +2799,7 @@ automatically.`; (5) already at head (recorded version == head) → print
 pending migrations to head and print `Created <db_file> and applied migrations
 to head (<N>).` when no version was recorded before the run (a fresh or
 table-less DB), else `Upgraded from <M> to <N>.`. `<M>` / `<N>` are the
-integer migration versions (the head is `4`). The driver's
+integer migration versions (the head is `5`). The driver's
 connection is closed when the command finishes (success or failure).
 
 ---

--- a/admin/src/api.ts
+++ b/admin/src/api.ts
@@ -75,3 +75,10 @@ export async function sendMessage(
 export async function getMonitor(): Promise<MonitorRuntime> {
   return request<MonitorRuntime>("/monitor");
 }
+
+export async function patchMonitor(wakeIntervalSeconds: number): Promise<void> {
+  await request<unknown>("/monitor", {
+    method: "PATCH",
+    body: JSON.stringify({ wake_interval_seconds: wakeIntervalSeconds }),
+  });
+}

--- a/admin/src/components/AppHeader.tsx
+++ b/admin/src/components/AppHeader.tsx
@@ -1,4 +1,7 @@
-import { RefreshCw } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import { LoaderCircle, RefreshCw } from "lucide-react";
+import type { MonitorRuntime } from "../types";
+import { patchMonitor } from "../api";
 import ThemeToggle from "./ThemeToggle";
 
 function BrandMark() {
@@ -14,25 +17,154 @@ function BrandMark() {
   );
 }
 
-function MonitorIndicator({ running }: { running: boolean | null }) {
-  if (running === null) return null;
-  return (
-    <span
-      className="flex items-center gap-1.5 text-xs text-text-muted"
-      title={
-        running
-          ? "cafleet monitor is running for this fleet"
-          : "No cafleet monitor running — start it with 'cafleet --fleet-id <id> monitor start'"
+function parseInterval(draft: string): number | null {
+  const trimmed = draft.trim();
+  if (!/^\d+$/.test(trimmed)) return null;
+  const value = Number(trimmed);
+  return Number.isSafeInteger(value) ? value : null;
+}
+
+function MonitorIndicator({
+  monitor,
+  onSaved,
+}: {
+  monitor: MonitorRuntime | null;
+  onSaved: () => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const [draft, setDraft] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const onPointerDown = (e: MouseEvent) => {
+      const container = containerRef.current;
+      if (container && !container.contains(e.target as Node)) {
+        setOpen(false);
       }
-    >
-      <span
-        aria-hidden="true"
-        className={`size-2 rounded-full ${
-          running ? "bg-success" : "bg-text-faint"
-        }`}
-      />
-      Monitor {running ? "running" : "stopped"}
-    </span>
+    };
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpen(false);
+    };
+    document.addEventListener("mousedown", onPointerDown);
+    document.addEventListener("keydown", onKeyDown);
+    return () => {
+      document.removeEventListener("mousedown", onPointerDown);
+      document.removeEventListener("keydown", onKeyDown);
+    };
+  }, [open]);
+
+  if (monitor === null) return null;
+  const running = monitor.running;
+  const parsed = parseInterval(draft);
+
+  const toggleOpen = () => {
+    if (!open) {
+      setDraft(
+        monitor.wake_interval_seconds === null
+          ? ""
+          : String(monitor.wake_interval_seconds),
+      );
+      setError(null);
+    }
+    setOpen((wasOpen) => !wasOpen);
+  };
+
+  const save = async () => {
+    if (!running || parsed === null) return;
+    setSaving(true);
+    setError(null);
+    try {
+      await patchMonitor(parsed);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Save failed");
+      return;
+    } finally {
+      setSaving(false);
+    }
+    setOpen(false);
+    onSaved();
+  };
+
+  return (
+    <div ref={containerRef} className="relative">
+      <button
+        type="button"
+        onClick={toggleOpen}
+        aria-haspopup="dialog"
+        aria-expanded={open}
+        className="flex items-center gap-1.5 rounded text-xs text-text-muted hover:text-text focus-visible:outline-2 focus-visible:outline-accent"
+        title={
+          running
+            ? "cafleet monitor is running for this fleet"
+            : "No cafleet monitor running — start it with 'cafleet monitor <fleet-id>'"
+        }
+      >
+        <span
+          aria-hidden="true"
+          className={`size-2 rounded-full ${
+            running ? "bg-success" : "bg-text-faint"
+          }`}
+        />
+        Monitor {running ? "running" : "stopped"}
+      </button>
+      {open && (
+        <div
+          role="dialog"
+          aria-label="Director wake interval"
+          className="absolute right-0 top-full z-10 mt-1 w-72 rounded-lg border border-border bg-surface-raised p-3 shadow-lg"
+        >
+          <label className="block text-xs font-medium">
+            Director wake interval (seconds)
+            <input
+              type="number"
+              min={0}
+              step={1}
+              value={draft}
+              onChange={(e) => {
+                setDraft(e.target.value);
+                setError(null);
+              }}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") void save();
+              }}
+              disabled={!running || saving}
+              className="mt-1.5 w-full rounded-lg border border-border bg-surface px-2 py-1.5 font-mono text-sm outline-none focus:border-accent focus:ring-2 focus:ring-accent/30 disabled:opacity-50"
+            />
+          </label>
+          {running && parsed === 0 && (
+            <p className="mt-1.5 text-[11px] text-text-muted">
+              0 disables the Director wake while the loop keeps running.
+            </p>
+          )}
+          {!running && (
+            <p className="mt-1.5 text-[11px] text-text-muted">
+              Monitor not running — the interval is re-stamped from the
+              CLI/env when the monitor starts, so there is nothing durable
+              to edit.
+            </p>
+          )}
+          {error && <p className="mt-1.5 text-xs text-danger">{error}</p>}
+          <button
+            type="button"
+            onClick={() => void save()}
+            disabled={!running || saving || parsed === null}
+            className="mt-2 flex w-full items-center justify-center gap-1.5 rounded-lg bg-accent px-2 py-1.5 text-xs font-medium text-accent-fg hover:bg-accent-hover focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {saving && (
+              <LoaderCircle
+                size={12}
+                className="motion-safe:animate-spin"
+                aria-hidden="true"
+              />
+            )}
+            Save
+          </button>
+        </div>
+      )}
+    </div>
   );
 }
 
@@ -66,8 +198,10 @@ interface AppHeaderProps {
   fleetName?: string;
   onBack?: () => void;
   sendingAsDirector?: boolean;
-  /** Monitor liveness for the fleet; `null` until the first fetch resolves. */
-  monitorRunning?: boolean | null;
+  /** The polled monitor payload; `null` until the first fetch resolves. */
+  monitor?: MonitorRuntime | null;
+  /** The dashboard refresh trigger, fired after a successful interval save. */
+  onMonitorSaved?: () => void;
 }
 
 export default function AppHeader({
@@ -76,7 +210,8 @@ export default function AppHeader({
   fleetName,
   onBack,
   sendingAsDirector = false,
-  monitorRunning = null,
+  monitor = null,
+  onMonitorSaved = () => {},
 }: AppHeaderProps) {
   return (
     <header className="flex shrink-0 items-center justify-between gap-3 border-b border-border bg-surface-raised px-4 py-2">
@@ -112,7 +247,7 @@ export default function AppHeader({
             Sending as <span className="font-medium text-text">Director</span>
           </span>
         )}
-        <MonitorIndicator running={monitorRunning} />
+        <MonitorIndicator monitor={monitor} onSaved={onMonitorSaved} />
         <LiveIndicator isPolling={isPolling} />
         <button
           type="button"

--- a/admin/src/components/Dashboard.tsx
+++ b/admin/src/components/Dashboard.tsx
@@ -95,7 +95,10 @@ export default function Dashboard({
         fleetName={fleetName ?? String(fleetId)}
         onBack={onBack}
         sendingAsDirector={senderId !== null}
-        monitorRunning={monitor === null ? null : monitor.running}
+        monitor={monitor}
+        onMonitorSaved={() => {
+          void trigger();
+        }}
       />
 
       <div className="flex flex-1 min-h-0">

--- a/admin/src/types.ts
+++ b/admin/src/types.ts
@@ -1,5 +1,6 @@
 export interface MonitorRuntime {
   running: boolean;
+  wake_interval_seconds: number | null;
 }
 
 export interface Member {

--- a/cafleet/migrations/V5__monitor_wake_interval.sql
+++ b/cafleet/migrations/V5__monitor_wake_interval.sql
@@ -1,0 +1,1 @@
+ALTER TABLE monitor_runtime ADD COLUMN wake_interval_seconds INTEGER;

--- a/cafleet/src/broker/fleets.rs
+++ b/cafleet/src/broker/fleets.rs
@@ -325,7 +325,7 @@ mod tests {
         let notifier = FakeNotifier::succeeding();
         common::send(&mut conn, &notifier, director_id, member_id, "hi");
         let now = crate::time::format_utc(chrono::Utc::now());
-        assert!(broker::claim_monitor_runtime(&mut conn, fleet_id, 4242, 5, &now).unwrap());
+        assert!(broker::claim_monitor_runtime(&mut conn, fleet_id, 4242, 5, 600, &now).unwrap());
 
         let result = broker::delete_fleet(&mut conn, fleet_id).unwrap();
         assert_eq!(result["deregistered_count"], 2);

--- a/cafleet/src/broker/monitor.rs
+++ b/cafleet/src/broker/monitor.rs
@@ -50,12 +50,13 @@ struct RuntimeRow {
     started_at: Option<String>,
     last_tick_at: Option<String>,
     tick_seconds: i64,
+    wake_interval_seconds: Option<i64>,
     last_wake_at: Option<String>,
 }
 
 fn runtime_row(conn: &Connection, fleet_id: i64) -> Result<Option<RuntimeRow>, CafleetError> {
     conn.query_row(
-        "SELECT pid, started_at, last_tick_at, tick_seconds, last_wake_at \
+        "SELECT pid, started_at, last_tick_at, tick_seconds, wake_interval_seconds, last_wake_at \
          FROM monitor_runtime WHERE fleet_id=?1",
         [fleet_id],
         |row| {
@@ -64,7 +65,8 @@ fn runtime_row(conn: &Connection, fleet_id: i64) -> Result<Option<RuntimeRow>, C
                 started_at: row.get(1)?,
                 last_tick_at: row.get(2)?,
                 tick_seconds: row.get(3)?,
-                last_wake_at: row.get(4)?,
+                wake_interval_seconds: row.get(4)?,
+                last_wake_at: row.get(5)?,
             })
         },
     )
@@ -137,6 +139,7 @@ pub fn claim_monitor_runtime(
     fleet_id: i64,
     pid: i64,
     tick_seconds: i64,
+    wake_interval: i64,
     when: &str,
 ) -> Result<bool, CafleetError> {
     let now = parse_lenient(when)?;
@@ -158,9 +161,10 @@ pub fn claim_monitor_runtime(
     match existing {
         None => {
             tx.execute(
-                "INSERT INTO monitor_runtime (fleet_id, pid, started_at, last_tick_at, tick_seconds) \
-                 VALUES (?1, ?2, ?3, ?3, ?4)",
-                params![fleet_id, pid, when, tick_seconds],
+                "INSERT INTO monitor_runtime \
+                 (fleet_id, pid, started_at, last_tick_at, tick_seconds, wake_interval_seconds) \
+                 VALUES (?1, ?2, ?3, ?3, ?4, ?5)",
+                params![fleet_id, pid, when, tick_seconds, wake_interval],
             )
             .map_err(db_err)?;
         }
@@ -173,15 +177,32 @@ pub fn claim_monitor_runtime(
             }
             tx.execute(
                 "UPDATE monitor_runtime \
-                 SET pid=?1, started_at=?2, last_tick_at=?2, tick_seconds=?3 \
-                 WHERE fleet_id=?4",
-                params![pid, when, tick_seconds, fleet_id],
+                 SET pid=?1, started_at=?2, last_tick_at=?2, tick_seconds=?3, \
+                     wake_interval_seconds=?4 \
+                 WHERE fleet_id=?5",
+                params![pid, when, tick_seconds, wake_interval, fleet_id],
             )
             .map_err(db_err)?;
         }
     }
     tx.commit().map_err(db_err)?;
     Ok(true)
+}
+
+/// Ownership-free interval update (the WebUI `PATCH /api/monitor` write):
+/// `false` ⇔ no row, i.e. the fleet's monitor has never run.
+pub fn set_monitor_wake_interval(
+    conn: &mut Connection,
+    fleet_id: i64,
+    wake_interval: i64,
+) -> Result<bool, CafleetError> {
+    let changed = conn
+        .execute(
+            "UPDATE monitor_runtime SET wake_interval_seconds=?1 WHERE fleet_id=?2",
+            params![wake_interval, fleet_id],
+        )
+        .map_err(db_err)?;
+    Ok(changed == 1)
 }
 
 /// Ownership-checked heartbeat: a non-owner's tick matches zero rows and
@@ -201,8 +222,9 @@ pub fn heartbeat_monitor_runtime(
     Ok(changed == 1)
 }
 
-/// Ownership-checked clear: nulls the process fields, preserves
-/// `tick_seconds`; a non-owner's clear is a no-op.
+/// Ownership-checked clear: nulls the process fields, preserves the durable
+/// fields (`tick_seconds`, `wake_interval_seconds`, `last_wake_at`); a
+/// non-owner's clear is a no-op.
 pub fn clear_monitor_runtime(
     conn: &mut Connection,
     fleet_id: i64,
@@ -228,6 +250,7 @@ pub fn read_monitor_runtime(
             "started_at": row.started_at,
             "last_tick_at": row.last_tick_at,
             "tick_seconds": row.tick_seconds,
+            "wake_interval_seconds": row.wake_interval_seconds,
             "last_wake_at": row.last_wake_at,
         })
     }))
@@ -249,15 +272,20 @@ pub fn monitor_runtime_payload(
     now: DateTime<Utc>,
 ) -> Result<Value, CafleetError> {
     let row = runtime_row(conn, fleet_id)?;
-    let (running, tick_seconds) = match &row {
-        None => (false, Value::Null),
-        Some(row) => (runtime_live(row, now), json!(row.tick_seconds)),
+    let (running, tick_seconds, wake_interval_seconds) = match &row {
+        None => (false, Value::Null, Value::Null),
+        Some(row) => (
+            runtime_live(row, now),
+            json!(row.tick_seconds),
+            json!(row.wake_interval_seconds),
+        ),
     };
     if !running {
         return Ok(json!({
             "running": false,
             "pid": Value::Null,
             "tick_seconds": tick_seconds,
+            "wake_interval_seconds": wake_interval_seconds,
             "last_tick_at": Value::Null,
             "last_tick_age_seconds": Value::Null,
             "started_at": Value::Null,
@@ -274,6 +302,7 @@ pub fn monitor_runtime_payload(
         "running": true,
         "pid": row.pid,
         "tick_seconds": row.tick_seconds,
+        "wake_interval_seconds": row.wake_interval_seconds,
         "last_tick_at": row.last_tick_at,
         "last_tick_age_seconds": age(row.last_tick_at.as_deref()),
         "started_at": row.started_at,

--- a/cafleet/src/broker/monitor.rs
+++ b/cafleet/src/broker/monitor.rs
@@ -360,7 +360,7 @@ mod tests {
         let mut conn = migrated_conn(&dir);
         let (fleet_id, _) = create_fleet(&mut conn, "alpha");
         let when = format_utc(base_time());
-        broker::claim_monitor_runtime(&mut conn, fleet_id, own_pid(), 5, &when).unwrap();
+        broker::claim_monitor_runtime(&mut conn, fleet_id, own_pid(), 5, 600, &when).unwrap();
 
         broker::record_monitor_wake(&mut conn, fleet_id, &when).unwrap();
         let row = broker::read_monitor_runtime(&conn, fleet_id)
@@ -385,13 +385,13 @@ mod tests {
         let mut conn = migrated_conn(&dir);
         let (fleet_id, _) = create_fleet(&mut conn, "alpha");
         let when = format_utc(base_time());
-        broker::claim_monitor_runtime(&mut conn, fleet_id, own_pid(), 5, &when).unwrap();
+        broker::claim_monitor_runtime(&mut conn, fleet_id, own_pid(), 5, 600, &when).unwrap();
         broker::record_monitor_wake(&mut conn, fleet_id, &when).unwrap();
 
         // stale_after = max(3 * 5, 15) = 15; the 100-second-old heartbeat lets
         // a restarted loop reclaim the slot.
         let later = format_utc(base_time() + Duration::seconds(100));
-        assert!(broker::claim_monitor_runtime(&mut conn, fleet_id, 4242, 5, &later).unwrap());
+        assert!(broker::claim_monitor_runtime(&mut conn, fleet_id, 4242, 5, 600, &later).unwrap());
         let row = broker::read_monitor_runtime(&conn, fleet_id)
             .unwrap()
             .unwrap();
@@ -472,7 +472,9 @@ mod tests {
         let (fleet_id, _) = create_fleet(&mut conn, "alpha");
         let when = format_utc(base_time());
 
-        assert!(broker::claim_monitor_runtime(&mut conn, fleet_id, own_pid(), 5, &when).unwrap());
+        assert!(
+            broker::claim_monitor_runtime(&mut conn, fleet_id, own_pid(), 5, 600, &when).unwrap()
+        );
         let row = broker::read_monitor_runtime(&conn, fleet_id)
             .unwrap()
             .unwrap();
@@ -492,6 +494,7 @@ mod tests {
             fleet_id,
             own_pid() + 1,
             5,
+            600,
             &format_utc(base_time() + Duration::seconds(1)),
         )
         .unwrap();
@@ -509,6 +512,7 @@ mod tests {
                 fleet_id,
                 own_pid(),
                 5,
+                600,
                 &format_utc(base_time())
             )
             .unwrap()
@@ -517,7 +521,7 @@ mod tests {
         // stale_after = max(3 * 5, 15) = 15; a 100-second-old heartbeat is
         // stale even though the owning process (this test) is alive.
         let later = format_utc(base_time() + Duration::seconds(100));
-        assert!(broker::claim_monitor_runtime(&mut conn, fleet_id, 4242, 5, &later).unwrap());
+        assert!(broker::claim_monitor_runtime(&mut conn, fleet_id, 4242, 5, 600, &later).unwrap());
         let row = broker::read_monitor_runtime(&conn, fleet_id)
             .unwrap()
             .unwrap();
@@ -536,6 +540,7 @@ mod tests {
                 fleet_id,
                 DEAD_PID,
                 5,
+                600,
                 &format_utc(base_time())
             )
             .unwrap()
@@ -546,6 +551,7 @@ mod tests {
             fleet_id,
             own_pid(),
             5,
+            600,
             &format_utc(base_time() + Duration::seconds(1)),
         )
         .unwrap();
@@ -558,7 +564,7 @@ mod tests {
         let mut conn = migrated_conn(&dir);
         let (fleet_id, _) = create_fleet(&mut conn, "alpha");
         let when = format_utc(base_time());
-        broker::claim_monitor_runtime(&mut conn, fleet_id, own_pid(), 5, &when).unwrap();
+        broker::claim_monitor_runtime(&mut conn, fleet_id, own_pid(), 5, 600, &when).unwrap();
 
         let tick = format_utc(base_time() + Duration::seconds(2));
         assert!(broker::heartbeat_monitor_runtime(&mut conn, fleet_id, own_pid(), &tick).unwrap());
@@ -582,12 +588,12 @@ mod tests {
     }
 
     #[test]
-    fn clear_is_ownership_checked_and_preserves_tick_seconds_and_last_wake_at() {
+    fn clear_is_ownership_checked_and_preserves_the_durable_fields() {
         let dir = TempDir::new().unwrap();
         let mut conn = migrated_conn(&dir);
         let (fleet_id, _) = create_fleet(&mut conn, "alpha");
         let when = format_utc(base_time());
-        broker::claim_monitor_runtime(&mut conn, fleet_id, own_pid(), 7, &when).unwrap();
+        broker::claim_monitor_runtime(&mut conn, fleet_id, own_pid(), 7, 600, &when).unwrap();
         broker::record_monitor_wake(&mut conn, fleet_id, &when).unwrap();
 
         broker::clear_monitor_runtime(&mut conn, fleet_id, 4242).unwrap();
@@ -605,6 +611,10 @@ mod tests {
         assert_eq!(row["last_tick_at"], Value::Null);
         assert_eq!(row["tick_seconds"], 7);
         assert_eq!(
+            row["wake_interval_seconds"], 600,
+            "the interval survives a stop, like tick_seconds"
+        );
+        assert_eq!(
             row["last_wake_at"], when,
             "the wake cadence survives a stop"
         );
@@ -621,7 +631,8 @@ mod tests {
             "no row"
         );
 
-        broker::claim_monitor_runtime(&mut conn, fleet_id, own_pid(), 5, &format_utc(now)).unwrap();
+        broker::claim_monitor_runtime(&mut conn, fleet_id, own_pid(), 5, 600, &format_utc(now))
+            .unwrap();
         assert!(broker::monitor_is_live(&conn, fleet_id, now + Duration::seconds(2)).unwrap());
         assert!(
             !broker::monitor_is_live(&conn, fleet_id, now + Duration::seconds(100)).unwrap(),
@@ -645,7 +656,7 @@ mod tests {
         assert_eq!(absent["tick_seconds"], Value::Null);
 
         let when = format_utc(now);
-        broker::claim_monitor_runtime(&mut conn, fleet_id, own_pid(), 5, &when).unwrap();
+        broker::claim_monitor_runtime(&mut conn, fleet_id, own_pid(), 5, 600, &when).unwrap();
         let live =
             broker::monitor_runtime_payload(&conn, fleet_id, now + Duration::seconds(2)).unwrap();
         assert_eq!(live["running"], true);
@@ -666,5 +677,112 @@ mod tests {
         assert_eq!(stale["last_tick_at"], Value::Null);
         assert_eq!(stale["last_tick_age_seconds"], Value::Null);
         assert_eq!(stale["started_at"], Value::Null);
+    }
+
+    #[test]
+    fn claim_stamps_the_wake_interval_on_insert_and_reclaim() {
+        let dir = TempDir::new().unwrap();
+        let mut conn = migrated_conn(&dir);
+        let (fleet_id, _) = create_fleet(&mut conn, "alpha");
+        let when = format_utc(base_time());
+        broker::claim_monitor_runtime(&mut conn, fleet_id, own_pid(), 5, 600, &when).unwrap();
+        let row = broker::read_monitor_runtime(&conn, fleet_id)
+            .unwrap()
+            .unwrap();
+        assert_eq!(row["wake_interval_seconds"], 600);
+
+        // stale_after = max(3 * 5, 15) = 15; the 100-second-old heartbeat lets
+        // a restarted loop reclaim the slot and re-stamp the interval.
+        let later = format_utc(base_time() + Duration::seconds(100));
+        assert!(broker::claim_monitor_runtime(&mut conn, fleet_id, 4242, 5, 300, &later).unwrap());
+        let row = broker::read_monitor_runtime(&conn, fleet_id)
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            row["wake_interval_seconds"], 300,
+            "a reclaim re-stamps the startup-resolved interval"
+        );
+    }
+
+    #[test]
+    fn set_monitor_wake_interval_updates_the_row_and_reports_a_never_run_fleet() {
+        let dir = TempDir::new().unwrap();
+        let mut conn = migrated_conn(&dir);
+        let (fleet_id, _) = create_fleet(&mut conn, "alpha");
+        assert!(
+            !broker::set_monitor_wake_interval(&mut conn, fleet_id, 120).unwrap(),
+            "no row ⇔ the fleet's monitor has never run"
+        );
+
+        let when = format_utc(base_time());
+        broker::claim_monitor_runtime(&mut conn, fleet_id, own_pid(), 5, 600, &when).unwrap();
+        assert!(broker::set_monitor_wake_interval(&mut conn, fleet_id, 120).unwrap());
+        let row = broker::read_monitor_runtime(&conn, fleet_id)
+            .unwrap()
+            .unwrap();
+        assert_eq!(row["wake_interval_seconds"], 120);
+
+        broker::clear_monitor_runtime(&mut conn, fleet_id, own_pid()).unwrap();
+        assert!(
+            broker::set_monitor_wake_interval(&mut conn, fleet_id, 0).unwrap(),
+            "the update is ownership-free; a stopped loop's row still updates"
+        );
+        let row = broker::read_monitor_runtime(&conn, fleet_id)
+            .unwrap()
+            .unwrap();
+        assert_eq!(row["wake_interval_seconds"], 0);
+    }
+
+    #[test]
+    fn runtime_payload_carries_the_wake_interval_in_every_shape() {
+        let dir = TempDir::new().unwrap();
+        let mut conn = migrated_conn(&dir);
+        let (fleet_id, _) = create_fleet(&mut conn, "alpha");
+        let now = base_time();
+
+        let absent = broker::monitor_runtime_payload(&conn, fleet_id, now).unwrap();
+        assert_eq!(
+            absent["wake_interval_seconds"],
+            Value::Null,
+            "no row has ever existed"
+        );
+
+        let when = format_utc(now);
+        broker::claim_monitor_runtime(&mut conn, fleet_id, own_pid(), 5, 600, &when).unwrap();
+        let live =
+            broker::monitor_runtime_payload(&conn, fleet_id, now + Duration::seconds(2)).unwrap();
+        assert_eq!(live["wake_interval_seconds"], 600);
+
+        let stale =
+            broker::monitor_runtime_payload(&conn, fleet_id, now + Duration::seconds(100)).unwrap();
+        assert_eq!(
+            stale["wake_interval_seconds"], 600,
+            "preserved from the stale row, like tick_seconds"
+        );
+
+        for payload in [&live, &stale] {
+            let keys: Vec<&str> = payload
+                .as_object()
+                .unwrap()
+                .keys()
+                .map(String::as_str)
+                .collect();
+            let tick_pos = keys.iter().position(|k| *k == "tick_seconds").unwrap();
+            assert_eq!(
+                keys.get(tick_pos + 1),
+                Some(&"wake_interval_seconds"),
+                "the key sits immediately after tick_seconds"
+            );
+        }
+
+        // A row that predates the migration and was never re-claimed since.
+        conn.execute(
+            "UPDATE monitor_runtime SET wake_interval_seconds=NULL WHERE fleet_id=?1",
+            [fleet_id],
+        )
+        .unwrap();
+        let premigration =
+            broker::monitor_runtime_payload(&conn, fleet_id, now + Duration::seconds(100)).unwrap();
+        assert_eq!(premigration["wake_interval_seconds"], Value::Null);
     }
 }

--- a/cafleet/src/broker/test_support.rs
+++ b/cafleet/src/broker/test_support.rs
@@ -51,7 +51,9 @@
 //! record_monitor_wake(conn: &mut Connection, fleet_id: i64, when: &str) -> Result<()>
 //! list_fleet_wake_targets(conn: &Connection, fleet_id: i64) -> Result<Vec<Value>>
 //! claim_monitor_runtime(conn: &mut Connection, fleet_id: i64, pid: i64,
-//!     tick_seconds: i64, when: &str) -> Result<bool>
+//!     tick_seconds: i64, wake_interval: i64, when: &str) -> Result<bool>
+//! set_monitor_wake_interval(conn: &mut Connection, fleet_id: i64,
+//!     wake_interval: i64) -> Result<bool>  // false ⇔ no row
 //! heartbeat_monitor_runtime(conn: &mut Connection, fleet_id: i64, pid: i64,
 //!     when: &str) -> Result<bool>
 //! clear_monitor_runtime(conn: &mut Connection, fleet_id: i64, pid: i64) -> Result<()>

--- a/cafleet/src/cli/monitor.rs
+++ b/cafleet/src/cli/monitor.rs
@@ -28,8 +28,8 @@ pub struct MonitorArgs {
     tick: i64,
     /// Director wake interval in seconds (0 disables the wake) [default:
     /// CAFLEET_MONITOR_WAKE_INTERVAL, 600].
-    #[arg(long)]
-    interval: Option<u64>,
+    #[arg(long, value_parser = clap::value_parser!(i64).range(0..))]
+    interval: Option<i64>,
 }
 
 #[derive(Subcommand)]
@@ -85,7 +85,7 @@ fn run_loop(
     settings: &Settings,
     fleet_id: i64,
     tick: i64,
-    interval: Option<u64>,
+    interval: Option<i64>,
 ) -> Result<(), CafleetError> {
     let mut conn = connect(settings)?;
     require_live_fleet(&conn, fleet_id)?;

--- a/cafleet/src/config.rs
+++ b/cafleet/src/config.rs
@@ -164,11 +164,42 @@ mod tests {
 
     #[test]
     fn non_integer_monitor_wake_interval_fails_loudly() {
-        let result = Settings::from_lookup(|name| match name {
+        let err = Settings::from_lookup(|name| match name {
             "CAFLEET_MONITOR_WAKE_INTERVAL" => Some("10m".to_string()),
             _ => None,
-        });
-        assert!(result.is_err());
+        })
+        .unwrap_err();
+        assert_eq!(
+            err.message(),
+            "CAFLEET_MONITOR_WAKE_INTERVAL must be a non-negative integer (got '10m')"
+        );
+    }
+
+    #[test]
+    fn negative_monitor_wake_interval_fails_loudly() {
+        let err = Settings::from_lookup(|name| match name {
+            "CAFLEET_MONITOR_WAKE_INTERVAL" => Some("-1".to_string()),
+            _ => None,
+        })
+        .unwrap_err();
+        assert_eq!(
+            err.message(),
+            "CAFLEET_MONITOR_WAKE_INTERVAL must be a non-negative integer (got '-1')"
+        );
+    }
+
+    #[test]
+    fn above_i64_max_monitor_wake_interval_fails_loudly() {
+        let err = Settings::from_lookup(|name| match name {
+            "CAFLEET_MONITOR_WAKE_INTERVAL" => Some("9223372036854775808".to_string()),
+            _ => None,
+        })
+        .unwrap_err();
+        assert_eq!(
+            err.message(),
+            "CAFLEET_MONITOR_WAKE_INTERVAL must be a non-negative integer \
+             (got '9223372036854775808')"
+        );
     }
 
     #[test]

--- a/cafleet/src/config.rs
+++ b/cafleet/src/config.rs
@@ -7,7 +7,7 @@ pub struct Settings {
     pub broker_port: u16,
     pub max_text_len: usize,
     pub multiplexer: Option<String>,
-    pub monitor_wake_interval: u64,
+    pub monitor_wake_interval: i64,
 }
 
 impl Settings {
@@ -37,11 +37,10 @@ impl Settings {
                 "a non-negative integer",
             )?,
             multiplexer: lookup("CAFLEET_MULTIPLEXER"),
-            monitor_wake_interval: parse_numeric(
+            monitor_wake_interval: parse_non_negative(
                 &lookup,
                 "CAFLEET_MONITOR_WAKE_INTERVAL",
                 600,
-                "a non-negative integer",
             )?,
         })
     }
@@ -62,6 +61,27 @@ fn parse_numeric<T: std::str::FromStr>(
         Some(raw) => raw
             .parse()
             .map_err(|_| CafleetError::App(format!("{name} must be {expectation} (got '{raw}')"))),
+    }
+}
+
+/// An `i64` field constrained to `0..=i64::MAX` (SPEC §7.1): a negative value
+/// parses but is rejected with the same error string as a non-integer.
+fn parse_non_negative(
+    lookup: &impl Fn(&str) -> Option<String>,
+    name: &str,
+    default: i64,
+) -> Result<i64, CafleetError> {
+    match lookup(name) {
+        None => Ok(default),
+        Some(raw) => raw
+            .parse::<i64>()
+            .ok()
+            .filter(|value| *value >= 0)
+            .ok_or_else(|| {
+                CafleetError::App(format!(
+                    "{name} must be a non-negative integer (got '{raw}')"
+                ))
+            }),
     }
 }
 

--- a/cafleet/src/db/mod.rs
+++ b/cafleet/src/db/mod.rs
@@ -139,11 +139,11 @@ mod tests {
     }
 
     #[test]
-    fn migrate_reaches_head_version_4_and_is_idempotent() {
+    fn migrate_reaches_head_version_5_and_is_idempotent() {
         let dir = TempDir::new().unwrap();
         let mut conn = connect(&temp_db_url(&dir)).unwrap();
-        assert_eq!(migrate_to_head(&mut conn).unwrap(), 4);
-        assert_eq!(migrate_to_head(&mut conn).unwrap(), 4);
+        assert_eq!(migrate_to_head(&mut conn).unwrap(), 5);
+        assert_eq!(migrate_to_head(&mut conn).unwrap(), 5);
     }
 
     #[test]
@@ -244,6 +244,10 @@ mod tests {
         assert_eq!(column_info(&conn, "members", "deregistered_at").0, 0);
         assert_eq!(column_info(&conn, "member_placements", "mux_pane_id").0, 0);
         assert_eq!(column_info(&conn, "monitor_runtime", "last_wake_at").0, 0);
+        assert_eq!(
+            column_info(&conn, "monitor_runtime", "wake_interval_seconds").0,
+            0
+        );
     }
 
     #[test]
@@ -329,14 +333,14 @@ mod tests {
             .unwrap()
             .map(Result::unwrap)
             .collect();
-        assert_eq!(versions, vec![1, 2, 3, 4]);
+        assert_eq!(versions, vec![1, 2, 3, 4, 5]);
     }
 
     // The chain guard reads the refinery-embedded listing, not the filesystem:
     // `migration_chain()` returns the `(version, name)` pairs of the embedded
     // runner's migrations, sorted ascending.
     #[test]
-    fn migration_chain_is_contiguous_from_1_with_exactly_one_baseline_and_head_4() {
+    fn migration_chain_is_contiguous_from_1_with_exactly_one_baseline_and_head_5() {
         let chain = migration_chain();
         let versions: Vec<u32> = chain.iter().map(|(version, _)| *version).collect();
         let contiguous: Vec<u32> = (1..=versions.len() as u32).collect();
@@ -352,6 +356,6 @@ mod tests {
             chain.iter().all(|(_, name)| !name.is_empty()),
             "every migration carries a slug"
         );
-        assert_eq!(versions.last(), Some(&4), "expected head version is 4");
+        assert_eq!(versions.last(), Some(&5), "expected head version is 5");
     }
 }

--- a/cafleet/src/monitor/mod.rs
+++ b/cafleet/src/monitor/mod.rs
@@ -24,16 +24,20 @@
 //! // wins as the baseline (unparsable → immediately due); a NULL last_wake_at
 //! // falls back to started_at (NULL or unparsable → immediately due).
 //! pub fn wake_due(last_wake_at: Option<&str>, started_at: Option<&str>,
-//!     wake_interval: u64, now: DateTime<Utc>) -> bool;
+//!     wake_interval: i64, now: DateTime<Utc>) -> bool;
 //!
+//! // No interval parameter: each pass re-reads wake_interval_seconds from
+//! // the fleet's runtime row, so an external update changes the cadence
+//! // within one tick.
 //! pub fn monitor_tick(conn: &mut Connection, mux: &dyn MonitorMux,
 //!     out: &mut dyn std::io::Write, fleet_id: i64, pid: i64,
-//!     wake_interval: u64, now: DateTime<Utc>)
-//!     -> Result<TickResult, CafleetError>;
+//!     now: DateTime<Utc>) -> Result<TickResult, CafleetError>;
 //!
+//! // wake_interval is used only to stamp the claim; the ticks read the
+//! // stored value.
 //! pub fn run_monitor_loop(conn: &mut Connection, mux: &dyn MonitorMux,
 //!     out: &mut dyn std::io::Write, fleet_id: i64, tick_seconds: i64,
-//!     wake_interval: u64) -> Result<(), CafleetError>;
+//!     wake_interval: i64) -> Result<(), CafleetError>;
 //! ```
 
 use std::collections::BTreeSet;
@@ -97,7 +101,7 @@ fn mux_err(error: MultiplexerError) -> CafleetError {
 pub fn wake_due(
     last_wake_at: Option<&str>,
     started_at: Option<&str>,
-    wake_interval: u64,
+    wake_interval: i64,
     now: DateTime<Utc>,
 ) -> bool {
     let Some(baseline) = last_wake_at.or(started_at) else {
@@ -106,19 +110,19 @@ pub fn wake_due(
     let Ok(parsed) = parse_lenient(baseline) else {
         return true;
     };
-    (now - parsed).num_seconds() >= wake_interval as i64
+    (now - parsed).num_seconds() >= wake_interval
 }
 
 /// One scan pass (SPEC §6.6): ownership-checked heartbeat → fleet liveness →
-/// wake-interval gate → Director-pane resolution → one fleet-level wake →
-/// the `woke`-gated ledger write and heartbeat echo.
+/// runtime-row read (the per-tick interval re-read) → wake-interval gate →
+/// Director-pane resolution → one fleet-level wake → the `woke`-gated ledger
+/// write and heartbeat echo.
 pub fn monitor_tick(
     conn: &mut Connection,
     mux: &dyn MonitorMux,
     out: &mut dyn Write,
     fleet_id: i64,
     pid: i64,
-    wake_interval: u64,
     now: DateTime<Utc>,
 ) -> Result<TickResult, CafleetError> {
     let iso = format_utc(now);
@@ -135,11 +139,14 @@ pub fn monitor_tick(
     }
     let fleet = fleet.expect("the live fleet row exists");
 
+    let runtime = broker::read_monitor_runtime(conn, fleet_id)?
+        .expect("the heartbeat just matched this fleet's runtime row");
+    let wake_interval = runtime["wake_interval_seconds"]
+        .as_i64()
+        .expect("the owning loop stamped the interval at claim");
     if wake_interval == 0 {
         return Ok(TickResult::Continue);
     }
-    let runtime = broker::read_monitor_runtime(conn, fleet_id)?
-        .expect("the heartbeat just matched this fleet's runtime row");
     if !wake_due(
         runtime["last_wake_at"].as_str(),
         runtime["started_at"].as_str(),
@@ -205,13 +212,11 @@ pub fn run_monitor_loop(
     out: &mut dyn Write,
     fleet_id: i64,
     tick_seconds: i64,
-    wake_interval: u64,
+    wake_interval: i64,
 ) -> Result<(), CafleetError> {
     let pid = i64::from(std::process::id());
     let now = format_utc(now_utc());
-    let stamped_interval = i64::try_from(wake_interval)
-        .expect("the CLI/config boundary keeps the interval within i64");
-    if !broker::claim_monitor_runtime(conn, fleet_id, pid, tick_seconds, stamped_interval, &now)? {
+    if !broker::claim_monitor_runtime(conn, fleet_id, pid, tick_seconds, wake_interval, &now)? {
         return Err(CafleetError::App(format!(
             "monitor already running for fleet {fleet_id}"
         )));
@@ -234,7 +239,7 @@ pub fn run_monitor_loop(
         if stop.load(Ordering::Relaxed) {
             break Ok(());
         }
-        match monitor_tick(conn, mux, out, fleet_id, pid, wake_interval, now_utc()) {
+        match monitor_tick(conn, mux, out, fleet_id, pid, now_utc()) {
             Ok(TickResult::Continue) => {}
             Ok(TickResult::Stop) => break Ok(()),
             Err(error) => break Err(error),

--- a/cafleet/src/monitor/mod.rs
+++ b/cafleet/src/monitor/mod.rs
@@ -322,7 +322,9 @@ mod tests {
     }
 
     fn claim(conn: &mut rusqlite::Connection, fleet_id: i64, pid: i64, now: DateTime<Utc>) {
-        assert!(broker::claim_monitor_runtime(conn, fleet_id, pid, 5, &format_utc(now)).unwrap());
+        assert!(
+            broker::claim_monitor_runtime(conn, fleet_id, pid, 5, 600, &format_utc(now)).unwrap()
+        );
     }
 
     fn tick(

--- a/cafleet/src/monitor/mod.rs
+++ b/cafleet/src/monitor/mod.rs
@@ -209,7 +209,9 @@ pub fn run_monitor_loop(
 ) -> Result<(), CafleetError> {
     let pid = i64::from(std::process::id());
     let now = format_utc(now_utc());
-    if !broker::claim_monitor_runtime(conn, fleet_id, pid, tick_seconds, &now)? {
+    let stamped_interval = i64::try_from(wake_interval)
+        .expect("the CLI/config boundary keeps the interval within i64");
+    if !broker::claim_monitor_runtime(conn, fleet_id, pid, tick_seconds, stamped_interval, &now)? {
         return Err(CafleetError::App(format!(
             "monitor already running for fleet {fleet_id}"
         )));

--- a/cafleet/src/monitor/mod.rs
+++ b/cafleet/src/monitor/mod.rs
@@ -638,7 +638,11 @@ mod tests {
                 own_pid(),
                 now + Duration::seconds(900),
             );
-            assert_eq!(mux.wake_count(), 1, "300 < 600 since the baseline → not due");
+            assert_eq!(
+                mux.wake_count(),
+                1,
+                "300 < 600 since the baseline → not due"
+            );
 
             set_interval(&mut conn, fleet_id, 200);
             let (_, _) = tick(
@@ -677,7 +681,11 @@ mod tests {
             let at = now + Duration::seconds(800);
             let (result, echo) = tick(&mut conn, &mux, fleet_id, own_pid(), at);
             assert!(matches!(result, TickResult::Continue));
-            assert_eq!(mux.wake_count(), 1, "0 disables the wake from the next tick");
+            assert_eq!(
+                mux.wake_count(),
+                1,
+                "0 disables the wake from the next tick"
+            );
             assert!(echo.is_empty());
             let row = broker::read_monitor_runtime(&conn, fleet_id)
                 .unwrap()

--- a/cafleet/src/monitor/mod.rs
+++ b/cafleet/src/monitor/mod.rs
@@ -324,9 +324,24 @@ mod tests {
     }
 
     fn claim(conn: &mut rusqlite::Connection, fleet_id: i64, pid: i64, now: DateTime<Utc>) {
+        claim_with_interval(conn, fleet_id, pid, 600, now);
+    }
+
+    fn claim_with_interval(
+        conn: &mut rusqlite::Connection,
+        fleet_id: i64,
+        pid: i64,
+        wake_interval: i64,
+        now: DateTime<Utc>,
+    ) {
         assert!(
-            broker::claim_monitor_runtime(conn, fleet_id, pid, 5, 600, &format_utc(now)).unwrap()
+            broker::claim_monitor_runtime(conn, fleet_id, pid, 5, wake_interval, &format_utc(now))
+                .unwrap()
         );
+    }
+
+    fn set_interval(conn: &mut rusqlite::Connection, fleet_id: i64, wake_interval: i64) {
+        assert!(broker::set_monitor_wake_interval(conn, fleet_id, wake_interval).unwrap());
     }
 
     fn tick(
@@ -334,11 +349,10 @@ mod tests {
         mux: &FakeMux,
         fleet_id: i64,
         pid: i64,
-        wake_interval: u64,
         now: DateTime<Utc>,
     ) -> (TickResult, String) {
         let mut out = Vec::new();
-        let result = monitor_tick(conn, mux, &mut out, fleet_id, pid, wake_interval, now).unwrap();
+        let result = monitor_tick(conn, mux, &mut out, fleet_id, pid, now).unwrap();
         (result, String::from_utf8(out).unwrap())
     }
 
@@ -441,11 +455,11 @@ mod tests {
             let mux = FakeMux::with_live_panes(&["%0", "%2", "%4"]);
             let now = base_now();
 
-            let (result, _) = tick(&mut conn, &mux, fleet_id, own_pid(), 600, now);
+            let (result, _) = tick(&mut conn, &mux, fleet_id, own_pid(), now);
             assert!(matches!(result, TickResult::Stop), "no claimed slot → Stop");
 
             claim(&mut conn, fleet_id, own_pid(), now);
-            let (result, _) = tick(&mut conn, &mux, fleet_id, own_pid() + 1, 600, now);
+            let (result, _) = tick(&mut conn, &mux, fleet_id, own_pid() + 1, now);
             assert!(matches!(result, TickResult::Stop), "displaced pid → Stop");
             assert_eq!(mux.wake_count(), 0, "a stopping tick never wakes");
         }
@@ -465,7 +479,7 @@ mod tests {
             .unwrap();
 
             let mux = FakeMux::with_live_panes(&["%0", "%2", "%4"]);
-            let (result, _) = tick(&mut conn, &mux, fleet_id, own_pid(), 600, now);
+            let (result, _) = tick(&mut conn, &mux, fleet_id, own_pid(), now);
             assert!(matches!(result, TickResult::Stop));
         }
 
@@ -479,7 +493,7 @@ mod tests {
             let mux = FakeMux::with_live_panes(&["%0", "%2", "%4"]);
 
             let due_at = now + Duration::seconds(600);
-            let (result, echo) = tick(&mut conn, &mux, fleet_id, own_pid(), 600, due_at);
+            let (result, echo) = tick(&mut conn, &mux, fleet_id, own_pid(), due_at);
             assert!(matches!(result, TickResult::Continue));
 
             let wakes = mux.wakes.borrow();
@@ -513,7 +527,7 @@ mod tests {
             claim(&mut conn, fleet_id, own_pid(), now);
             let mux = FakeMux::with_live_panes(&["%0", "%2", "%4"]);
 
-            let (_, echo) = tick(&mut conn, &mux, fleet_id, own_pid(), 600, now);
+            let (_, echo) = tick(&mut conn, &mux, fleet_id, own_pid(), now);
             assert_eq!(
                 mux.wake_count(),
                 0,
@@ -526,7 +540,6 @@ mod tests {
                 &mux,
                 fleet_id,
                 own_pid(),
-                600,
                 now + Duration::seconds(599),
             );
             assert_eq!(mux.wake_count(), 0, "599 < 600 since started_at → not due");
@@ -537,7 +550,6 @@ mod tests {
                 &mux,
                 fleet_id,
                 own_pid(),
-                600,
                 now + Duration::seconds(600),
             );
             assert_eq!(
@@ -551,7 +563,6 @@ mod tests {
                 &mux,
                 fleet_id,
                 own_pid(),
-                600,
                 now + Duration::seconds(1199),
             );
             assert_eq!(mux.wake_count(), 1, "599 since the first wake → not due");
@@ -562,7 +573,6 @@ mod tests {
                 &mux,
                 fleet_id,
                 own_pid(),
-                600,
                 now + Duration::seconds(1200),
             );
             assert_eq!(
@@ -578,11 +588,11 @@ mod tests {
             let mut conn = migrated_conn(&dir);
             let (fleet_id, _, _, _) = wake_fleet(&mut conn);
             let now = base_now();
-            claim(&mut conn, fleet_id, own_pid(), now);
+            claim_with_interval(&mut conn, fleet_id, own_pid(), 0, now);
             let mux = FakeMux::with_live_panes(&["%0", "%2", "%4"]);
 
             let later = now + Duration::seconds(2);
-            let (result, echo) = tick(&mut conn, &mux, fleet_id, own_pid(), 0, later);
+            let (result, echo) = tick(&mut conn, &mux, fleet_id, own_pid(), later);
             assert!(matches!(result, TickResult::Continue));
             assert_eq!(mux.wake_count(), 0, "interval 0 disables the wake");
             assert!(echo.is_empty());
@@ -595,6 +605,164 @@ mod tests {
                 row["last_tick_at"],
                 format_utc(later),
                 "the loop keeps claiming the slot and heartbeating"
+            );
+        }
+
+        #[test]
+        fn a_mid_run_shrink_below_the_elapsed_time_is_due_on_the_next_tick() {
+            let dir = TempDir::new().unwrap();
+            let mut conn = migrated_conn(&dir);
+            let (fleet_id, _, _, _) = wake_fleet(&mut conn);
+            let now = base_now();
+            claim(&mut conn, fleet_id, own_pid(), now);
+            let mux = FakeMux::with_live_panes(&["%0", "%2", "%4"]);
+
+            let (_, _) = tick(
+                &mut conn,
+                &mux,
+                fleet_id,
+                own_pid(),
+                now + Duration::seconds(600),
+            );
+            assert_eq!(mux.wake_count(), 1, "the first wake sets the baseline");
+
+            let (_, _) = tick(
+                &mut conn,
+                &mux,
+                fleet_id,
+                own_pid(),
+                now + Duration::seconds(900),
+            );
+            assert_eq!(mux.wake_count(), 1, "300 < 600 since the baseline → not due");
+
+            set_interval(&mut conn, fleet_id, 200);
+            let (_, _) = tick(
+                &mut conn,
+                &mux,
+                fleet_id,
+                own_pid(),
+                now + Duration::seconds(905),
+            );
+            assert_eq!(
+                mux.wake_count(),
+                2,
+                "305 >= the shrunken 200 → due on the very next tick"
+            );
+        }
+
+        #[test]
+        fn a_mid_run_zero_disables_and_a_raise_re_enables_against_the_baseline() {
+            let dir = TempDir::new().unwrap();
+            let mut conn = migrated_conn(&dir);
+            let (fleet_id, _, _, _) = wake_fleet(&mut conn);
+            let now = base_now();
+            claim(&mut conn, fleet_id, own_pid(), now);
+            let mux = FakeMux::with_live_panes(&["%0", "%2", "%4"]);
+
+            let (_, _) = tick(
+                &mut conn,
+                &mux,
+                fleet_id,
+                own_pid(),
+                now + Duration::seconds(600),
+            );
+            assert_eq!(mux.wake_count(), 1, "the first wake sets the baseline");
+
+            set_interval(&mut conn, fleet_id, 0);
+            let at = now + Duration::seconds(800);
+            let (result, echo) = tick(&mut conn, &mux, fleet_id, own_pid(), at);
+            assert!(matches!(result, TickResult::Continue));
+            assert_eq!(mux.wake_count(), 1, "0 disables the wake from the next tick");
+            assert!(echo.is_empty());
+            let row = broker::read_monitor_runtime(&conn, fleet_id)
+                .unwrap()
+                .unwrap();
+            assert_eq!(
+                row["last_tick_at"],
+                format_utc(at),
+                "the loop keeps heartbeating while disabled"
+            );
+
+            set_interval(&mut conn, fleet_id, 300);
+            let (_, _) = tick(
+                &mut conn,
+                &mux,
+                fleet_id,
+                own_pid(),
+                now + Duration::seconds(899),
+            );
+            assert_eq!(
+                mux.wake_count(),
+                1,
+                "299 < 300 since the existing baseline → not yet due"
+            );
+
+            let (_, _) = tick(
+                &mut conn,
+                &mux,
+                fleet_id,
+                own_pid(),
+                now + Duration::seconds(900),
+            );
+            assert_eq!(
+                mux.wake_count(),
+                2,
+                "the raise re-enables, gated against the existing baseline"
+            );
+        }
+
+        #[test]
+        fn an_edit_before_the_first_wake_moves_the_first_wake_boundary() {
+            let dir = TempDir::new().unwrap();
+            let mut conn = migrated_conn(&dir);
+            let (fleet_id, _, _, _) = wake_fleet(&mut conn);
+            let now = base_now();
+            claim(&mut conn, fleet_id, own_pid(), now);
+            let mux = FakeMux::with_live_panes(&["%0", "%2", "%4"]);
+
+            let (_, _) = tick(
+                &mut conn,
+                &mux,
+                fleet_id,
+                own_pid(),
+                now + Duration::seconds(100),
+            );
+            assert_eq!(mux.wake_count(), 0, "not due under the startup 600");
+
+            set_interval(&mut conn, fleet_id, 900);
+            let (_, _) = tick(
+                &mut conn,
+                &mux,
+                fleet_id,
+                own_pid(),
+                now + Duration::seconds(600),
+            );
+            assert_eq!(
+                mux.wake_count(),
+                0,
+                "the old started_at + 600 boundary no longer applies"
+            );
+
+            let (_, _) = tick(
+                &mut conn,
+                &mux,
+                fleet_id,
+                own_pid(),
+                now + Duration::seconds(899),
+            );
+            assert_eq!(mux.wake_count(), 0, "899 < 900 since started_at → not due");
+
+            let (_, _) = tick(
+                &mut conn,
+                &mux,
+                fleet_id,
+                own_pid(),
+                now + Duration::seconds(900),
+            );
+            assert_eq!(
+                mux.wake_count(),
+                1,
+                "the first wake fires at started_at + the new interval"
             );
         }
 
@@ -612,7 +780,6 @@ mod tests {
                 &mux,
                 fleet_id,
                 own_pid(),
-                600,
                 now + Duration::seconds(600),
             );
             assert!(matches!(result, TickResult::Continue));
@@ -640,7 +807,6 @@ mod tests {
                 &mux,
                 fleet_id,
                 own_pid(),
-                600,
                 now + Duration::seconds(600),
             );
             assert!(matches!(result, TickResult::Continue));
@@ -654,7 +820,6 @@ mod tests {
                 &mux,
                 fleet_id,
                 own_pid(),
-                600,
                 now + Duration::seconds(605),
             );
             assert_eq!(mux.wake_count(), 2, "the unstamped fleet stays due");
@@ -675,7 +840,7 @@ mod tests {
             let mux = FakeMux::with_live_panes(&["%0"]);
 
             let due_at = now + Duration::seconds(600);
-            let (result, echo) = tick(&mut conn, &mux, fleet_id, own_pid(), 600, due_at);
+            let (result, echo) = tick(&mut conn, &mux, fleet_id, own_pid(), due_at);
             assert!(matches!(result, TickResult::Continue));
 
             let wakes = mux.wakes.borrow();

--- a/cafleet/src/webui/mod.rs
+++ b/cafleet/src/webui/mod.rs
@@ -241,7 +241,10 @@ async fn patch_monitor(State(state): State<AppState>, headers: HeaderMap, body: 
                 StatusCode::OK,
                 &json!({"wake_interval_seconds": wake_interval}),
             ),
-            Ok(false) => detail(StatusCode::NOT_FOUND, "monitor has never run for this fleet"),
+            Ok(false) => detail(
+                StatusCode::NOT_FOUND,
+                "monitor has never run for this fleet",
+            ),
             Err(error) => broker_500(error),
         }
     })

--- a/cafleet/src/webui/mod.rs
+++ b/cafleet/src/webui/mod.rs
@@ -1,4 +1,4 @@
-//! The admin WebUI HTTP app (SPEC §6.8): the 9 `/api` routes behind the
+//! The admin WebUI HTTP app (SPEC §6.8): the 8 `/api` routes behind the
 //! `X-Fleet-Id` header dependency, the wire renames (`status_state`→`status`,
 //! `text`→`body`), the `{"detail": <string>}` error shape (422 included), and
 //! the SPA fallback over the dist embedded at build time. Handlers bridge to
@@ -38,7 +38,7 @@ pub fn create_app(database_url: &str) -> Result<Router, CafleetError> {
     let api = Router::new()
         .route("/fleets", get(list_fleets))
         .route("/members", get(roster))
-        .route("/monitor", get(monitor))
+        .route("/monitor", get(monitor).patch(patch_monitor))
         .route("/members/{member_id}/inbox", get(inbox))
         .route("/members/{member_id}/sent", get(sent))
         .route("/timeline", get(timeline))
@@ -204,6 +204,46 @@ async fn monitor(State(state): State<AppState>, headers: HeaderMap) -> Response 
         };
         payload["members"] = Value::Array(members);
         json_response(StatusCode::OK, &payload)
+    })
+    .await
+}
+
+/// `wake_interval_seconds` must be a JSON integer in `0..=i64::MAX` — floats,
+/// stringified integers, negatives, and numbers above `i64::MAX` are
+/// rejected, not coerced (SPEC §6.8).
+fn parse_patch_monitor_body(body: &Bytes) -> Result<i64, Box<Response>> {
+    let invalid = |message: &str| Box::new(detail(StatusCode::UNPROCESSABLE_ENTITY, message));
+    let payload: Value =
+        serde_json::from_slice(body).map_err(|e| invalid(&format!("invalid JSON body: {e}")))?;
+    payload["wake_interval_seconds"]
+        .as_i64()
+        .filter(|value| *value >= 0)
+        .ok_or_else(|| invalid("wake_interval_seconds must be a non-negative integer"))
+}
+
+/// Body validation precedes the fleet check, matching `POST /api/messages/send`;
+/// the row update reports a never-run fleet as its own 404.
+async fn patch_monitor(State(state): State<AppState>, headers: HeaderMap, body: Bytes) -> Response {
+    let fleet_id = match fleet_header(&headers) {
+        Ok(fleet_id) => fleet_id,
+        Err(response) => return *response,
+    };
+    let wake_interval = match parse_patch_monitor_body(&body) {
+        Ok(value) => value,
+        Err(response) => return *response,
+    };
+    run_blocking(state, move |conn| {
+        if let Err(response) = require_fleet(conn, fleet_id) {
+            return *response;
+        }
+        match broker::set_monitor_wake_interval(conn, fleet_id, wake_interval) {
+            Ok(true) => json_response(
+                StatusCode::OK,
+                &json!({"wake_interval_seconds": wake_interval}),
+            ),
+            Ok(false) => detail(StatusCode::NOT_FOUND, "monitor has never run for this fleet"),
+            Err(error) => broker_500(error),
+        }
     })
     .await
 }

--- a/cafleet/tests/cli_setup_doctor.rs
+++ b/cafleet/tests/cli_setup_doctor.rs
@@ -14,7 +14,7 @@ fn schema_only_setup_migrates_and_reports_the_head() {
     assert_eq!(code(&output), 0, "stderr: {}", stderr(&output));
     let out = stdout(&output);
     assert!(
-        out.contains("applied migrations to head (4)."),
+        out.contains("applied migrations to head (5)."),
         "fresh DB reports the created-and-migrated line, got: {out}"
     );
     assert!(
@@ -27,7 +27,7 @@ fn schema_only_setup_migrates_and_reports_the_head() {
     ]);
     assert_eq!(code(&again), 0);
     assert!(
-        stdout(&again).contains("Already at head (4); nothing to do."),
+        stdout(&again).contains("Already at head (5); nothing to do."),
         "got: {}",
         stdout(&again)
     );

--- a/cafleet/tests/webui_routes.rs
+++ b/cafleet/tests/webui_routes.rs
@@ -464,8 +464,15 @@ async fn the_monitor_endpoint_reports_and_masks_the_runtime() {
 
     let now = cafleet::time::now_utc();
     let pid = i64::from(std::process::id());
-    broker::claim_monitor_runtime(&mut conn, fleet_id, pid, 5, &cafleet::time::format_utc(now))
-        .unwrap();
+    broker::claim_monitor_runtime(
+        &mut conn,
+        fleet_id,
+        pid,
+        5,
+        600,
+        &cafleet::time::format_utc(now),
+    )
+    .unwrap();
     broker::record_monitor_wake(&mut conn, fleet_id, &cafleet::time::format_utc(now)).unwrap();
     let (status, body) = call(app.clone(), "GET", "/api/monitor", Some("1"), None).await;
     assert_eq!(status, StatusCode::OK);

--- a/cafleet/tests/webui_routes.rs
+++ b/cafleet/tests/webui_routes.rs
@@ -529,7 +529,14 @@ async fn patch_monitor_updates_the_wake_interval_with_the_pinned_error_contract(
     let app = app(&url);
     let valid = json!({"wake_interval_seconds": 300});
 
-    let (status, body) = call(app.clone(), "PATCH", "/api/monitor", None, Some(valid.clone())).await;
+    let (status, body) = call(
+        app.clone(),
+        "PATCH",
+        "/api/monitor",
+        None,
+        Some(valid.clone()),
+    )
+    .await;
     assert_eq!(status, StatusCode::BAD_REQUEST);
     assert_eq!(body, r#"{"detail":"X-Fleet-Id header required"}"#);
 
@@ -572,14 +579,11 @@ async fn patch_monitor_updates_the_wake_interval_with_the_pinned_error_contract(
     let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
         .await
         .unwrap();
-    let detail = parsed(&String::from_utf8(bytes.to_vec()).unwrap())["detail"]
+    let detail = parsed(core::str::from_utf8(&bytes).unwrap())["detail"]
         .as_str()
         .unwrap()
         .to_string();
-    assert!(
-        detail.starts_with("invalid JSON body: "),
-        "got: {detail}"
-    );
+    assert!(detail.starts_with("invalid JSON body: "), "got: {detail}");
 
     // Rejected, not coerced: missing, float, stringified, negative, and
     // above-i64::MAX — all 422 before the unknown-fleet 404.
@@ -600,8 +604,7 @@ async fn patch_monitor_updates_the_wake_interval_with_the_pinned_error_contract(
         .await;
         assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY, "for {bad}");
         assert_eq!(
-            body,
-            r#"{"detail":"wake_interval_seconds must be a non-negative integer"}"#,
+            body, r#"{"detail":"wake_interval_seconds must be a non-negative integer"}"#,
             "for {bad}"
         );
     }
@@ -653,7 +656,8 @@ async fn patch_monitor_updates_the_wake_interval_with_the_pinned_error_contract(
     let (status, body) = call(app.clone(), "GET", "/api/monitor", Some("1"), None).await;
     assert_eq!(status, StatusCode::OK);
     assert_eq!(
-        parsed(&body)["wake_interval_seconds"], 300,
+        parsed(&body)["wake_interval_seconds"],
+        300,
         "GET reflects the PATCHed value"
     );
 
@@ -666,7 +670,10 @@ async fn patch_monitor_updates_the_wake_interval_with_the_pinned_error_contract(
     )
     .await;
     assert_eq!(status, StatusCode::OK);
-    assert_eq!(body, r#"{"wake_interval_seconds":0}"#, "0 disables the wake");
+    assert_eq!(
+        body, r#"{"wake_interval_seconds":0}"#,
+        "0 disables the wake"
+    );
 
     let (status, body) = call(
         app,

--- a/cafleet/tests/webui_routes.rs
+++ b/cafleet/tests/webui_routes.rs
@@ -1,5 +1,5 @@
 //! Step 8 contract tests: the WebUI HTTP app, in-process via
-//! `tower::ServiceExt` (SPEC §6.8) — the 9 routes, the `X-Fleet-Id` header
+//! `tower::ServiceExt` (SPEC §6.8) — the 8 routes, the `X-Fleet-Id` header
 //! dependency, the wire renames, the 422 `{"detail": <string>}` body, and the
 //! SPA fallback over the embedded dist.
 //!
@@ -429,6 +429,7 @@ async fn the_monitor_endpoint_reports_and_masks_the_runtime() {
     assert_eq!(payload["running"], false);
     assert_eq!(payload["pid"], Value::Null);
     assert_eq!(payload["tick_seconds"], Value::Null, "no row at all");
+    assert_eq!(payload["wake_interval_seconds"], Value::Null);
     assert_eq!(payload["last_wake_at"], Value::Null);
     assert_eq!(payload["last_wake_age_seconds"], Value::Null);
     let rows = payload["members"].as_array().unwrap();
@@ -480,6 +481,7 @@ async fn the_monitor_endpoint_reports_and_masks_the_runtime() {
     assert_eq!(payload["running"], true);
     assert_eq!(payload["pid"], pid);
     assert_eq!(payload["tick_seconds"], 5);
+    assert_eq!(payload["wake_interval_seconds"], 600);
     let age = payload["last_tick_age_seconds"].as_i64().unwrap();
     assert!((0..=5).contains(&age), "whole-second age, got {age}");
     assert!(payload["last_wake_at"].is_string());
@@ -505,6 +507,10 @@ async fn the_monitor_endpoint_reports_and_masks_the_runtime() {
         "a stale row never leaks its pid"
     );
     assert_eq!(payload["tick_seconds"], 5, "only tick_seconds survives");
+    assert_eq!(
+        payload["wake_interval_seconds"], 600,
+        "the interval survives from the stale row, like tick_seconds"
+    );
     assert_eq!(payload["last_tick_at"], Value::Null);
     assert_eq!(payload["started_at"], Value::Null);
     assert_eq!(
@@ -513,6 +519,168 @@ async fn the_monitor_endpoint_reports_and_masks_the_runtime() {
         "last_wake_at is masked with the stale row"
     );
     assert_eq!(payload["last_wake_age_seconds"], Value::Null);
+}
+
+#[tokio::test]
+async fn patch_monitor_updates_the_wake_interval_with_the_pinned_error_contract() {
+    let dir = TempDir::new().unwrap();
+    let (url, mut conn) = migrated(&dir);
+    let (fleet_id, _, _, _) = seeded_fleet(&mut conn);
+    let app = app(&url);
+    let valid = json!({"wake_interval_seconds": 300});
+
+    let (status, body) = call(app.clone(), "PATCH", "/api/monitor", None, Some(valid.clone())).await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert_eq!(body, r#"{"detail":"X-Fleet-Id header required"}"#);
+
+    let (status, body) = call(
+        app.clone(),
+        "PATCH",
+        "/api/monitor",
+        Some(""),
+        Some(valid.clone()),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert_eq!(
+        body, r#"{"detail":"X-Fleet-Id header required"}"#,
+        "empty counts as missing"
+    );
+
+    let (status, body) = call(
+        app.clone(),
+        "PATCH",
+        "/api/monitor",
+        Some("abc"),
+        Some(valid.clone()),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert_eq!(body, r#"{"detail":"X-Fleet-Id must be an integer"}"#);
+
+    // An unparsable body 422s before the fleet check — the unknown fleet 999
+    // never reaches its 404, matching POST /api/messages/send.
+    let request = Request::builder()
+        .method("PATCH")
+        .uri("/api/monitor")
+        .header("X-Fleet-Id", "999")
+        .header(header::CONTENT_TYPE, "application/json")
+        .body(Body::from("not json"))
+        .unwrap();
+    let response = app.clone().oneshot(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let detail = parsed(&String::from_utf8(bytes.to_vec()).unwrap())["detail"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    assert!(
+        detail.starts_with("invalid JSON body: "),
+        "got: {detail}"
+    );
+
+    // Rejected, not coerced: missing, float, stringified, negative, and
+    // above-i64::MAX — all 422 before the unknown-fleet 404.
+    for bad in [
+        json!({}),
+        json!({"wake_interval_seconds": 1.5}),
+        json!({"wake_interval_seconds": "300"}),
+        json!({"wake_interval_seconds": -1}),
+        json!({"wake_interval_seconds": 9_223_372_036_854_775_808u64}),
+    ] {
+        let (status, body) = call(
+            app.clone(),
+            "PATCH",
+            "/api/monitor",
+            Some("999"),
+            Some(bad.clone()),
+        )
+        .await;
+        assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY, "for {bad}");
+        assert_eq!(
+            body,
+            r#"{"detail":"wake_interval_seconds must be a non-negative integer"}"#,
+            "for {bad}"
+        );
+    }
+
+    let (status, body) = call(
+        app.clone(),
+        "PATCH",
+        "/api/monitor",
+        Some("999"),
+        Some(valid.clone()),
+    )
+    .await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+    assert_eq!(
+        body, r#"{"detail":"Fleet not found"}"#,
+        "a valid body against an unknown fleet 404s after validation"
+    );
+
+    let (status, body) = call(
+        app.clone(),
+        "PATCH",
+        "/api/monitor",
+        Some("1"),
+        Some(valid.clone()),
+    )
+    .await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+    assert_eq!(
+        body, r#"{"detail":"monitor has never run for this fleet"}"#,
+        "a known fleet with no runtime row"
+    );
+
+    broker::claim_monitor_runtime(
+        &mut conn,
+        fleet_id,
+        i64::from(std::process::id()),
+        5,
+        600,
+        &cafleet::time::format_utc(cafleet::time::now_utc()),
+    )
+    .unwrap();
+    let (status, body) = call(app.clone(), "PATCH", "/api/monitor", Some("1"), Some(valid)).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        body, r#"{"wake_interval_seconds":300}"#,
+        "the 200 payload is pinned"
+    );
+
+    let (status, body) = call(app.clone(), "GET", "/api/monitor", Some("1"), None).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        parsed(&body)["wake_interval_seconds"], 300,
+        "GET reflects the PATCHed value"
+    );
+
+    let (status, body) = call(
+        app.clone(),
+        "PATCH",
+        "/api/monitor",
+        Some("1"),
+        Some(json!({"wake_interval_seconds": 0})),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body, r#"{"wake_interval_seconds":0}"#, "0 disables the wake");
+
+    let (status, body) = call(
+        app,
+        "PATCH",
+        "/api/monitor",
+        Some("1"),
+        Some(json!({"wake_interval_seconds": i64::MAX})),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        body, r#"{"wake_interval_seconds":9223372036854775807}"#,
+        "i64::MAX is the inclusive domain ceiling"
+    );
 }
 
 #[tokio::test]

--- a/design-docs/0000162-webui-wake-interval-editing/design-doc.md
+++ b/design-docs/0000162-webui-wake-interval-editing/design-doc.md
@@ -1,7 +1,7 @@
 # Restore WebUI editing of the Director wake interval
 
 **Status**: Approved
-**Progress**: 20/22 tasks complete
+**Progress**: 22/22 tasks complete
 **Last Updated**: 2026-08-07
 
 ## Overview
@@ -337,6 +337,8 @@ non-negative integer.
 
 ### Step 7: Verification
 
-- [ ] `mise //cafleet:format`, `mise //cafleet:lint`,
-      `mise //cafleet:typecheck`, `mise //admin:lint`. <!-- completed: -->
-- [ ] `mise //cafleet:test` — full suite green. <!-- completed: -->
+- [x] `mise //cafleet:format`, `mise //cafleet:lint`,
+      `mise //cafleet:typecheck`, `mise //admin:lint`.
+      <!-- completed: 2026-08-07T06:35 -->
+- [x] `mise //cafleet:test` — full suite green.
+      <!-- completed: 2026-08-07T06:35 -->

--- a/design-docs/0000162-webui-wake-interval-editing/design-doc.md
+++ b/design-docs/0000162-webui-wake-interval-editing/design-doc.md
@@ -1,7 +1,7 @@
 # Restore WebUI editing of the Director wake interval
 
 **Status**: Approved
-**Progress**: 8/22 tasks complete
+**Progress**: 12/22 tasks complete
 **Last Updated**: 2026-08-07
 
 ## Overview
@@ -281,17 +281,19 @@ non-negative integer.
 
 ### Step 3: Broker layer
 
-- [ ] Extend `claim_monitor_runtime` with the `wake_interval` parameter,
-      stamped in both the INSERT and the reclaim UPDATE. <!-- completed: -->
-- [ ] Carry `wake_interval_seconds` through `RuntimeRow`,
+- [x] Extend `claim_monitor_runtime` with the `wake_interval` parameter,
+      stamped in both the INSERT and the reclaim UPDATE.
+      <!-- completed: 2026-08-07T06:11 -->
+- [x] Carry `wake_interval_seconds` through `RuntimeRow`,
       `read_monitor_runtime`, and `monitor_runtime_payload` (both shapes, key
       after `tick_seconds`); keep `clear_monitor_runtime` preserving it.
-      <!-- completed: -->
-- [ ] Add `set_monitor_wake_interval` returning `changed == 1`.
-      <!-- completed: -->
-- [ ] Colocated broker tests: stamp on claim and reclaim, preservation across
+      <!-- completed: 2026-08-07T06:11 -->
+- [x] Add `set_monitor_wake_interval` returning `changed == 1`.
+      <!-- completed: 2026-08-07T06:11 -->
+- [x] Colocated broker tests: stamp on claim and reclaim, preservation across
       clear, the payload key in running/stale/no-row shapes, and the
-      `set_monitor_wake_interval` true/false split. <!-- completed: -->
+      `set_monitor_wake_interval` true/false split.
+      <!-- completed: 2026-08-07T06:11 -->
 
 ### Step 4: Monitor loop
 

--- a/design-docs/0000162-webui-wake-interval-editing/design-doc.md
+++ b/design-docs/0000162-webui-wake-interval-editing/design-doc.md
@@ -1,7 +1,7 @@
 # Restore WebUI editing of the Director wake interval
 
 **Status**: Approved
-**Progress**: 15/22 tasks complete
+**Progress**: 17/22 tasks complete
 **Last Updated**: 2026-08-07
 
 ## Overview
@@ -314,14 +314,16 @@ non-negative integer.
 
 ### Step 5: HTTP endpoint
 
-- [ ] Add the `PATCH /api/monitor` handler in `cafleet/src/webui/mod.rs` with
+- [x] Add the `PATCH /api/monitor` handler in `cafleet/src/webui/mod.rs` with
       the § *S3* resolution order, validation, and error strings; register the
       route and correct the module doc's route count to 8 (it reads "the 9
-      `/api` routes" today while 7 are registered). <!-- completed: -->
-- [ ] `webui_routes` tests: 200 round-trip (PATCH then GET reflects the
+      `/api` routes" today while 7 are registered).
+      <!-- completed: 2026-08-07T06:24 -->
+- [x] `webui_routes` tests: 200 round-trip (PATCH then GET reflects the
       value), both 400s, fleet 404, both 422s (including
       float/string/negative/above-`i64::MAX` rejection and the
-      422-before-fleet-404 ordering), and the no-row 404. <!-- completed: -->
+      422-before-fleet-404 ordering), and the no-row 404.
+      <!-- completed: 2026-08-07T06:24 -->
 
 ### Step 6: Admin WebUI
 

--- a/design-docs/0000162-webui-wake-interval-editing/design-doc.md
+++ b/design-docs/0000162-webui-wake-interval-editing/design-doc.md
@@ -1,8 +1,8 @@
 # Restore WebUI editing of the Director wake interval
 
 **Status**: Approved
-**Progress**: 0/22 tasks complete
-**Last Updated**: 2026-08-06
+**Progress**: 6/22 tasks complete
+**Last Updated**: 2026-08-07
 
 ## Overview
 
@@ -241,32 +241,32 @@ non-negative integer.
 
 ### Step 1: Documentation first
 
-- [ ] Update `docs/docs/concepts/monitoring.md` § cadence: the interval is
+- [x] Update `docs/docs/concepts/monitoring.md` § cadence: the interval is
       stamped per fleet at each monitor start, re-read per tick, and editable
       from the admin WebUI (effective within one tick; re-stamped at the next
-      start). <!-- completed: -->
-- [ ] Update `docs/docs/spec/webui-api.md`: add `PATCH /api/monitor` to the
+      start). <!-- completed: 2026-08-07T05:55 -->
+- [x] Update `docs/docs/spec/webui-api.md`: add `PATCH /api/monitor` to the
       route table and as a section with the § *S3* contract verbatim; add
       `wake_interval_seconds` to the `GET /api/monitor` example and the
-      not-running field table. <!-- completed: -->
-- [ ] Update `docs/docs/spec/data-model.md` § `monitor_runtime`: the
+      not-running field table. <!-- completed: 2026-08-07T05:55 -->
+- [x] Update `docs/docs/spec/data-model.md` § `monitor_runtime`: the
       `wake_interval_seconds` column and its stamp/re-read/preserve
-      lifecycle. <!-- completed: -->
-- [ ] Update `docs/docs/spec/cli-options.md` (monitor loop form): the resolved
+      lifecycle. <!-- completed: 2026-08-07T05:55 -->
+- [x] Update `docs/docs/spec/cli-options.md` (monitor loop form): the resolved
       interval is stamped into `monitor_runtime` at each start.
-      <!-- completed: -->
-- [ ] Update `SPEC.md`: §6.2 (`claim_monitor_runtime` /
+      <!-- completed: 2026-08-07T05:55 -->
+- [x] Update `SPEC.md`: §6.2 (`claim_monitor_runtime` /
       `set_monitor_wake_interval` / payload keys and the schema DDL), §6.3
       (`--interval` stamping and the `i64` domain), §6.6 (per-tick re-read
       order, the dropped `monitor_tick` parameter, and `wake_due`'s `i64`
       interval), §6.8 (`PATCH /api/monitor`, the GET payload addition, and
       the route-catalog title bump "The 7 routes" → 8), §7.1
       (`monitor_wake_interval` domain), and the head version in the migration
-      inventory. <!-- completed: -->
-- [ ] Verify `skills/cafleet/reference/cli.md` and
+      inventory. <!-- completed: 2026-08-07T05:55 -->
+- [x] Verify `skills/cafleet/reference/cli.md` and
       `reference/supervision.md` stay accurate (their `--interval`/env/0
       statements are unchanged by this design); edit only if a statement
-      drifts. <!-- completed: -->
+      drifts. <!-- completed: 2026-08-07T05:55 -->
 
 ### Step 2: Migration
 

--- a/design-docs/0000162-webui-wake-interval-editing/design-doc.md
+++ b/design-docs/0000162-webui-wake-interval-editing/design-doc.md
@@ -1,6 +1,6 @@
 # Restore WebUI editing of the Director wake interval
 
-**Status**: Approved
+**Status**: Complete
 **Progress**: 22/22 tasks complete
 **Last Updated**: 2026-08-07
 
@@ -342,3 +342,12 @@ non-negative integer.
       <!-- completed: 2026-08-07T06:35 -->
 - [x] `mise //cafleet:test` — full suite green.
       <!-- completed: 2026-08-07T06:35 -->
+
+---
+
+## Changelog
+
+- 2026-08-07: Implementation complete — all 22 tasks and 6 success criteria
+  verified (unit/contract suites, isolated live E2E of the API matrix, and
+  browser checks of the popover editor); Reviewer approved in one round;
+  PR #281 opened. Status: Approved → Complete.

--- a/design-docs/0000162-webui-wake-interval-editing/design-doc.md
+++ b/design-docs/0000162-webui-wake-interval-editing/design-doc.md
@@ -1,7 +1,7 @@
 # Restore WebUI editing of the Director wake interval
 
 **Status**: Approved
-**Progress**: 6/22 tasks complete
+**Progress**: 8/22 tasks complete
 **Last Updated**: 2026-08-07
 
 ## Overview
@@ -270,14 +270,14 @@ non-negative integer.
 
 ### Step 2: Migration
 
-- [ ] Add `cafleet/migrations/V5__monitor_wake_interval.sql` with the § *S1*
-      DDL. <!-- completed: -->
-- [ ] Bump every head-4 assertion in `cafleet/src/db/mod.rs` to head 5 —
+- [x] Add `cafleet/migrations/V5__monitor_wake_interval.sql` with the § *S1*
+      DDL. <!-- completed: 2026-08-07T06:02 -->
+- [x] Bump every head-4 assertion in `cafleet/src/db/mod.rs` to head 5 —
       `migrate_reaches_head_version_4_and_is_idempotent` (renamed),
       `refinery_ledger_records_the_baseline` (`vec![1, 2, 3, 4]` → `..5`),
       and `migration_chain_is_contiguous_from_1_with_exactly_one_baseline_and_head_4`
       (renamed) — and the `applied migrations to head (4).` assertion in
-      `cafleet/tests/cli_setup_doctor.rs`. <!-- completed: -->
+      `cafleet/tests/cli_setup_doctor.rs`. <!-- completed: 2026-08-07T06:02 -->
 
 ### Step 3: Broker layer
 

--- a/design-docs/0000162-webui-wake-interval-editing/design-doc.md
+++ b/design-docs/0000162-webui-wake-interval-editing/design-doc.md
@@ -1,7 +1,7 @@
 # Restore WebUI editing of the Director wake interval
 
 **Status**: Approved
-**Progress**: 17/22 tasks complete
+**Progress**: 20/22 tasks complete
 **Last Updated**: 2026-08-07
 
 ## Overview
@@ -209,7 +209,7 @@ the trigger for a popover carrying the interval editor.
 
 | Element | Behavior |
 |---|---|
-| Trigger | The existing indicator dot, now a button; the tooltip text stays. |
+| Trigger | The existing indicator dot, now a button; the tooltip text stays, except the stopped-state tooltip's launch command reads `cafleet monitor <fleet-id>` (the prior text cited a CLI form that no longer exists). |
 | Interval input | Numeric input in seconds (integer ≥ 0), seeded from `wake_interval_seconds` in the polled `GET /api/monitor` payload. |
 | Zero hint | Inline hint at value `0`: the Director wake is disabled while the loop keeps running. |
 | Save | Calls `PATCH /api/monitor`, surfaces a `detail` error inline on failure, and triggers the dashboard's existing refresh on success. |
@@ -327,13 +327,13 @@ non-negative integer.
 
 ### Step 6: Admin WebUI
 
-- [ ] Extend `MonitorRuntime` in `admin/src/types.ts` and add `patchMonitor`
-      to `admin/src/api.ts`. <!-- completed: -->
-- [ ] Turn the `AppHeader` monitor indicator into the popover editor per
+- [x] Extend `MonitorRuntime` in `admin/src/types.ts` and add `patchMonitor`
+      to `admin/src/api.ts`. <!-- completed: 2026-08-07T06:29 -->
+- [x] Turn the `AppHeader` monitor indicator into the popover editor per
       § *S4* (input, zero hint, save with inline error, disabled not-running
-      state). <!-- completed: -->
-- [ ] Wire `Dashboard` to pass the monitor payload and refresh trigger into
-      `AppHeader`. <!-- completed: -->
+      state). <!-- completed: 2026-08-07T06:29 -->
+- [x] Wire `Dashboard` to pass the monitor payload and refresh trigger into
+      `AppHeader`. <!-- completed: 2026-08-07T06:29 -->
 
 ### Step 7: Verification
 

--- a/design-docs/0000162-webui-wake-interval-editing/design-doc.md
+++ b/design-docs/0000162-webui-wake-interval-editing/design-doc.md
@@ -16,23 +16,23 @@ the current architecture.
 
 ## Success Criteria
 
-- [ ] `monitor_runtime` has a nullable `wake_interval_seconds` column; the
+- [x] `monitor_runtime` has a nullable `wake_interval_seconds` column; the
       migration chain is contiguous from 1 with head **5** and the chain-guard
       test matches.
-- [ ] Every `cafleet monitor` start stamps its startup-resolved interval
+- [x] Every `cafleet monitor` start stamps its startup-resolved interval
       (`--interval` > `CAFLEET_MONITOR_WAKE_INTERVAL` > 600) into the column;
       each tick gates the wake on the column's current value, so an external
       update changes the running loop's cadence within one tick without a
       restart (pinned by a `monitor_tick` test).
-- [ ] `PATCH /api/monitor` updates the column under the `X-Fleet-Id` header
+- [x] `PATCH /api/monitor` updates the column under the `X-Fleet-Id` header
       with the exact 200/400/404/422 contract in § *S3*, pinned by
       `webui_routes` tests.
-- [ ] `GET /api/monitor` includes `wake_interval_seconds` in both the running
+- [x] `GET /api/monitor` includes `wake_interval_seconds` in both the running
       and not-running payload shapes.
-- [ ] The WebUI header monitor indicator opens a popover with the interval
+- [x] The WebUI header monitor indicator opens a popover with the interval
       editor; the editor saves via `PATCH /api/monitor` and is disabled when
       the monitor is not running.
-- [ ] `docs/`, `SPEC.md`, and the skill references are drift-free for the new
+- [x] `docs/`, `SPEC.md`, and the skill references are drift-free for the new
       surfaces; `mise //cafleet:test`, `mise //cafleet:lint`,
       `mise //cafleet:typecheck`, and `mise //admin:lint` pass.
 

--- a/design-docs/0000162-webui-wake-interval-editing/design-doc.md
+++ b/design-docs/0000162-webui-wake-interval-editing/design-doc.md
@@ -1,7 +1,7 @@
 # Restore WebUI editing of the Director wake interval
 
 **Status**: Approved
-**Progress**: 12/22 tasks complete
+**Progress**: 15/22 tasks complete
 **Last Updated**: 2026-08-07
 
 ## Overview
@@ -297,19 +297,20 @@ non-negative integer.
 
 ### Step 4: Monitor loop
 
-- [ ] Rework `monitor_tick` to the § *S2* order (drop the parameter, read the
+- [x] Rework `monitor_tick` to the § *S2* order (drop the parameter, read the
       row before the interval gate, `expect` the stamped value); update
       `run_monitor_loop` to pass the startup interval only to the claim, and
-      `wake_due` to take `i64`. <!-- completed: -->
-- [ ] Apply the § *S2* value domain at the CLI/config boundaries: `--interval`
+      `wake_due` to take `i64`. <!-- completed: 2026-08-07T06:19 -->
+- [x] Apply the § *S2* value domain at the CLI/config boundaries: `--interval`
       switches to `clap::value_parser!(i64).range(0..)` in
       `cafleet/src/cli/monitor.rs`, and `Settings.monitor_wake_interval`
       becomes `i64` with an explicit non-negative check preserving the
-      existing error string; update the config tests. <!-- completed: -->
-- [ ] Monitor tests: a mid-run column update changes the cadence on the next
+      existing error string; update the config tests.
+      <!-- completed: 2026-08-07T06:19 -->
+- [x] Monitor tests: a mid-run column update changes the cadence on the next
       tick (shrink-to-due, set-0-disables, raise-re-enables), and the
       first-wake boundary follows an edit made before the first wake.
-      <!-- completed: -->
+      <!-- completed: 2026-08-07T06:19 -->
 
 ### Step 5: HTTP endpoint
 

--- a/docs/docs/concepts/monitoring.md
+++ b/docs/docs/concepts/monitoring.md
@@ -78,6 +78,13 @@ later wake is measured from the last delivered wake.
 `CAFLEET_MONITOR_WAKE_INTERVAL=0` (or `--interval 0`) disables the wake while
 the loop keeps claiming the runtime slot and heartbeating every tick.
 
+The resolved interval is stamped per fleet into the `monitor_runtime` row at
+each monitor start and re-read on every tick, so a running loop's cadence is
+editable from the admin WebUI's interval editor: an edit takes effect within
+one tick and lasts until the next monitor start re-stamps the interval from
+the CLI/env resolution. Saving `0` disables the wake exactly as `--interval 0`
+does, while the loop keeps heartbeating.
+
 The wake is unconditional: it fires whenever the interval has elapsed and the
 Director's pane is alive, **including when the fleet has no other members**.
 The Director is itself a supervision target — the resume clause is the remedy

--- a/docs/docs/concepts/monitoring.md
+++ b/docs/docs/concepts/monitoring.md
@@ -79,11 +79,11 @@ later wake is measured from the last delivered wake.
 the loop keeps claiming the runtime slot and heartbeating every tick.
 
 The resolved interval is stamped per fleet into the `monitor_runtime` row at
-each monitor start and re-read on every tick, so a running loop's cadence is
-editable from the admin WebUI's interval editor: an edit takes effect within
-one tick and lasts until the next monitor start re-stamps the interval from
-the CLI/env resolution. Saving `0` disables the wake exactly as `--interval 0`
-does, while the loop keeps heartbeating.
+each `cafleet monitor` start and re-read on every tick, so a running loop's
+cadence is editable from the admin WebUI's interval editor: an edit takes
+effect within one tick and lasts until the next `cafleet monitor` start
+re-stamps the interval from the CLI/env resolution. Saving `0` disables the
+wake exactly as `--interval 0` does, while the loop keeps heartbeating.
 
 The wake is unconditional: it fires whenever the interval has elapsed and the
 Director's pane is alive, **including when the fleet has no other members**.

--- a/docs/docs/spec/cli-options.md
+++ b/docs/docs/spec/cli-options.md
@@ -759,6 +759,12 @@ loop, and a still-running loop self-terminates on its next tick after
 | `--tick` | no | The scan-tick cadence in seconds (an integer ≥ 1, default **5**). The tick is the floor on interval precision — see [Monitoring](../concepts/monitoring.md#cadence-and-tick-precision). |
 | `--interval` | no | The Director wake interval in seconds (an integer ≥ 0); `0` disables the wake while the loop keeps heartbeating. When omitted, falls back to `CAFLEET_MONITOR_WAKE_INTERVAL` (default **600**). |
 
+The startup-resolved interval (`--interval` > `CAFLEET_MONITOR_WAKE_INTERVAL`
+> 600) is stamped into the fleet's `monitor_runtime` row at each start and
+re-read on every tick, so a
+[`PATCH /api/monitor`](webui-api.md#patch-api-monitor)
+edit changes the running loop's cadence within one tick.
+
 Runs the loop **in-process** (the Director launches it as a background task
 in its own pane; the loop blocks the task and writes to its stdout — one
 `<iso-ts> tick -> wake director <director-member-id> (<N> members)` line per

--- a/docs/docs/spec/data-model.md
+++ b/docs/docs/spec/data-model.md
@@ -55,10 +55,16 @@ value.
 
 `monitor_runtime` is the one-row-per-fleet loop pid/heartbeat table: the
 single-instance claim (`pid`, `started_at`), the liveness heartbeat
-(`last_tick_at`, `tick_seconds`), and `last_wake_at` — the nullable UTC ISO
+(`last_tick_at`, `tick_seconds`), `last_wake_at` — the nullable UTC ISO
 timestamp of the last successfully delivered Director wake, kept durable
 across loop restarts so an immediate restart honors the remaining wake
-cadence. The cadence semantics are defined in
+cadence — and `wake_interval_seconds`, the nullable live mirror of the
+running loop's Director wake interval: stamped with the startup-resolved
+value at every monitor start (claim and reclaim), re-read by the loop on
+every tick, overwritten by `PATCH /api/monitor`, and preserved across a
+loop stop like `tick_seconds`. It is `NULL` only in rows that predate the
+column and have not been re-claimed since — a running loop's row is always
+stamped. The cadence semantics are defined in
 [Monitoring](../concepts/monitoring.md#cadence-and-tick-precision).
 
 ### `asset_installs`

--- a/docs/docs/spec/data-model.md
+++ b/docs/docs/spec/data-model.md
@@ -60,7 +60,7 @@ timestamp of the last successfully delivered Director wake, kept durable
 across loop restarts so an immediate restart honors the remaining wake
 cadence — and `wake_interval_seconds`, the nullable live mirror of the
 running loop's Director wake interval: stamped with the startup-resolved
-value at every monitor start (claim and reclaim), re-read by the loop on
+value at every `cafleet monitor` start (claim and reclaim), re-read by the loop on
 every tick, overwritten by `PATCH /api/monitor`, and preserved across a
 loop stop like `tick_seconds`. It is `NULL` only in rows that predate the
 column and have not been re-claimed since — a running loop's row is always

--- a/docs/docs/spec/webui-api.md
+++ b/docs/docs/spec/webui-api.md
@@ -155,7 +155,7 @@ and a still-running loop self-terminates after `fleet delete`.
 
 Updates the fleet's Director wake interval. The running loop re-reads the
 stored value on every tick, so the edit changes the cadence within one scan
-tick; the next monitor start re-stamps the interval from the CLI/env
+tick; the next `cafleet monitor` start re-stamps the interval from the CLI/env
 resolution. See
 [Monitoring](../concepts/monitoring.md#cadence-and-tick-precision).
 

--- a/docs/docs/spec/webui-api.md
+++ b/docs/docs/spec/webui-api.md
@@ -26,6 +26,7 @@ No server-side session cookies. The SPA stores the active fleet_id client-side v
 | `GET` | `/api/fleets` | Non-soft-deleted fleets with member counts | no |
 | `GET` | `/api/members` | The fleet's roster | yes |
 | `GET` | `/api/monitor` | Liveness of the fleet's `cafleet monitor` process plus per-member pending-delivery counts | yes |
+| `PATCH` | `/api/monitor` | The updated Director wake interval | yes |
 | `GET` | `/api/members/{member_id}/inbox` | Messages received by the member | yes |
 | `GET` | `/api/members/{member_id}/sent` | Messages sent by the member | yes |
 | `GET` | `/api/timeline` | The fleet's unified message timeline | yes |
@@ -108,6 +109,7 @@ page show a "monitor running / stopped" indicator. See
   "running": true,
   "pid": 4821,
   "tick_seconds": 5,
+  "wake_interval_seconds": 600,
   "last_tick_at": "2026-06-13T04:51:02+00:00",
   "last_tick_age_seconds": 2,
   "started_at": "2026-06-13T04:50:00+00:00",
@@ -142,11 +144,55 @@ the runtime fields take these values:
 | `last_wake_at` | `null` | `null` |
 | `last_wake_age_seconds` | `null` | `null` |
 | `tick_seconds` | `null` | **preserved** — the cadence the monitor last ran at |
+| `wake_interval_seconds` | `null` | **preserved** — the wake interval the monitor last ran at; `null` when the row predates the column and was never re-stamped |
 
 Launching the loop is CLI-only (`cafleet monitor`, run by the Director
 as a background task in its own pane); there is no `POST`/`DELETE` counterpart
 here and no CLI stop command — the Director stops the background task,
 and a still-running loop self-terminates after `fleet delete`.
+
+### PATCH /api/monitor — Update the Wake Interval {#patch-api-monitor}
+
+Updates the fleet's Director wake interval. The running loop re-reads the
+stored value on every tick, so the edit changes the cadence within one scan
+tick; the next monitor start re-stamps the interval from the CLI/env
+resolution. See
+[Monitoring](../concepts/monitoring.md#cadence-and-tick-precision).
+
+**Request**: `X-Fleet-Id: <fleet_id>` header.
+
+```json
+{"wake_interval_seconds": 300}
+```
+
+`wake_interval_seconds` must be a JSON integer in `0..=i64::MAX` — floats,
+stringified integers, negatives, and numbers above `i64::MAX` are rejected,
+not coerced, mirroring the send endpoint's strictness. `0` disables the wake;
+there is no application-level cap below `i64::MAX`.
+
+**Response** (200 OK):
+
+```json
+{"wake_interval_seconds": 300}
+```
+
+**Errors** (all `{"detail": <string>}`-shaped):
+
+| Status | `detail` | Trigger |
+|---|---|---|
+| 400 | `X-Fleet-Id header required` | The `X-Fleet-Id` header is missing or empty |
+| 400 | `X-Fleet-Id must be an integer` | The header value is not an integer |
+| 422 | `invalid JSON body: <parse error>` | The request body is not parsable JSON |
+| 422 | `wake_interval_seconds must be a non-negative integer` | `wake_interval_seconds` is missing, or not an integer in `0..=i64::MAX` |
+| 404 | `Fleet not found` | The header names a fleet id that does not exist |
+| 404 | `monitor has never run for this fleet` | The fleet has no `monitor_runtime` row |
+
+Resolution order (the table's row order): header errors, then body
+validation, then the fleet check, then the row update — matching
+`POST /api/messages/send`, whose body parse likewise precedes the fleet
+check, so an unknown fleet plus an invalid body yields 422 on both
+endpoints. A no-row 404 means the fleet's monitor has never run —
+`monitor_runtime` rows are removed only by `fleet delete`.
 
 ### GET /api/members/{member_id}/inbox — Inbox Messages
 


### PR DESCRIPTION
- **docs: document wake-interval persistence, PATCH /api/monitor, and WebUI editor**
- **test: add tests for the V5 wake-interval migration head**
- **feat: add V5 migration for monitor_runtime.wake_interval_seconds**
- **test: add tests for wake-interval stamping, set_monitor_wake_interval, and payload shapes**
- **feat: stamp and serve wake_interval_seconds in the broker monitor runtime**
- **test: add tests for per-tick interval re-read and i64 config boundaries**
- **feat: re-read the wake interval per tick and enforce the i64 domain at the boundaries**
- **test: add tests for the PATCH /api/monitor contract**
- **feat: add PATCH /api/monitor to update the Director wake interval**
- **feat: add the wake-interval popover editor to the admin WebUI header**
- **fix: correct tests for the clippy unnecessary_to_owned lint and apply formatter reflow**
- **docs: check off Step 7 verification tasks (22/22)**
- **docs: check off all success criteria after Phase D verification**
